### PR TITLE
java version extraction not working with solaris awk

### DIFF
--- a/installer/src/main/bin/createDomain.sh
+++ b/installer/src/main/bin/createDomain.sh
@@ -208,8 +208,8 @@ fi
 #
 # Validate the JVM version based on whether or not the user asked us to use encryption
 #
-JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F "\"" '{ print $2 }'`
-JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F "." '{ print $2 }'`
+JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
+JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F"." '{ print $2 }'`
 
 if [ ${JVM_VERSION} -lt ${MIN_JDK_VERSION} ]; then
   if [ ${JVM_VERSION} -lt 7 ]; then

--- a/installer/src/main/bin/deployApps.sh
+++ b/installer/src/main/bin/deployApps.sh
@@ -193,8 +193,8 @@ fi
 #
 # Validate the JVM version based on whether or not the user asked us to use encryption
 #
-JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F "\"" '{ print $2 }'`
-JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F "." '{ print $2 }'`
+JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
+JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F"." '{ print $2 }'`
 
 if [ ${JVM_VERSION} -lt ${MIN_JDK_VERSION} ]; then
   if [ ${JVM_VERSION} -lt 7 ]; then

--- a/installer/src/main/bin/discoverDomain.sh
+++ b/installer/src/main/bin/discoverDomain.sh
@@ -123,8 +123,8 @@ case "${JVM_OUTPUT}" in
     ;;
 esac
 
-JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F "\"" '{ print $2 }'`
-JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F "." '{ print $2 }'`
+JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
+JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F"." '{ print $2 }'`
 
 if [ ${JVM_VERSION} -lt 7 ]; then
   echo "You are using an unsupported JDK version ${JVM_FULL_VERSION}" >&2

--- a/installer/src/main/bin/encryptModel.sh
+++ b/installer/src/main/bin/encryptModel.sh
@@ -123,8 +123,8 @@ case "${JVM_OUTPUT}" in
     ;;
 esac
 
-JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F "\"" '{ print $2 }'`
-JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F "." '{ print $2 }'`
+JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
+JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F"." '{ print $2 }'`
 
 if [ ${JVM_VERSION} -lt 8 ]; then
   if [ ${JVM_VERSION} -lt 7 ]; then

--- a/installer/src/main/bin/injectVariables.sh
+++ b/installer/src/main/bin/injectVariables.sh
@@ -135,8 +135,8 @@ case "${JVM_OUTPUT}" in
     ;;
 esac
 
-JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F "\"" '{ print $2 }'`
-JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F "." '{ print $2 }'`
+JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
+JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F"." '{ print $2 }'`
 
 if [ ${JVM_VERSION} -lt 7 ]; then
   echo "You are using an unsupported JDK version ${JVM_FULL_VERSION}" >&2

--- a/installer/src/main/bin/updateDomain.sh
+++ b/installer/src/main/bin/updateDomain.sh
@@ -192,8 +192,8 @@ fi
 #
 # Validate the JVM version based on whether or not the user asked us to use encryption
 #
-JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F "\"" '{ print $2 }'`
-JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F "." '{ print $2 }'`
+JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
+JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F"." '{ print $2 }'`
 
 if [ ${JVM_VERSION} -lt ${MIN_JDK_VERSION} ]; then
   if [ ${JVM_VERSION} -lt 7 ]; then

--- a/installer/src/main/bin/validateModel.sh
+++ b/installer/src/main/bin/validateModel.sh
@@ -145,8 +145,8 @@ case "${JVM_OUTPUT}" in
     ;;
 esac
 
-JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F "\"" '{ print $2 }'`
-JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F "." '{ print $2 }'`
+JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
+JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F"." '{ print $2 }'`
 
 if [ ${JVM_VERSION} -lt 7 ]; then
   echo "You are using an unsupported JDK version ${JVM_FULL_VERSION}" >&2


### PR DESCRIPTION
After attempting to use the tool on solaris 11, we've noticed the included awk does not allow spaces between the "-F" option and its argument.