### PR TITLE
WDT-87 Allow slashes in object names, for SOA create/deploy, full fix…

### DIFF
--- a/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
+++ b/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
@@ -280,7 +280,7 @@ fragment ID_START
 fragment ID_CONTINUE
     : ID_START
     | [0-9]
-    | [. ()]
+    | [. ()/]
     ;
 
 // to support variables in IDs that will need to be quoted because of the curly braces
@@ -292,7 +292,7 @@ fragment QUOTED_ID_START
 
 fragment QUOTED_ID_CONTINUE
     : ID_CONTINUE
-    | [@#\-(){}[\]:]
+    | [@#\-(){}[\]:/]
     ;
 
 fragment SQUOTED_STRING_CHARS

--- a/core/src/test/java/oracle/weblogic/deploy/yaml/YamlParserTest.java
+++ b/core/src/test/java/oracle/weblogic/deploy/yaml/YamlParserTest.java
@@ -22,11 +22,9 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.antlr.v4.runtime.tree.TerminalNode;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.python.core.PyObject;
 
 public class YamlParserTest extends YamlBaseListener {
     private static final boolean DEBUG = System.getProperty("DEBUG") != null;
@@ -467,6 +465,7 @@ public class YamlParserTest extends YamlBaseListener {
             text = nameCtx.NAME().getText();
             if (!StringUtils.isEmpty(text)) {
                 value = text.trim();
+                value = StringUtils.stripQuotes(value.toString());  // similar to AbstractYamlTranslator
             } else {
                 value = null;
             }


### PR DESCRIPTION
Allow slashes in object names, for SOA create/deploy, full fix pending.  Restored Johnny's original fix and revised unit test.