### PR TITLE
Dont apply jrf resources if running domain_type WLS

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -408,7 +408,7 @@ class DomainCreator(Creator):
             server_groups_to_target = self._domain_typedef.get_server_groups_to_target()
             self.target_helper.target_server_groups_to_servers(server_groups_to_target)
             self.wlst_helper.update_domain()
-        else:
+        elif self._domain_typedef.domain_type_has_jrf_resources():
             # Update the domain to apply the extension templates.
             self.wlst_helper.update_domain()
             self.target_helper.target_jrf_groups_to_clusters_servers(domain_home)

--- a/core/src/main/python/wlsdeploy/tool/create/domain_typedef.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_typedef.py
@@ -95,6 +95,20 @@ class DomainTypedef(object):
         """
         return self._domain_type
 
+    def domain_type_is_jrf(self):
+        """
+        Determine if the tool is running with domain type JRF or RestrictedJRF.
+        :return : True if running with domain type JRF or RestrictedJRF.
+        """
+        return self.get_domain_type() == 'JRF' or self.get_domain_type() == 'RestrictedJRF'
+
+    def domain_type_has_jrf_resources(self):
+        """
+        Does the running domain type contain the JRF server group ?
+        :return:
+        """
+        return 'JRF-MAN-SVR' in self.get_server_groups_to_target()
+
     def get_base_template(self):
         """
         Get the base template to use when create the domain.

--- a/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
@@ -114,7 +114,7 @@ class TopologyUpdater(Deployer):
         if self.wls_helper.is_set_server_groups_supported():
             server_groups_to_target = self._domain_typedef.get_server_groups_to_target()
             self.target_helper.target_server_groups_to_servers(server_groups_to_target)
-        else:
+        elif self._domain_typedef.domain_type_has_jrf_resources():
             deployer_utils.save_changes(self.model_context)
             self.target_helper.target_jrf_groups_to_clusters_servers(self.model_context.get_domain_home())
             deployer_utils.read_again(self.model_context)


### PR DESCRIPTION
Only do applyJRF if running with a -domain_type that has JRF template server group. Reported by Richard Killen on 10.3.6 running -domain_type WLS