### PR TITLE
Fix how we calculate temporary file for archive

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/util/WLSDeployZipFile.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/WLSDeployZipFile.java
@@ -775,7 +775,14 @@ public class WLSDeployZipFile {
     private File getNewOutputFile() throws WLSDeployArchiveIOException {
         final String METHOD = "getNewOutputFile";
 
-        String[] nameComponents = FileUtils.parseFileName(getFileName());
+        String fileName = getFileName();
+        if (fileName.contains(File.separator)) {
+            int lastSeparator = fileName.lastIndexOf(File.separator);
+            if (lastSeparator > 0)
+                fileName = fileName.substring(lastSeparator+1);
+        }
+
+        String[] nameComponents = FileUtils.parseFileName(fileName);
 
         File directory = getFile().getParentFile();
         File newOutputFile;


### PR DESCRIPTION
Prior than jdk 8,  java.io.File generateFile does not strip down the prefix to base name in createTempFile, we are changing how we pass in the prefix now.