### PR TITLE
modifications for log chatter

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/aliases/VersionUtils.java
+++ b/core/src/main/java/oracle/weblogic/deploy/aliases/VersionUtils.java
@@ -341,7 +341,7 @@ public final class VersionUtils {
             LOGGER.throwing(CLASS, METHOD, ve);
             throw ve;
         }
-        LOGGER.exiting(CLASS, METHOD, result);
+        LOGGER.exiting(CLASS, METHOD, Arrays.toString(result));
         return result;
     }
 

--- a/core/src/main/python/wlsdeploy/tool/util/filter_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/filter_helper.py
@@ -11,7 +11,7 @@ from wlsdeploy.util import dictionary_utils
 from wlsdeploy.util.model_translator import FileToPython
 
 __class_name = 'filter_helper'
-__logger = PlatformLogger('wlsdeploy.wlst')
+__logger = PlatformLogger('wlsdeploy.tool.util')
 __filter_file_location = os.path.join(os.environ.get('WLSDEPLOY_HOME'), 'lib', 'model_filters.json')
 
 __id_filter_map = {

--- a/installer/src/main/etc/logging.properties
+++ b/installer/src/main/etc/logging.properties
@@ -2,5 +2,13 @@
 # The Universal Permissive License (UPL), Version 1.0
 # 
 wlsdeploy.level=FINER
-wlsdeploy.create.level=FINEST
-wlsdeploy.validate.level=FINEST
+
+wlsdeploy.create.level=FINER
+wlsdeploy.deploy.level=FINER
+wlsdeploy.discover.level=FINER
+wlsdeploy.update.level=FINER
+
+wlsdeploy.aliases.level=FINE
+wlsdeploy.util.level=FINER
+wlsdeploy.versions.level=FINE
+wlsdeploy.wlst.level=FINER


### PR DESCRIPTION
Please do not delete the repository or close the corresponding issue for this pull request until you have read the below:

I changed the logging properties to set the aliases and versions loggers to level FINE. This will reduce the ENTER, EXIT chatter. We can request the end user to change those logger levels if needed. However, the quality of logs in the aliases is not ideal. Informative loggers at the FINE level should be added to the aliases code. I have yet to find the information I need for an alias issue from the entering,exiting code. Entering,Exiting loggers is about all that aliases logs except for those at INFO and above.

If setting the version and alias loggers to level FINE is acceptable, we can close the issue and delete the repository. I suggest we open another issue for quality of logs in aliases if we need to spend our time on this. Else, we should add loggers as we find the need when troubleshooting issues.

I put loggers into the logging.properties for the more import logger names. This will be helpful to the user since the logger name is not included in the log stream. The user does not know the names or where to in the source to find the names.

The WDT logger names I did not include in the logger properties are as follows:
wlsdeploy.encrypt
wlsdeploy.validate
wlsdeploy.tool.util
wlsdeploy.json
wlsdeploy.archive
wlsdeploy.yaml
wlsdeploy.model
wlsdeploy.translator
wlsdeploy.variables
