### PR TITLE
Do not end discover if wlst.cd() fails

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/discover/common_resources_discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/common_resources_discoverer.py
@@ -91,13 +91,13 @@ class CommonResourcesDiscoverer(Discoverer):
                 self._populate_model_parameters(result[datasource], location)
 
                 location.append_location(model_second_folder)
-                wlst_helper.cd(self._alias_helper.get_wlst_attributes_path(location))
-                result[datasource][model_second_folder] = OrderedDict()
-                resource_result = result[datasource][model_second_folder]
-                self._populate_model_parameters(resource_result, location)
-                self._discover_subfolders(resource_result, location)
-                location.remove_name_token(name_token)
-                location.pop_location()
+                if self.wlst_cd(self._alias_helper.get_wlst_attributes_path(location), location):
+                    result[datasource][model_second_folder] = OrderedDict()
+                    resource_result = result[datasource][model_second_folder]
+                    self._populate_model_parameters(resource_result, location)
+                    self._discover_subfolders(resource_result, location)
+                    location.remove_name_token(name_token)
+                    location.pop_location()
         _logger.exiting(class_name=_class_name, method_name=_method_name, result=result)
         return model_top_folder_name, result
 

--- a/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
@@ -64,7 +64,10 @@ class Discoverer(object):
         _method_name = '_populate_model_parameters'
         wlst_path = self._alias_helper.get_wlst_attributes_path(location)
         _logger.finer('WLSDPLY-06100', wlst_path, class_name=_class_name, method_name=_method_name)
-        self._wlst_helper.cd(wlst_path)
+
+        if not self.wlst_cd(wlst_path, location):
+            return
+
         wlst_params = self._get_attributes_for_current_location(location)
         _logger.finest('WLSDPLY-06102', self._wlst_helper.get_pwd(), wlst_params, class_name=_class_name,
                        method_name=_method_name)
@@ -232,7 +235,7 @@ class Discoverer(object):
             folder_path = self._alias_helper.get_wlst_list_path(location)
             _logger.finest('WLSDPLY-06111', folder_path, class_name=_class_name, method_name=_method_name)
             if wlst_helper.path_exists(folder_path):
-                self._wlst_helper.cd(folder_path)
+                self.wlst_cd(folder_path, location)
                 names = self._wlst_helper.lsc()
         return names
 
