### PR TITLE
Issue#118 - Initialize archive helper to None to enable later check

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/util/library_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/library_helper.py
@@ -26,6 +26,7 @@ class LibraryHelper(object):
         self.alias_helper = AliasHelper(aliases, self.logger, exception_type)
         self.wlst_helper = WlstHelper(self.logger, exception_type)
 
+        self.archive_helper = None
         archive_file_name = self.model_context.get_archive_file_name()
         if archive_file_name is not None:
             self.archive_helper = ArchiveHelper(archive_file_name, self.domain_home, self.logger, exception_type)


### PR DESCRIPTION
Initialize archive helper to None to enable later check. Fixes #118