### PR TITLE
Add RetryCount attribute to /ServerTemplate/WebService/WebServiceBuff…

### DIFF
--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Server.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Server.json
@@ -1241,6 +1241,7 @@
                     },
                     "attributes": {
                         "Notes":      [ {"version": "[10,)", "wlst_mode": "both", "wlst_name": "Notes",      "wlst_path": "WP001", "value": {"default": "None"   }, "wlst_type": "string"} ],
+                        "RetryCount": [ {"version": "[10,)", "wlst_mode": "both", "wlst_name": "RetryCount", "wlst_path": "WP001", "value": {"default": 3        }, "wlst_type": "integer"} ],
                         "RetryDelay": [ {"version": "[10,)", "wlst_mode": "both", "wlst_name": "RetryDelay", "wlst_path": "WP001", "value": {"default": "P0DT30S"}, "wlst_type": "string"} ]
                     },
                     "wlst_attributes_path": "WP001",

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
@@ -1245,6 +1245,7 @@
                     },
                     "attributes": {
                         "Notes":      [ {"version": "[10,)",     "wlst_mode": "both", "wlst_name": "Notes",      "wlst_path": "WP001", "value": {"default": "None"    }, "wlst_type": "string"} ],
+                        "RetryCount": [ {"version": "[10,)",     "wlst_mode": "both", "wlst_name": "RetryCount", "wlst_path": "WP001", "value": {"default": 3         }, "wlst_type": "integer"} ],
                         "RetryDelay": [ {"version": "[10,)",     "wlst_mode": "both", "wlst_name": "RetryDelay", "wlst_path": "WP001", "value": {"default": "P0DT30S" }, "wlst_type": "string"} ]
                     },
                     "wlst_attributes_path": "WP001",

--- a/core/src/test/python/aliases_test.py
+++ b/core/src/test/python/aliases_test.py
@@ -1114,6 +1114,22 @@ class AliasesTestCase(unittest.TestCase):
 
         return
 
+    def testIssue50Fix(self):
+        location = LocationContext().append_location(FOLDERS.SERVER_TEMPLATE)
+        token = self.aliases.get_name_token(location)
+        location.add_name_token(token, 'ServerTemplate-0')
+        location.append_location(FOLDERS.WEB_SERVICE)
+        location.append_location(FOLDERS.WEB_SERVICE_BUFFERING)
+
+        wlst_attribute_name = self.aliases.get_wlst_attribute_name(location, 'RetryCount')
+        expected = 'RetryCount'
+        self.assertEqual(wlst_attribute_name, expected)
+
+        wlst_attribute_name = self.online_aliases.get_wlst_attribute_name(location, 'RetryCount')
+        self.assertEqual(wlst_attribute_name, expected)
+
+        return
+
     def testGetModelAttributeName(self):
         location=LocationContext().append_location(FOLDERS.JMS_SYSTEM_RESOURCE)
         token = self.aliases.get_name_token(location)


### PR DESCRIPTION
Added RetryCount attribute to /ServerTemplate/WebService/WebServiceBuffering and /Server/WebService/WebServiceBuffering folders. Made it available for version [10,) and set the default value to 3 (as per https://docs.oracle.com/cd/E28613_01/apirefs.1211/e24403/mbeans/WebServiceBufferingMBean.html?skipReload=true#RetryCount)