### PR TITLE
Changed value of wlst_type field under the "ForeignJNDILink" folder, …

### DIFF
--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ForeignJNDIProvider.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ForeignJNDIProvider.json
@@ -5,7 +5,7 @@
     "child_folders_type": "multiple",
     "folders": {
         "ForeignJNDILink": {
-            "wlst_type": "ForeignJNDILink",
+            "wlst_type": "ForeignJNDILink${:s}",
             "child_folders_type": "multiple",
             "folders": {},
             "attributes": {


### PR DESCRIPTION
Hi Carolyn, 

I changed the value of the wlst_type field to "ForeignJNDILink${:s}", then created and ran (but didn't commit) the following unittest to verify the correct value was being returned:

def testIssue28Fix(self):
    location=LocationContext().append_location(FOLDERS.FOREIGN_JNDI_PROVIDER)
    token = self.aliases.get_name_token(location)
    location.add_name_token(token, 'ForeignJNDIProvider-0')
    location.append_location(FOLDERS.FOREIGN_JNDI_PROVIDER_LINK)
    token = self.aliases.get_name_token(location)
    location.add_name_token(token, 'ForeignJNDILink-0')

    wlst_mbean_type = **self.aliases.get_wlst_mbean_type(location)
    expected = FOLDERS.FOREIGN_JNDI_PROVIDER_LINK**
    self.assertEqual(wlst_mbean_type, expected)

    wlst_mbean_type = **self.online_aliases.get_wlst_mbean_type(location)
    expected = '%ss' % FOLDERS.FOREIGN_JNDI_PROVIDER_LINK**
    self.assertEqual(wlst_mbean_type, expected)

    return
