### PR TITLE
Filter out Provider string in 1036 and 1211

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/alias_constants.py
+++ b/core/src/main/python/wlsdeploy/aliases/alias_constants.py
@@ -18,6 +18,7 @@ FOLDER_PARAMS = 'folder_params'
 GET_MBEAN_TYPE = 'get_mbean_type'
 GET_METHOD = 'get_method'
 MERGE = 'merge'
+METHOD = 'METHOD'
 MODEL_NAME = 'model_name'
 NAME_VALUE = 'name_value'
 PASSWORD_TOKEN = "--FIX ME--"
@@ -59,6 +60,7 @@ ChildFoldersTypes = Enum(['MULTIPLE', 'MULTIPLE_WITH_TYPE_SUBFOLDER', 'NONE', 'S
 GET = 'GET'
 LSA = 'LSA'
 NONE = 'NONE'
+NAMES = 'NAMES'
 
 # set_method values
 MBEAN = 'MBEAN'

--- a/core/src/main/python/wlsdeploy/tool/util/alias_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/alias_helper.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
 The Universal Permissive License (UPL), Version 1.0
 """
 from oracle.weblogic.deploy.aliases import AliasException
@@ -610,6 +610,25 @@ class AliasHelper(object):
             raise ex
         return result
 
+    def get_wlst_method_required_attribute_names(self, location):
+        """
+        Get the list of attribute names that require special processing via a method
+        :param location: the location
+        :return: dict[string=string]: the dictionary of attribute names and the attribute's method
+        :raises: BundleAwareException of the specified type: if an error occurs
+        """
+        _method_name = 'get_wlst_method_required_attribute_names'
+
+        try:
+            result = self.__aliases.get_wlst_method_required_attribute_names(location)
+        except AliasException, ae:
+            ex = exception_helper.create_exception(self.__exception_type, 'WLSDPLY-19034',
+                                                   location.get_current_model_folder(), location.get_folder_path(),
+                                                   ae.getLocalizedMessage(), error=ae)
+            self.__logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
+            raise ex
+        return result
+
     def get_model_subfolder_name(self, location, wlst_name):
         """
         Get the model folder name for the WLST subfolder name at the specified location.
@@ -687,6 +706,24 @@ class AliasHelper(object):
             self.__logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
             raise ex
         return result
+
+    def get_folder_names_method(self, location):
+        """
+        Get the method for retrieving the folder names for the folder at the current location
+        :param location: current location context
+        :return: method name or None if not present for the folder
+        """
+        _method_name = 'get_folder_names_method'
+
+        try:
+            getter_method = self.__aliases.get_folder_names_method(location)
+        except AliasException, ae:
+            ex = exception_helper.create_exception(self.__exception_type, 'WLSDPLY-19035',
+                                                   location.get_model_folders()[-1], location.get_folder_path(),
+                                                       ae.getLocalizedMessage(), error=ae)
+            self.__logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
+            raise ex
+        return getter_method
 
     ###########################################################################
     #                          Convenience Methods                            #

--- a/core/src/main/python/wlsdeploy/tool/util/attribute_getter.py
+++ b/core/src/main/python/wlsdeploy/tool/util/attribute_getter.py
@@ -1,0 +1,28 @@
+"""
+Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+The Universal Permissive License (UPL), Version 1.0
+"""
+
+from wlsdeploy.aliases.wlst_modes import WlstModes
+from wlsdeploy.tool.util.alias_helper import AliasHelper
+from wlsdeploy.tool.util.wlst_helper import WlstHelper
+
+
+class AttributeGetter(object):
+    """
+    Contains the methods that will get the values for specific wlst attributes.
+    These wlst attributes require the special processing. The method knows whether
+    to get the value from the provided attribute LSA list, or to retrieve it
+    using a GET or some other mechanism.
+    """
+
+    _class_name = "AttributeGetter"
+
+    def __init__(self, aliases, logger, exception_type, wlst_mode=WlstModes.OFFLINE):
+        self.__logger = logger
+        self.__exception_type = exception_type
+        self.__wlst_mode = wlst_mode
+        self.__alias_helper = AliasHelper(aliases, self.__logger, exception_type)
+        return
+
+

--- a/core/src/main/python/wlsdeploy/tool/util/mbean_getter.py
+++ b/core/src/main/python/wlsdeploy/tool/util/mbean_getter.py
@@ -1,0 +1,54 @@
+"""
+Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+The Universal Permissive License (UPL), Version 1.0
+"""
+
+from wlsdeploy.logging.platform_logger import PlatformLogger
+from wlsdeploy.tool.util.alias_helper import AliasHelper
+from wlsdeploy.tool.util.wlst_helper import WlstHelper
+from wlsdeploy.util.weblogic_helper import WebLogicHelper
+
+_class_name = "MBeanGetter"
+
+_logger = PlatformLogger('wlsdeploy.mbean.getter')
+
+
+class MBeanGetter(object):
+    """
+    Contains methods to help retrieve the wlst MBeans at the specific location.
+    """
+
+    def __init__(self, aliases, exception_type, logger=_logger):
+        self.__logger = logger
+        self.__exception_type = exception_type
+        self.__alias_helper = AliasHelper(aliases, self.__logger, exception_type)
+        self.__wlst_helper = WlstHelper(self.__logger, exception_type)
+        self.__wls_version = WebLogicHelper(self.__logger).get_actual_weblogic_version()
+        return
+
+    def get_class_name(self):
+        return _class_name
+
+    def get_valid_provider_name_list(self, location):
+        """
+        This version of offline wlst installs default security providers with no name. If a name does not exist for
+        a provider mbean, the string 'Provider' is returned. Bug 29217589 opened on this problem. This only
+        occurs in 10.3.x and 12.1.1 in offline mode.
+        :param location: current location context
+        :return: mbean name list excluding any 'Provider' name.
+        """
+        _method_name = 'get_valid_provider_name_list'
+        self.__logger.entering(location.get_folder_path(), class_name=_class_name, method_name=_method_name)
+
+        filtered_list = []
+        path_to_bean = self.__alias_helper.get_wlst_list_path(location)
+        name_list = self.__wlst_helper.lsc()
+        self.__logger.finer('WLSDPLY-06201', path_to_bean, name_list, class_name=_class_name, method_name=_method_name)
+        for name in name_list:
+            if name == 'Provider':
+                self.__logger.warning('WLSDPLY-06200', path_to_bean, self.__wls_version, class_name=_class_name,
+                                      method_name=_method_name)
+            else:
+                filtered_list.append(name)
+        self.__logger.exiting(class_name=_class_name, method_name=_method_name, result=filtered_list)
+        return filtered_list

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/SecurityConfiguration.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/SecurityConfiguration.json
@@ -1158,6 +1158,12 @@
                     }
                 },
                 "RoleMapper" : {
+                    "folder_params": [{
+                        "version": "[10,12.1.1]",
+                        "get_method": "${NAMES.get_valid_provider_name_list:}"
+                    }, {
+                        "version": "[12.1.2,)"
+                    }],
                     "wlst_type" : "RoleMapper${:s}",
                     "child_folders_type": "multiple_with_type_subfolder",
                     "folders" : {

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/SecurityConfiguration.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/SecurityConfiguration.json
@@ -1,5 +1,5 @@
 {
-    "copyright": "Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.",
+    "copyright": "Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.",
     "license": "The Universal Permissive License (UPL), Version 1.0",
     "wlst_type": "SecurityConfiguration",
     "folders": {
@@ -71,6 +71,12 @@
             "child_folders_type": "multiple",
             "folders": {
                 "Adjudicator" : {
+                    "folder_params": [{
+                        "version": "[10,12.1.1]",
+                        "get_method": "${NAMES.get_valid_provider_name_list:}"
+                    }, {
+                        "version": "[12.1.2,)"
+                    }],
                     "wlst_type" : "Adjudicator",
                     "child_folders_type": "multiple_with_type_subfolder",
                     "folders" : {
@@ -86,7 +92,6 @@
                             "wlst_paths": {
                                 "WP001": "/SecurityConfiguration/%DOMAIN%/Realm${:s}/%REALM%/Adjudicator/%PROVIDER%"
                             }
-
                         }
                     },
                     "attributes" : { },
@@ -96,6 +101,12 @@
                     }
                 },
                 "Auditor" : {
+                    "folder_params": [{
+                        "version": "[10,12.1.1]",
+                        "get_method": "${NAMES.get_valid_provider_name_list:}"
+                    }, {
+                        "version": "[12.1.2,)"
+                    }],
                     "wlst_type" : "Auditor",
                     "child_folders_type": "multiple_with_type_subfolder",
                     "folders" : {
@@ -133,6 +144,12 @@
                     }
                 },
                 "AuthenticationProvider" : {
+                    "folder_params": [{
+                        "version": "[10,12.1.1]",
+                        "get_method": "${NAMES.get_valid_provider_name_list:}"
+                    }, {
+                        "version": "[12.1.2,)"
+                    }],
                     "wlst_type" : "AuthenticationProvider${:s}",
                     "child_folders_type": "multiple_with_type_subfolder",
                     "folders": {
@@ -899,6 +916,12 @@
                     }
                 },
                 "Authorizer" : {
+                    "folder_params": [{
+                        "version": "[10,12.1.1]",
+                        "get_method": "${NAMES.get_valid_provider_name_list:}"
+                    }, {
+                        "version": "[12.1.2,)"
+                    }],
                     "wlst_type" : "Authorizer${:s}",
                     "child_folders_type": "multiple_with_type_subfolder",
                     "folders" : {
@@ -936,6 +959,12 @@
                     }
                 },
                 "CertPathProvider" : {
+                    "folder_params": [{
+                        "version": "[10,12.1.1]",
+                        "get_method": "${NAMES.get_valid_provider_name_list:}"
+                    }, {
+                        "version": "[12.1.2,)"
+                    }],
                     "wlst_type" : "CertPathProvider${:s}",
                     "child_folders_type": "multiple_with_type_subfolder",
                     "folders" : {
@@ -971,6 +1000,12 @@
                     }
                 },
                 "CredentialMapper" : {
+                    "folder_params": [{
+                        "version": "[10,12.1.1]",
+                        "get_method": "${NAMES.get_valid_provider_name_list:}"
+                    }, {
+                        "version": "[12.1.2,)"
+                    }],
                     "wlst_type" : "CredentialMapper${:s}",
                     "child_folders_type": "multiple_with_type_subfolder",
                     "folders" : {
@@ -1058,6 +1093,12 @@
                     }
                 },
                 "PasswordValidator" : {
+                    "folder_params": [{
+                        "version": "[10,12.1.1]",
+                        "get_method": "${NAMES.get_valid_provider_name_list:}"
+                    }, {
+                        "version": "[12.1.2,)"
+                    }],
                     "wlst_type" : "PasswordValidator${:s}",
                     "child_folders_type": "multiple_with_type_subfolder",
                     "folders" : {

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
 # The Universal Permissive License (UPL), Version 1.0
 #
 #
@@ -465,7 +465,15 @@ WLSDPLY-06143=Attribute {0} at location {1} is not writable and is deprecated
 WLSDPLY-06144=Folder {0} at location {1} is not an online folder. Removing from online subfolder list
 WLSDPLY-06145=Subfolder list {0} at location {1} does not match the mbi containment folder list {2}
 WLSDPLY-06146=Discovered WLST MBean names {0} at location {1}
-WLSDPLY-06147=Call method {0} to get the value for wlst attribute {1} at wlst path {2}
+WLSDPLY-06147=Call names method {0} to get the list of mbean names at location {1}
+WLSDPLY-06148=Failed to get or exec names getter method {0} to retrieve mbean names at location {1}
+WLSDPLY-06149=Call getter method {0} to return the list of mbean names for model location {1}
+
+# mbean_getter.py, attribute_getter.py specific to discover
+WLSDPLY-06200=Unable to get the Security Realm Provider name at location {0} using offline wlst in version {1}. \
+  Bug 29217589 has been opened for this problem. The Provider will not be added to the model. The work-around is to \
+  manually add the missing domain provider to the model or to discover the domain in online mode.
+WLSDPLY-06201=The name list returned for the Security Realm Provider MBean at location {0} is '''{1}'''
 
 # resources_discoverer.py
 WLSDPLY-06300=Discovering domain model resources
@@ -715,6 +723,7 @@ WLSDPLY-08132=Folder {0} present only for {1} mode is not relevant for WLST in {
 WLSDPLY-08133=Folder {0} present for {1} mode is relevant in WebLogic Server version {2}
 WLSDPLY-08134=Folder parameters for Folder {0} are invalid and cannot be processed
 WLSDPLY-08135=Found a valid parameters for Folder {0} in the array of folder parameters
+WLSDPLY-08136=Folder {0} matching folder param {1} contained folders or attributes which will be ignored
 
 #
 # Empty slots to fill up...
@@ -944,6 +953,8 @@ WLSDPLY-12122=The attribute {0} in model location {1} has value {2} that referen
   archive file but the archive file was not provided
 # The WLSDPLY-12123 resource is used for messages returned from aliases.is_version_valid_location()
 WLSDPLY-12123={0}
+WLSDPLY-12124=Call the mbean getter method {0} to retrieve the mbean names for location {1}
+WLSDPLY-12125=Failed to get get method {0} for mbean at model path {1}
 
 # domain_creator.py
 WLSDPLY-12200={0} did not find the required {1} section in the model file {2}
@@ -1090,6 +1101,7 @@ WLSDPLY-19032=Failed to get the default value for model attribute {0} at locatio
 WLSDPLY-19033=Failed to determine if location ({0}) is version valid, or not
 WLSDPLY-19034=Failed to get the model attribute list that require a special processing via a method for model \
   folder ({0}) at location ({1}): {2}
+WLSDPLY-19035=Failed to get the getter method name for mbean {0} at model location ({1}): {2}
 
 # wlsdeploy/tool/util/wlst_helper.py
 WLSDPLY-19100=Failed to change to the WLST directory {0}: {1}

--- a/core/src/test/python/aliases_test.py
+++ b/core/src/test/python/aliases_test.py
@@ -13,7 +13,6 @@ from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.aliases import TypeUtils
 
 from wlsdeploy.aliases.aliases import Aliases
-from wlsdeploy.aliases.alias_constants import ATTRIBUTES
 from wlsdeploy.aliases.location_context import LocationContext
 import wlsdeploy.aliases.model_constants as FOLDERS
 from wlsdeploy.aliases.validation_codes import ValidationCodes
@@ -1321,6 +1320,37 @@ class AliasesTestCase(unittest.TestCase):
 
         actual_attr, actual_value = self.aliases.get_wlst_attribute_name_and_value(location, actual_attr, actual_value)
         self.assertEqual(wlst_list, actual_value)
+
+    def testSecurityProviderGetMethod(self):
+        old_wls_version = '10.3.6'
+        new_wls_version = '12.2.1.3'
+
+        old_aliases_offline = Aliases(self.model_context, WlstModes.OFFLINE, old_wls_version)
+        old_aliases_online = Aliases(self.model_context, WlstModes.ONLINE, old_wls_version)
+        new_aliases = Aliases(self.model_context, WlstModes.OFFLINE, new_wls_version)
+
+        location = LocationContext()
+        location.append_location(FOLDERS.SECURITY_CONFIGURATION)
+        location.add_name_token(old_aliases_offline.get_name_token(location), 'mydomain')
+        location.append_location(FOLDERS.REALM)
+        location.add_name_token(old_aliases_offline.get_name_token(location), 'myrealm')
+        location.append_location(FOLDERS.AUTHENTICATION_PROVIDER)
+
+        getter_method = old_aliases_offline.get_folder_names_method(location)
+
+        version_string = str(old_aliases_offline.get_version()) + ' ' + old_aliases_offline.get_mode_string()
+        self.assertNotEqual(getter_method, None, 'expected Authenticator getter method for ' + version_string)
+
+        version_string = str(old_aliases_online.get_version()) + ' ' + old_aliases_online.get_mode_string()
+        self.assertNotEqual(getter_method, None, 'expected Authenticator getter method to be null for ' +
+                            version_string)
+
+        version_string = str(new_aliases.get_version()) + ' ' + new_aliases.get_mode_string()
+        getter_method = new_aliases.get_folder_names_method(location)
+        self.assertEqual(getter_method, None, 'expected Authenticator getter method to be null for ' + version_string)
+
+        return
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Problem in offline 10.3.6 and 12.1.1 in offline mode does not return a valid name for Providers. Add a filter to not add the invalid Provider mbeans to the model in Discover. Write message to stdout that states the reason and the bug number opened in CIE