### PR TITLE
Issue#64 deprecate using ${ as variable substitution expression

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -362,9 +362,7 @@ class Validator(object):
             # section_dict_value is either the dict of a folder in the
             # section, or the value of an attribute in the section
             if '${' in section_dict_key:
-                section_dict_key, validation_result = self.__validate_variable_substitution(section_dict_key,
-                                                                                            model_folder_path,
-                                                                                            validation_result)
+                validation_result.add_error('WLSDPLY-05035', model_folder_path, section_dict_key)
 
             self._logger.finer('WLSDPLY-05011', section_dict_key, section_dict_value,
                                class_name=_class_name, method_name=_method_name)
@@ -536,8 +534,7 @@ class Validator(object):
             for name in model_node:
                 expanded_name = name
                 if '${' in name:
-                    expanded_name, validation_result = \
-                        self.__validate_variable_substitution(name, model_folder_path, validation_result)
+                    _report_unsupported_variable_usage(name, model_folder_path, validation_result)
 
                 self._logger.finest('3 expanded_name={0}', expanded_name,
                                     class_name=_class_name, method_name=_method_name)
@@ -830,18 +827,12 @@ class Validator(object):
                     # FIXME(mwooten) - the cla_utils should be fixing all windows paths to use forward slashes already...
                     # assuming that the value is not None
                     variables_file_name = self._model_context.get_variable_file()
-                    if self._validation_mode == _ValidationModes.STANDALONE:
-                        if variables_file_name is None:
-                            validation_result.add_info('WLSDPLY-05021', model_folder_path, property_name)
-                        else:
-                            validation_result.add_info('WLSDPLY-05022', model_folder_path, property_name,
-                                                       variables_file_name)
-                    elif self._validation_mode == _ValidationModes.TOOL:
-                        if variables_file_name is None:
-                            validation_result.add_error('WLSDPLY-05021', model_folder_path, property_name)
-                        else:
-                            validation_result.add_error('WLSDPLY-05022', model_folder_path, property_name,
-                                                        variables_file_name)
+                    if variables_file_name is None:
+                        self._logger.warning('WLSDPLY-05021', model_folder_path, property_name,
+                                             class_name=_class_name, method_name=_method_name)
+                    else:
+                        self._logger.warning('WLSDPLY-05022', model_folder_path, property_name, variables_file_name,
+                                             class_name=_class_name, method_name=_method_name)
 
         self._logger.exiting(class_name=_class_name, method_name=_method_name, result=untokenized_value)
         return untokenized_value, validation_result

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -340,11 +340,13 @@ WLSDPLY-05029={0} is not one of the attribute names allowed in model location {1
 WLSDPLY-05030=Model location {0} uses variable {1} to represent the name of a model subfolder or attribute. \
   Substitution variables can only be used for folder instance names and attribute values.
 WLSDPLY-05031=Attribute {0} in model location {1} references a relative file location {2}.  This makes the model \
-  subject to failure unless the tool in voked from the correct location to resolve the relative path to the file. \
+  subject to failure unless the tool invoked from the correct location to resolve the relative path to the file. \
   It is recommended to use a path token if the absolute path is expected to change between systems.
 WLSDPLY-05032=Attribute {0} in model location {1} should be a dictionary but was a {2}
 WLSDPLY-05033=Attribute {0} in model location {1} should be a string but was a {2}
 WLSDPLY-05034=The value for attribute {0} in model location {1} should be a string or a list but was a {2}
+WLSDPLY-05035=The {0} attribute with value {1} in model location {2}, should be a string but was a {3}
+WLSDPLY-05036=Attribute {0} in model location {1}, uses the {2} macro expression for an integer or references to other another server template configuration element. The Oracle documentation for server templates, cites this as being not supported.
 
 
 # wlsdeploy/tools/validate/usage_printer.py

--- a/core/src/test/python/validation_test.py
+++ b/core/src/test/python/validation_test.py
@@ -23,11 +23,12 @@ class ValidationTestCase(unittest.TestCase):
     _class_name = 'ValidationTestCase'
     _resources_dir = '../../test-classes'
     _model_file = _resources_dir + '/test_jms_mail.json'
-    _variable_file = _resources_dir + "/test_sub_variable_file.properties"
+    _variable_file = None
+    _archive_file = None
+    # _variable_file = _resources_dir + "/test_sub_variable_file.properties"
     # _model_file = _resources_dir + '/test_empty.json'
     # _variable_file = _resources_dir + "/test_invalid_variable_file.properties"
-    # _variable_file = None
-    _archive_file = _resources_dir + "/test_jms_archive.zip"
+    # _archive_file = _resources_dir + "/test_jms_archive.zip"
     _logger = PlatformLogger('wlsdeploy.validate')
 
     def setUp(self):
@@ -41,10 +42,14 @@ class ValidationTestCase(unittest.TestCase):
         mw_home = os.environ['MW_HOME']
         args_map = {
             '-oracle_home': mw_home,
-            '-model_file': self._model_file,
-            '-variable_file': self._variable_file,
-            '-archive_file': self._archive_file
+            '-model_file': self._model_file
         }
+
+        if self._variable_file is not None:
+            args_map['-variable_file'] = self._variable_file
+
+        if self._variable_file is not None:
+            args_map['-archive_file'] = self._archive_file
 
         model_context = ModelContext('ValidationTestCase', args_map)
 


### PR DESCRIPTION
Changed validator to not report it as a validation result error, if the model dictionary has an attribute value with a '${' sequence, but no matching properties file entry. Now it just logs it as a warning level log message, and keeps validating.