### PR TITLE
Wdt 33 domaintypechk

### DIFF
--- a/installer/src/main/bin/createDomain.cmd
+++ b/installer/src/main/bin/createDomain.cmd
@@ -227,7 +227,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid value is "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/createDomain.cmd
+++ b/installer/src/main/bin/createDomain.cmd
@@ -227,7 +227,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/createDomain.cmd
+++ b/installer/src/main/bin/createDomain.cmd
@@ -151,6 +151,10 @@ IF NOT "%~1" == "" (
   GOTO arg_loop
 )
 
+@rem Default domain type if not specified
+IF "%DOMAIN_TYPE%"=="" SET DOMAIN_TYPE="WLS"
+
+
 @rem
 @rem Validate the JVM version based on whether or not the user asked us to use encryption
 @rem
@@ -223,8 +227,9 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script... assuming JRF is required
-SET USE_JRF_WLST=TRUE
+ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+SET  RETURN_CODE=98
+GOTO exit_script
 
 :domain_type_recognized
 IF "%USE_JRF_WLST%" == "TRUE" (

--- a/installer/src/main/bin/createDomain.sh
+++ b/installer/src/main/bin/createDomain.sh
@@ -198,6 +198,13 @@ while [[ $# > 1 ]]; do
     shift # past arg or value
 done
 
+# default DOMAIN_TYPE
+
+if [ -z "${DOMAIN_TYPE}" ]; then
+    DOMAIN_TYPE="WLS"
+fi
+
+
 #
 # Validate the JVM version based on whether or not the user asked us to use encryption
 #
@@ -256,7 +263,8 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Domain type ${DOMAIN_TYPE} not recognized by shell script...assuming JRF is required"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        exit 98
     fi
 
     if [ "${USE_JRF_WLST}" = "TRUE" ]; then

--- a/installer/src/main/bin/createDomain.sh
+++ b/installer/src/main/bin/createDomain.sh
@@ -263,7 +263,7 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid value is WLS|JRF|RestrictedJRF"
         exit 98
     fi
 

--- a/installer/src/main/bin/deployApps.cmd
+++ b/installer/src/main/bin/deployApps.cmd
@@ -224,7 +224,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/deployApps.cmd
+++ b/installer/src/main/bin/deployApps.cmd
@@ -224,7 +224,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid value is "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/deployApps.cmd
+++ b/installer/src/main/bin/deployApps.cmd
@@ -149,6 +149,9 @@ IF NOT "%~1" == "" (
   GOTO arg_loop
 )
 
+@rem Default domain type if not specified
+IF "%DOMAIN_TYPE%"=="" SET DOMAIN_TYPE="WLS"
+
 @rem
 @rem Validate the JVM version based on whether or not the user asked us to use encryption
 @rem
@@ -221,8 +224,9 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script... assuming JRF is required
-SET USE_JRF_WLST=TRUE
+ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+SET  RETURN_CODE=98
+GOTO exit_script
 
 :domain_type_recognized
 IF "%USE_JRF_WLST%" == "TRUE" (

--- a/installer/src/main/bin/deployApps.sh
+++ b/installer/src/main/bin/deployApps.sh
@@ -249,7 +249,7 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid value is WLS|JRF|RestrictedJRF"
         exit 98
     fi
 

--- a/installer/src/main/bin/deployApps.sh
+++ b/installer/src/main/bin/deployApps.sh
@@ -149,7 +149,6 @@ fi
 
 SCRIPT_ARGS="$*"
 MIN_JDK_VERSION=7
-
 #
 # Find the args required to determine the WLST script to run
 #
@@ -182,6 +181,14 @@ while [[ $# > 1 ]]; do
     esac
     shift # past arg or value
 done
+
+
+# default DOMAIN_TYPE
+
+if [ -z "${DOMAIN_TYPE}" ]; then
+    DOMAIN_TYPE="WLS"
+fi
+
 
 #
 # Validate the JVM version based on whether or not the user asked us to use encryption
@@ -234,6 +241,7 @@ else
     #
     WLST=""
     USE_JRF_WLST=FALSE
+
     if [ "${DOMAIN_TYPE}" = "WLS" ]; then
         USE_JRF_WLST=FALSE
     elif [ "${DOMAIN_TYPE}" = "RestrictedJRF" ]; then
@@ -241,7 +249,8 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Domain type ${DOMAIN_TYPE} not recognized by shell script...assuming JRF is required"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        exit 98
     fi
 
     if [ "${USE_JRF_WLST}" = "TRUE" ]; then

--- a/installer/src/main/bin/discoverDomain.cmd
+++ b/installer/src/main/bin/discoverDomain.cmd
@@ -212,7 +212,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/discoverDomain.cmd
+++ b/installer/src/main/bin/discoverDomain.cmd
@@ -212,7 +212,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid value is "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/discoverDomain.cmd
+++ b/installer/src/main/bin/discoverDomain.cmd
@@ -158,6 +158,9 @@ IF NOT "%~1" == "" (
   GOTO arg_loop
 )
 
+@rem Default domain type if not specified
+IF "%DOMAIN_TYPE%"=="" SET DOMAIN_TYPE="WLS"
+
 @rem
 @rem Check for values of required arguments for this script to continue.
 @rem The underlying WLST script has other required arguments.
@@ -209,8 +212,9 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script... assuming JRF is required
-SET USE_JRF_WLST=TRUE
+ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+SET  RETURN_CODE=98
+GOTO exit_script
 
 :domain_type_recognized
 IF "%USE_JRF_WLST%" == "TRUE" (

--- a/installer/src/main/bin/discoverDomain.sh
+++ b/installer/src/main/bin/discoverDomain.sh
@@ -172,6 +172,12 @@ while [[ $# > 1 ]]; do
     shift # past arg or value
 done
 
+# default DOMAIN_TYPE
+
+if [ -z "${DOMAIN_TYPE}" ]; then
+    DOMAIN_TYPE="WLS"
+fi
+
 #
 # Check for values of required arguments for this script to continue.
 # The underlying WLST script has other required arguments.
@@ -213,7 +219,8 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Domain type ${DOMAIN_TYPE} not recognized by shell script...assuming JRF is required"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        exit 98
     fi
 
     if [ "${USE_JRF_WLST}" = "TRUE" ]; then

--- a/installer/src/main/bin/discoverDomain.sh
+++ b/installer/src/main/bin/discoverDomain.sh
@@ -219,7 +219,7 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid value is WLS|JRF|RestrictedJRF"
         exit 98
     fi
 

--- a/installer/src/main/bin/encryptModel.cmd
+++ b/installer/src/main/bin/encryptModel.cmd
@@ -221,7 +221,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid value is "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/encryptModel.cmd
+++ b/installer/src/main/bin/encryptModel.cmd
@@ -221,7 +221,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/encryptModel.cmd
+++ b/installer/src/main/bin/encryptModel.cmd
@@ -166,6 +166,10 @@ IF NOT "%~1" == "" (
   GOTO arg_loop
 )
 
+
+@rem Default domain type if not specified
+IF "%DOMAIN_TYPE%"=="" SET DOMAIN_TYPE="WLS"
+
 @rem
 @rem Check for values of required arguments for this script to continue.
 @rem The underlying WLST script has other required arguments.
@@ -217,8 +221,9 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script... assuming JRF is required
-SET USE_JRF_WLST=TRUE
+ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+SET  RETURN_CODE=98
+GOTO exit_script
 
 :domain_type_recognized
 IF "%USE_JRF_WLST%" == "TRUE" (

--- a/installer/src/main/bin/encryptModel.sh
+++ b/installer/src/main/bin/encryptModel.sh
@@ -176,6 +176,12 @@ while [[ $# > 1 ]]; do
     shift # past arg or value
 done
 
+# default DOMAIN_TYPE
+
+if [ -z "${DOMAIN_TYPE}" ]; then
+    DOMAIN_TYPE="WLS"
+fi
+
 #
 # Check for values of required arguments for this script to continue.
 # The underlying WLST script has other required arguments.
@@ -217,7 +223,8 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Domain type ${DOMAIN_TYPE} not recognized by shell script...assuming JRF is required"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        exit 98
     fi
 
     if [ "${USE_JRF_WLST}" = "TRUE" ]; then

--- a/installer/src/main/bin/encryptModel.sh
+++ b/installer/src/main/bin/encryptModel.sh
@@ -223,7 +223,7 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid value is WLS|JRF|RestrictedJRF"
         exit 98
     fi
 

--- a/installer/src/main/bin/injectVariables.cmd
+++ b/installer/src/main/bin/injectVariables.cmd
@@ -215,7 +215,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid value is "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/injectVariables.cmd
+++ b/installer/src/main/bin/injectVariables.cmd
@@ -161,6 +161,9 @@ IF NOT "%~1" == "" (
   GOTO arg_loop
 )
 
+@rem Default domain type if not specified
+IF "%DOMAIN_TYPE%"=="" SET DOMAIN_TYPE="WLS"
+
 @rem
 @rem Check for values of required arguments for this script to continue.
 @rem The underlying WLST script has other required arguments.
@@ -212,8 +215,9 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script... assuming JRF is required
-SET USE_JRF_WLST=TRUE
+ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+SET  RETURN_CODE=98
+GOTO exit_script
 
 :domain_type_recognized
 IF "%USE_JRF_WLST%" == "TRUE" (

--- a/installer/src/main/bin/injectVariables.cmd
+++ b/installer/src/main/bin/injectVariables.cmd
@@ -215,7 +215,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/injectVariables.sh
+++ b/installer/src/main/bin/injectVariables.sh
@@ -232,7 +232,7 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid value is WLS|JRF|RestrictedJRF"
         exit 98
     fi
 

--- a/installer/src/main/bin/injectVariables.sh
+++ b/installer/src/main/bin/injectVariables.sh
@@ -185,6 +185,12 @@ while [[ $# > 1 ]]; do
     shift # past arg or value
 done
 
+# default DOMAIN_TYPE
+
+if [ -z "${DOMAIN_TYPE}" ]; then
+    DOMAIN_TYPE="WLS"
+fi
+
 #
 # Check for values of required arguments for this script to continue.
 # The underlying WLST script has other required arguments.
@@ -226,7 +232,8 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Domain type ${DOMAIN_TYPE} not recognized by shell script...assuming JRF is required"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        exit 98
     fi
 
     if [ "${USE_JRF_WLST}" = "TRUE" ]; then

--- a/installer/src/main/bin/updateDomain.cmd
+++ b/installer/src/main/bin/updateDomain.cmd
@@ -224,7 +224,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/updateDomain.cmd
+++ b/installer/src/main/bin/updateDomain.cmd
@@ -224,7 +224,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid value is "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/updateDomain.cmd
+++ b/installer/src/main/bin/updateDomain.cmd
@@ -149,6 +149,9 @@ IF NOT "%~1" == "" (
   GOTO arg_loop
 )
 
+@rem Default domain type if not specified
+IF "%DOMAIN_TYPE%"=="" SET DOMAIN_TYPE="WLS"
+
 @rem
 @rem Validate the JVM version based on whether or not the user asked us to use encryption
 @rem
@@ -221,8 +224,9 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script... assuming JRF is required
-SET USE_JRF_WLST=TRUE
+ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+SET  RETURN_CODE=98
+GOTO exit_script
 
 :domain_type_recognized
 IF "%USE_JRF_WLST%" == "TRUE" (

--- a/installer/src/main/bin/updateDomain.sh
+++ b/installer/src/main/bin/updateDomain.sh
@@ -247,7 +247,7 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid value is WLS|JRF|RestrictedJRF"
         exit 98
     fi
 

--- a/installer/src/main/bin/updateDomain.sh
+++ b/installer/src/main/bin/updateDomain.sh
@@ -183,6 +183,12 @@ while [[ $# > 1 ]]; do
     shift # past arg or value
 done
 
+# default DOMAIN_TYPE
+
+if [ -z "${DOMAIN_TYPE}" ]; then
+    DOMAIN_TYPE="WLS"
+fi
+
 #
 # Validate the JVM version based on whether or not the user asked us to use encryption
 #
@@ -241,7 +247,8 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Domain type ${DOMAIN_TYPE} not recognized by shell script...assuming JRF is required"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        exit 98
     fi
 
     if [ "${USE_JRF_WLST}" = "TRUE" ]; then

--- a/installer/src/main/bin/validateModel.cmd
+++ b/installer/src/main/bin/validateModel.cmd
@@ -211,7 +211,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/validateModel.cmd
+++ b/installer/src/main/bin/validateModel.cmd
@@ -211,7 +211,7 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid values are "WLS|JRF|RestrictedJRF"
+ECHO Wrong domain type specified "%DOMAIN_TYPE%": valid value is "WLS|JRF|RestrictedJRF"
 SET  RETURN_CODE=98
 GOTO exit_script
 

--- a/installer/src/main/bin/validateModel.cmd
+++ b/installer/src/main/bin/validateModel.cmd
@@ -157,6 +157,9 @@ IF NOT "%~1" == "" (
   GOTO arg_loop
 )
 
+@rem Default domain type if not specified
+IF "%DOMAIN_TYPE%"=="" SET DOMAIN_TYPE="WLS"
+
 @rem
 @rem Check for values of required arguments for this script to continue.
 @rem The underlying WLST script has other required arguments.
@@ -208,8 +211,9 @@ IF DEFINED DOMAIN_TYPE (
   )
 )
 
-ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script... assuming JRF is required
-SET USE_JRF_WLST=TRUE
+ECHO Domain type "%DOMAIN_TYPE%" not recognized by shell script. Valid values are: WLS, JRF, RestrictedJRF
+SET  RETURN_CODE=98
+GOTO exit_script
 
 :domain_type_recognized
 IF "%USE_JRF_WLST%" == "TRUE" (

--- a/installer/src/main/bin/validateModel.sh
+++ b/installer/src/main/bin/validateModel.sh
@@ -242,7 +242,7 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid value is WLS|JRF|RestrictedJRF"
         exit 98
     fi
 

--- a/installer/src/main/bin/validateModel.sh
+++ b/installer/src/main/bin/validateModel.sh
@@ -195,6 +195,12 @@ while [[ $# > 1 ]]; do
     shift # past arg or value
 done
 
+# default DOMAIN_TYPE
+
+if [ -z "${DOMAIN_TYPE}" ]; then
+    DOMAIN_TYPE="WLS"
+fi
+
 #
 # Check for values of required arguments for this script to continue.
 # The underlying WLST script has other required arguments.
@@ -236,7 +242,8 @@ else
     elif [ "${DOMAIN_TYPE}" = "JRF" ]; then
         USE_JRF_WLST=TRUE
     else
-        echo "Domain type ${DOMAIN_TYPE} not recognized by shell script...assuming JRF is required"
+        echo "Wrong domain type specified ${DOMAIN_TYPE}: valid values are WLS|JRF|RestrictedJRF"
+        exit 98
     fi
 
     if [ "${USE_JRF_WLST}" = "TRUE" ]; then


### PR DESCRIPTION
Add check for invalid domain_type in shell script, if it is not set then it will set to WLS and if it is not equals to one of WLS|JRF|RestrictedJRF it will exit with an error message; since the shell scripts are the only entry points, no need to fix it in python.