### PR TITLE
JIRA WDT 299 admin server name problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Many organizations are using WebLogic Server, with or without other Oracle Fusio
     - [Simple Example](#simple-example)
     - [Model Names](#model-names)
     - [Model Semantics](#model-semantics)
-    - [Admin Server Configuration](site/admin_server.md)
+    - [Administration Server Configuration](site/admin_server.md)
     - [Modeling Security Providers](site/security_providers.md)
         - [JRF Trust Service Identity Asserter](site/security_providers.md#trust-service-identity-asserter)
         - [Custom Security Providers](site/security_providers.md#custom-security-providers)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Many organizations are using WebLogic Server, with or without other Oracle Fusio
     - [Simple Example](#simple-example)
     - [Model Names](#model-names)
     - [Model Semantics](#model-semantics)
+    - [Admin Server Configuration](site/admin_server.md)
     - [Modeling Security Providers](site/security_providers.md)
         - [JRF Trust Service Identity Asserter](site/security_providers.md#trust-service-identity-asserter)
         - [Custom Security Providers](site/security_providers.md#custom-security-providers)

--- a/core/src/main/python/wlsdeploy/aliases/model_constants.py
+++ b/core/src/main/python/wlsdeploy/aliases/model_constants.py
@@ -19,8 +19,8 @@ APP_DEPLOYMENTS = 'appDeployments'
 APP_DIR = 'AppDir'
 APPLICATION = 'Application'
 RCU_DB_INFO = 'RCUDbInfo'
-RCU_PREFIX= 'rcu_prefix'
-RCU_SCHEMA_PASSWORD= 'rcu_schema_password'
+RCU_PREFIX = 'rcu_prefix'
+RCU_SCHEMA_PASSWORD = 'rcu_schema_password'
 RCU_ADMIN_PASSWORD = 'rcu_admin_password'
 RCU_DB_CONN = 'rcu_db_conn_string'
 RCU_VARIABLES = 'rcu_variables'
@@ -223,7 +223,7 @@ SERVER_START = 'ServerStart'
 SERVER_START_MODE = 'ServerStartMode'
 SERVER_TEMPLATE = 'ServerTemplate'
 SHUTDOWN_CLASS = 'ShutdownClass'
-SINGLETON_SERVICE= 'SingletonService'
+SINGLETON_SERVICE = 'SingletonService'
 SMTP_NOTIFICATION = 'SMTPNotification'
 SNMP_NOTIFICATION = 'SNMPNotification'
 SOURCE_DESTINATION = 'SourceDestination'
@@ -348,4 +348,11 @@ KNOWN_TOPLEVEL_MODEL_SECTIONS = [
     TOPOLOGY,
     RESOURCES,
     APP_DEPLOYMENTS
+]
+
+# these domain attributes have special processing in create,
+# and should be skipped in regular attribute processing.
+CREATE_ONLY_DOMAIN_ATTRIBUTES = [
+    DOMAIN_NAME,
+    ADMIN_SERVER_NAME
 ]

--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -15,6 +15,7 @@ from wlsdeploy.aliases.model_constants import ATP_TNS_ENTRY
 from wlsdeploy.aliases.model_constants import ATP_DEFAULT_TABLESPACE
 from wlsdeploy.aliases.model_constants import ATP_TEMPORARY_TABLESPACE
 from wlsdeploy.aliases.model_constants import CLUSTER
+from wlsdeploy.aliases.model_constants import CREATE_ONLY_DOMAIN_ATTRIBUTES
 from wlsdeploy.aliases.model_constants import DEFAULT_ADMIN_SERVER_NAME
 from wlsdeploy.aliases.model_constants import DEFAULT_WLS_DOMAIN_NAME
 from wlsdeploy.aliases.model_constants import DOMAIN_NAME
@@ -1038,8 +1039,12 @@ class DomainCreator(Creator):
         _method_name = '__set_domain_attributes'
         self.logger.finer('WLSDPLY-12231', self._domain_name, class_name=self.__class_name, method_name=_method_name)
         attrib_dict = dictionary_utils.get_dictionary_attributes(self.model.get_model_topology())
-        if DOMAIN_NAME in attrib_dict:
-            del attrib_dict[DOMAIN_NAME]
+
+        # skip any attributes that have special handling
+        for attribute in CREATE_ONLY_DOMAIN_ATTRIBUTES:
+            if attribute in attrib_dict:
+                del attrib_dict[attribute]
+
         location = LocationContext()
         attribute_path = self.alias_helper.get_wlst_attributes_path(location)
         self.wlst_helper.cd(attribute_path)

--- a/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
@@ -5,7 +5,7 @@ The Universal Permissive License (UPL), Version 1.0
 from wlsdeploy.aliases.location_context import LocationContext
 from wlsdeploy.aliases.model_constants import ADMIN_CONSOLE
 from wlsdeploy.aliases.model_constants import CLUSTER
-from wlsdeploy.aliases.model_constants import DOMAIN_NAME
+from wlsdeploy.aliases.model_constants import CREATE_ONLY_DOMAIN_ATTRIBUTES
 from wlsdeploy.aliases.model_constants import MACHINE
 from wlsdeploy.aliases.model_constants import MIGRATABLE_TARGET
 from wlsdeploy.aliases.model_constants import SECURITY
@@ -143,8 +143,12 @@ class TopologyUpdater(Deployer):
         self.logger.fine('WLSDPLY-09700', self.model_context.get_domain_name(), class_name=self._class_name,
                          method_name=_method_name)
         attrib_dict = dictionary_utils.get_dictionary_attributes(self._topology)
-        if DOMAIN_NAME in attrib_dict:
-            del attrib_dict[DOMAIN_NAME]
+
+        # skip any attributes that have special handling in create
+        for attribute in CREATE_ONLY_DOMAIN_ATTRIBUTES:
+            if attribute in attrib_dict:
+                del attrib_dict[attribute]
+
         location = LocationContext()
         attribute_path = self.alias_helper.get_wlst_attributes_path(location)
         self.wlst_helper.cd(attribute_path)

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Domain.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Domain.json
@@ -5,7 +5,7 @@
     "folders": {},
     "attributes": {
         "Active":                                          [ {"version": "[10,)",             "wlst_mode": "offline", "wlst_name": "Active",                                           "wlst_path": "WP001", "value": {"default": "false"       }, "wlst_type": "boolean", "access": "RO"  } ],
-        "AdminServerName":                                 [ {"version": "[10,)",             "wlst_mode": "both",    "wlst_name": "AdminServerName",                                  "wlst_path": "WP001", "value": {"default": "None"        }, "wlst_type": "string",  "access": "RO"} ],
+        "AdminServerName":                                 [ {"version": "[10,)",             "wlst_mode": "both",    "wlst_name": "AdminServerName",                                  "wlst_path": "WP001", "value": {"default": "AdminServer" }, "wlst_type": "string"   } ],
         "AdministrationMBeanAuditingEnabled":              [ {"version": "[10,)",             "wlst_mode": "both",    "wlst_name": "AdministrationMBeanAuditingEnabled",               "wlst_path": "WP001", "value": {"default": "false"       }, "wlst_type": "boolean"  } ],
         "AdministrationPort":                              [ {"version": "[10,)",             "wlst_mode": "both",    "wlst_name": "AdministrationPort",                               "wlst_path": "WP001", "value": {"default": 9002          }, "wlst_type": "integer"  } ],
         "AdministrationPortEnabled":                       [ {"version": "[10,)",             "wlst_mode": "both",    "wlst_name": "AdministrationPortEnabled",                        "wlst_path": "WP001", "value": {"default": "false"       }, "wlst_type": "boolean"  } ],

--- a/site/admin_server.md
+++ b/site/admin_server.md
@@ -4,11 +4,11 @@ The Create Domain Tool allows you to configure the admin server using a domain m
 
 ### Using the Default Admin Server Configuration
 
-When the Create Domain Tool is run, the templates associated with your domain type will automatically create an admin server named **AdminServer**, with default values for all the attributes. If you don't need to change any of these attributes, such as **ListenAddress** or **ListenPort**, or any of the sub-folders, such as **SSL** or **ServerStart**, nothing needs to be added to the model.
+When the Create Domain Tool is run, the templates associated with your domain type will automatically create an admin server named `AdminServer`, with default values for all the attributes. If you don't need to change any of these attributes, such as `ListenAddress` or `ListenPort`, or any of the sub-folders, such as `SSL` or `ServerStart`, nothing needs to be added to the model.
 
 ### Customizing the Admin Server Configuration
 
-To customize the configuration of the default Admin Server, you will need to add a server with the default name **AdminServer**. Since you are not changing the name of the Admin Server, there is no need to specify the **AdminServerName** attribute under the topology section. This example has some attributes and sub-folders:
+To customize the configuration of the default Admin Server, you will need to add a server with the default name `AdminServer`. Since you are not changing the name of the Admin Server, there is no need to specify the `AdminServerName` attribute under the topology section. This example has some attributes and sub-folders:
 
 ```yaml
 topology:
@@ -28,11 +28,11 @@ topology:
                 Enabled: true
 ```
 
-The most common problem with this type of configuration is to misspell the name of the folder under **Server**, when it should be **AdminServer**. This will result in the creation of an admin server with the default name, and an additional managed server with the misspelled name.
+The most common problem with this type of configuration is to misspell the name of the folder under `Server`, when it should be `AdminServer`. This will result in the creation of an admin server with the default name, and an additional managed server with the misspelled name.
 
 ### Configuring the Admin Server with a Different Name
 
-If you want the Admin Server to have a name other than the default **AdminServer**, you will need to specify that name in the **AdminServerName** attribute, and use that name in the **Server** section. This example uses the name **my-admin-server**:
+If you want the Admin Server to have a name other than the default `AdminServer`, you will need to specify that name in the `AdminServerName` attribute, and use that name in the `Server` section. This example uses the name `my-admin-server`:
 
 ```yaml
 topology:
@@ -53,6 +53,6 @@ topology:
                 Enabled: true
 ```
 
-The most common problem with this type of configuration is to mismatch the **AdminServerName** attribute with the name in the **Server** folder. This will change the name of the default Admin Server to the value of **AdminServerName**, and the folder under **Server** to be created as an additional managed server.
+The most common problem with this type of configuration is to mismatch the `AdminServerName` attribute with the name in the `Server` folder. This will change the name of the default Admin Server to the value of `AdminServerName`, and the folder under `Server` to be created as an additional managed server.
 
-For this type of configuration, the **AdminServerName** attribute is only applied with the Create Domain Tool, and is ignored by the Update Domain Tool.
+For this type of configuration, the `AdminServerName` attribute is only applied with the Create Domain Tool, and is ignored by the Update Domain Tool.

--- a/site/admin_server.md
+++ b/site/admin_server.md
@@ -1,14 +1,14 @@
-## Admin Server Configuration
+## Administration Server Configuration
 
-The Create Domain Tool allows you to configure the admin server using a domain model. These examples show how some common configurations can be represented in the model.
+The Create Domain Tool allows you to configure the Administration Server using a domain model. These examples show how some common configurations can be represented in the model.
 
-### Using the Default Admin Server Configuration
+### Using the Default Administration Server Configuration
 
-When the Create Domain Tool is run, the templates associated with your domain type will automatically create an admin server named `AdminServer`, with default values for all the attributes. If you don't need to change any of these attributes, such as `ListenAddress` or `ListenPort`, or any of the sub-folders, such as `SSL` or `ServerStart`, nothing needs to be added to the model.
+When the Create Domain Tool is run, the templates associated with your domain type will automatically create an Administration Server named `AdminServer`, with default values for all the attributes. If you don't need to change any of these attributes, such as `ListenAddress` or `ListenPort`, or any of the sub-folders, such as `SSL` or `ServerStart`, nothing needs to be added to the model.
 
-### Customizing the Admin Server Configuration
+### Customizing the Administration Server Configuration
 
-To customize the configuration of the default Admin Server, you will need to add a server with the default name `AdminServer`. Since you are not changing the name of the Admin Server, there is no need to specify the `AdminServerName` attribute under the topology section. This example has some attributes and sub-folders:
+To customize the configuration of the default Administration Server, you will need to add a server with the default name `AdminServer`. Because you are not changing the name of the Administration Server, there is no need to specify the `AdminServerName` attribute under the topology section. This example shows some attributes and sub-folders:
 
 ```yaml
 topology:
@@ -28,11 +28,11 @@ topology:
                 Enabled: true
 ```
 
-The most common problem with this type of configuration is to misspell the name of the folder under `Server`, when it should be `AdminServer`. This will result in the creation of an admin server with the default name, and an additional managed server with the misspelled name.
+The most common problem with this type of configuration is to misspell the name of the folder under `Server`, when it should be `AdminServer`. This will result in the creation of an Administration Server with the default name, and an additional managed server with the misspelled name.
 
-### Configuring the Admin Server with a Different Name
+### Configuring the Administration Server with a Different Name
 
-If you want the Admin Server to have a name other than the default `AdminServer`, you will need to specify that name in the `AdminServerName` attribute, and use that name in the `Server` section. This example uses the name `my-admin-server`:
+If you want the Administration Server to have a name other than the default `AdminServer`, you will need to specify that name in the `AdminServerName` attribute, and use that name in the `Server` section. This example uses the name `my-admin-server`:
 
 ```yaml
 topology:
@@ -53,6 +53,6 @@ topology:
                 Enabled: true
 ```
 
-The most common problem with this type of configuration is to mismatch the `AdminServerName` attribute with the name in the `Server` folder. This will change the name of the default Admin Server to the value of `AdminServerName`, and the folder under `Server` to be created as an additional managed server.
+The most common problem with this type of configuration is to mismatch the `AdminServerName` attribute with the name in the `Server` folder. This will change the name of the default Administration Server to the value of `AdminServerName`, and the folder under `Server` to be created as an additional managed server.
 
-The name of the admin server cannot be changed after domain creation, so any changes to the `AdminServerName` attribute will be ignored by the Update Domain Tool.
+The name of the Administration Server cannot be changed after domain creation, so any changes to the `AdminServerName` attribute will be ignored by the Update Domain Tool.

--- a/site/admin_server.md
+++ b/site/admin_server.md
@@ -1,0 +1,58 @@
+## Admin Server Configuration
+
+The Create Domain Tool allows you to configure the admin server using a domain model. These examples show how some common configurations can be represented in the model.
+
+### Using the Default Admin Server Configuration
+
+When the Create Domain Tool is run, the templates associated with your domain type will automatically create an admin server named **AdminServer**, with default values for all the attributes. If you don't need to change any of these attributes, such as **ListenAddress** or **ListenPort**, or any of the sub-folders, such as **SSL** or **ServerStart**, nothing needs to be added to the model.
+
+### Customizing the Admin Server Configuration
+
+To customize the configuration of the default Admin Server, you will need to add a server with the default name **AdminServer**. Since you are not changing the name of the Admin Server, there is no need to specify the **AdminServerName** attribute under the topology section. This example has some attributes and sub-folders:
+
+```yaml
+topology:
+    Server:
+        AdminServer:
+            ListenPort: 9071
+            RestartDelaySeconds: 10
+            ListenAddress: 'my-host-1'
+            Log:
+                FileCount: 9
+                LogFileSeverity: Info
+                FileMinSize: 5000
+            SSL:
+                HostnameVerificationIgnored: true
+                JSSEEnabled: true
+                ListenPort: 9072
+                Enabled: true
+```
+
+The most common problem with this type of configuration is to misspell the name of the folder under **Server**, when it should be **AdminServer**. This will result in the creation of an admin server with the default name, and an additional managed server with the misspelled name.
+
+### Configuring the Admin Server with a Different Name
+
+If you want the Admin Server to have a name other than the default **AdminServer**, you will need to specify that name in the **AdminServerName** attribute, and use that name in the **Server** section. This example uses the name **my-admin-server**:
+
+```yaml
+topology:
+    AdminServerName: 'my-admin-server'
+    Server:
+        'my-admin-server':
+            ListenPort: 9071
+            RestartDelaySeconds: 10
+            ListenAddress: 'my-host-1'
+            Log:
+                FileCount: 9
+                LogFileSeverity: Info
+                FileMinSize: 5000
+            SSL:
+                HostnameVerificationIgnored: true
+                JSSEEnabled: true
+                ListenPort: 9072
+                Enabled: true
+```
+
+The most common problem with this type of configuration is to mismatch the **AdminServerName** attribute with the name in the **Server** folder. This will cause the name of the default Admin Server to become the value of **AdminServerName**, and the folder under **Server** to be created as an additional managed server.
+
+For this type of configuration, the **AdminServerName** attribute is only applied with the Create Domain Tool, and is ignored by the Update Domain Tool.

--- a/site/admin_server.md
+++ b/site/admin_server.md
@@ -28,7 +28,7 @@ topology:
                 Enabled: true
 ```
 
-The most common problem with this type of configuration is to misspell the name of the folder under `Server`, when it should be `AdminServer`. This will result in the creation of an Administration Server with the default name, and an additional managed server with the misspelled name.
+The most common problem with this type of configuration is to misspell the name of the folder under `Server`, when it should be `AdminServer`. This will result in the creation of an Administration Server with the default name, and an additional Managed Server with the misspelled name.
 
 ### Configuring the Administration Server with a Different Name
 
@@ -53,6 +53,6 @@ topology:
                 Enabled: true
 ```
 
-The most common problem with this type of configuration is to mismatch the `AdminServerName` attribute with the name in the `Server` folder. This will change the name of the default Administration Server to the value of `AdminServerName`, and the folder under `Server` to be created as an additional managed server.
+The most common problem with this type of configuration is to mismatch the `AdminServerName` attribute with the name in the `Server` folder. This will change the name of the default Administration Server to the value of `AdminServerName`, and the folder under `Server` to be created as an additional Managed Server.
 
 The name of the Administration Server cannot be changed after domain creation, so any changes to the `AdminServerName` attribute will be ignored by the Update Domain Tool.

--- a/site/admin_server.md
+++ b/site/admin_server.md
@@ -55,4 +55,4 @@ topology:
 
 The most common problem with this type of configuration is to mismatch the `AdminServerName` attribute with the name in the `Server` folder. This will change the name of the default Admin Server to the value of `AdminServerName`, and the folder under `Server` to be created as an additional managed server.
 
-For this type of configuration, the `AdminServerName` attribute is only applied with the Create Domain Tool, and is ignored by the Update Domain Tool.
+The name of the admin server cannot be changed after domain creation, so any changes to the `AdminServerName` attribute will be ignored by the Update Domain Tool.

--- a/site/admin_server.md
+++ b/site/admin_server.md
@@ -53,6 +53,6 @@ topology:
                 Enabled: true
 ```
 
-The most common problem with this type of configuration is to mismatch the **AdminServerName** attribute with the name in the **Server** folder. This will cause the name of the default Admin Server to become the value of **AdminServerName**, and the folder under **Server** to be created as an additional managed server.
+The most common problem with this type of configuration is to mismatch the **AdminServerName** attribute with the name in the **Server** folder. This will change the name of the default Admin Server to the value of **AdminServerName**, and the folder under **Server** to be created as an additional managed server.
 
 For this type of configuration, the **AdminServerName** attribute is only applied with the Create Domain Tool, and is ignored by the Update Domain Tool.


### PR DESCRIPTION
Avoid misleading logging on create when admin server name is in model; discover admin server name.
Added a document describing admin server configuration.