@@ -264,15 +267,16 @@ class Discoverer(object):
         :return: list of subfolders
         """
         wlst_path = self._alias_helper.get_wlst_subfolders_path(location)
-        self._wlst_helper.cd(wlst_path)
-        wlst_subfolders = self._wlst_helper.lsc()
-        if wlst_subfolders:
-            new_subfolders = []
-            for wlst_subfolder in wlst_subfolders:
-                model_subfolder_name = self._get_model_name(location, wlst_subfolder)
-                if model_subfolder_name:
-                    new_subfolders.append(wlst_subfolder)
-            wlst_subfolders = new_subfolders
+        wlst_subfolders = []
+        if self.wlst_cd(wlst_path, location):
+            wlst_subfolders = self._wlst_helper.lsc()
+            if wlst_subfolders:
+                new_subfolders = []
+                for wlst_subfolder in wlst_subfolders:
+                    model_subfolder_name = self._get_model_name(location, wlst_subfolder)
+                    if model_subfolder_name:
+                        new_subfolders.append(wlst_subfolder)
+                wlst_subfolders = new_subfolders
         return wlst_subfolders
 
     def _discover_subfolder_singleton(self, model_subfolder_name, location):
@@ -290,9 +294,9 @@ class Discoverer(object):
         # For all server subfolder names there should only be one path
         if self._mbean_names_exist(location):
             subfolder_path = self._alias_helper.get_wlst_attributes_path(location)
-            self._wlst_helper.cd(subfolder_path)
-            self._populate_model_parameters(subfolder_result, location)
-            self._discover_subfolders(subfolder_result, location)
+            if self.wlst_cd(subfolder_path, location):
+                self._populate_model_parameters(subfolder_result, location)
+                self._discover_subfolders(subfolder_result, location)
         _logger.finest('WLSDPLY-06111', str(location), class_name=_class_name, method_name=_method_name)
         _logger.exiting(class_name=_class_name, method_name=_method_name)
         return subfolder_result
@@ -374,9 +378,9 @@ class Discoverer(object):
                 subfolder_result[name] = OrderedDict()
                 location.add_name_token(name_token, name)
                 subfolder_path = self._alias_helper.get_wlst_attributes_path(location)
-                self._wlst_helper.cd(subfolder_path)
-                self._populate_model_parameters(subfolder_result[name], location)
-                self._discover_subfolders(subfolder_result[name], location)
+                if self.wlst_cd(subfolder_path, location):
+                    self._populate_model_parameters(subfolder_result[name], location)
+                    self._discover_subfolders(subfolder_result[name], location)
                 location.remove_name_token(name_token)
         _logger.finest('WLSDPLY-06114', str(location), class_name=_class_name, method_name=_method_name)
         _logger.exiting(class_name=_class_name, method_name=_method_name)
@@ -449,8 +453,8 @@ class Discoverer(object):
         _logger.entering(str(location), class_name=_class_name, method_name=_method_name)
         result = OrderedDict()
         subfolder_path = self._alias_helper.get_wlst_attributes_path(location)
-        self._wlst_helper.cd(subfolder_path)
-        self._populate_model_parameters(result, location)
+        if self.wlst_cd(subfolder_path, location):
+            self._populate_model_parameters(result, location)
         _logger.exiting(class_name=_class_name, method_name=_method_name)
         return result
 
@@ -532,7 +536,7 @@ class Discoverer(object):
         mbean_name = None
         subfolder_path = self._alias_helper.get_wlst_attributes_path(location)
         if subfolder_path:
-            location_object = self._wlst_helper.cd(subfolder_path)
+            location_object = self.wlst_cd(subfolder_path, location)
             if location_object is None:
                 _logger.fine('WLSDPLY-06121', self._alias_helper.get_wlst_attributes_path(location),
                              class_name=_class_name, method_name=_method_name)
@@ -576,6 +580,24 @@ class Discoverer(object):
                 except AliasException, ae:
                     continue
         return wlst_attributes
+
+    def wlst_cd(self, path, location):
+        """
+        Change to the directory specified in the path. If the wlst.cd() fails, assume something is wrong with the
+        construction of the path tokens: Log a message, and return a indication to the caller that it should
+        not continue on in this path.
+        :param path: where to change directory
+        :param location: context containing the current location information used to determine the path
+        :return: the mbean instance if the wlst.cd() was successful, or None
+        """
+        _method_name = 'wlst_cd'
+        result = None
+        try:
+            result = wlst_helper.cd(path)
+        except PyWLSTException, pe:
+            _logger.warning('WLSDPLY-06140', path, str(location), pe.getLocalizedMessage(), class_name=_class_name,
+                            method_name=_method_name)
+        return result
 
 
 def add_to_model_if_not_empty(dictionary, entry_name, entry_value):

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -458,6 +458,8 @@ WLSDPLY-06127=Unable to discover attribute {0} at location {1} under wls version
   will not be added to the model : {4}
 WLSDPLY-06130=Unexpected exception attempting to discover MBean entries at location {0} will prevent the discovery \
   of attributes at this location : {1}
+WLSDPLY-06140=Unable to cd to the expected path {0} constructed from location context {1}; the current folder \
+  and its sub-folders cannot be discovered : {2}
 
 # resources_discoverer.py
 WLSDPLY-06300=Discovering domain model resources


### PR DESCRIPTION
We still need to determine why the exception domain differs from our expectations of what the /Server/Log directory should be named, and determine if it is a problem that we need to consider and solve.

However, the correct action would be to warn the user and continue with the discover, not end immediately on this type of condition.