### PR TITLE
JIRA WDT-46 Avoid assigning non-parsable value in YAML

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
+++ b/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * The Universal Permissive License (UPL), Version 1.0
  */
 package oracle.weblogic.deploy.yaml;
@@ -72,7 +72,11 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
         PyObject value = getAssignValue(name, ctx);
 
         PyDictionary container = currentDict.peek();
-        container.__setitem__(new PyString(name), value);
+
+        // null indicates not parsable, Py.None would be returned for legitimate cases
+        if (value != null) {
+            container.__setitem__(new PyString(name), value);
+        }
     }
 
     /**


### PR DESCRIPTION
The NPE no longer occurs.  The parse error is still detected on the next line number in this scenario, but there are additional messages that point to the JdbcResource model entry.  Fixes #208