### PR TITLE
Issue#84 - Avoid displaying password fields as part of entry logging.…

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/alias_entries.py
+++ b/core/src/main/python/wlsdeploy/aliases/alias_entries.py
@@ -155,7 +155,7 @@ class AliasEntries(object):
 
     __domain_info_attributes_and_types = {
         'AdminUserName': 'string',
-        'AdminPassword': 'string',
+        'AdminPassword': 'password',
         'ServerStartMode': 'string',
         'domainLibraries': 'list',
         # A map of Server Group names to the list of servers/clusters to which they should

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -715,7 +715,12 @@ class Validator(object):
                              model_folder_path, validation_location, validation_result):
         _method_name = '__validate_attribute'
 
-        self._logger.entering(attribute_name, attribute_value, str(valid_attr_infos), str(path_tokens_attr_keys),
+        log_value = attribute_value
+        expected_data_type = dictionary_utils.get_element(valid_attr_infos, attribute_name)
+        if expected_data_type == 'password':
+            log_value = '<masked>'
+
+        self._logger.entering(attribute_name, log_value, str(valid_attr_infos), str(path_tokens_attr_keys),
                               model_folder_path, str(validation_location),
                               class_name=_class_name, method_name=_method_name)
 


### PR DESCRIPTION
Avoid displaying password fields as part of entry logging. Password fields appear as <masked>, consistent with other logging. Fixes #84