### PR TITLE
Correct discover domain log message for application deployment plan

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/discover/deployments_discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/deployments_discoverer.py
@@ -270,7 +270,7 @@ class DeploymentsDiscoverer(Discoverer):
             app_source_name = application_dict[model_constants.SOURCE_PATH]
             plan_path = application_dict[model_constants.PLAN_PATH]
             if plan_path:
-                _logger.info('WLSDPLY-06389', application_name, plan_path, class_name=_class_name,
+                _logger.info('WLSDPLY-06402', application_name, plan_path, class_name=_class_name,
                              method_name=_method_name)
                 plan_dir = None
                 if model_constants.PLAN_DIR in application_dict:

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -552,6 +552,7 @@ WLSDPLY-06399=Application {0} plan deployment has new source path location {1} w
   archive file deployment location
 WLSDPLY-06400=Skipping {0} application {1}
 WLSDPLY-06401=Skipping {0} shared library {1}
+WLSDPLY-06402=Add application {0} deployment plan {1} to archive file
 
 # domain_info_discoverer.py
 WLSDPLY-06420=Add the java archive files from the domain library {0} to the archive file


### PR DESCRIPTION
Correct discover domain log message for application deployment plan.  The log message was pointing at the library deployment plan message.