### PR TITLE
Issue #359 - Support custom extension templates

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -394,7 +394,8 @@ class DomainCreator(Creator):
 
         self.logger.entering(domain_home, class_name=self.__class_name, method_name=_method_name)
         extension_templates = self._domain_typedef.get_extension_templates()
-        if len(extension_templates) == 0:
+        custom_templates = self._domain_typedef.get_custom_extension_templates()
+        if (len(extension_templates) == 0) and (len(custom_templates) == 0):
             return
 
         self.logger.info('WLSDPLY-12207', self._domain_name, domain_home,
@@ -407,6 +408,11 @@ class DomainCreator(Creator):
                              class_name=self.__class_name, method_name=_method_name)
             self.wlst_helper.add_template(extension_template)
 
+        for custom_template in custom_templates:
+            self.logger.info('WLSDPLY-12246', custom_template,
+                             class_name=self.__class_name, method_name=_method_name)
+            self.wlst_helper.add_template(custom_template)
+
         self.__configure_fmw_infra_database()
 
         if self.wls_helper.is_set_server_groups_supported():
@@ -415,6 +421,8 @@ class DomainCreator(Creator):
             self.wlst_helper.update_domain()
         elif self._domain_typedef.is_jrf_domain_type():
             self.target_helper.target_jrf_groups_to_clusters_servers(domain_home)
+        else:
+            self.wlst_helper.update_domain()
 
         self.wlst_helper.close_domain()
         self.logger.info('WLSDPLY-12209', self._domain_name,
@@ -443,6 +451,12 @@ class DomainCreator(Creator):
             self.logger.info('WLSDPLY-12211', extension_template,
                              class_name=self.__class_name, method_name=_method_name)
             self.wlst_helper.select_template(extension_template)
+
+        custom_templates = self._domain_typedef.get_custom_extension_templates()
+        for custom_template in custom_templates:
+            self.logger.info('WLSDPLY-12245', custom_template,
+                             class_name=self.__class_name, method_name=_method_name)
+            self.wlst_helper.select_custom_template(custom_template)
 
         self.logger.info('WLSDPLY-12212', class_name=self.__class_name, method_name=_method_name)
         self.wlst_helper.load_templates()

--- a/core/src/main/python/wlsdeploy/tool/create/domain_typedef.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_typedef.py
@@ -149,6 +149,15 @@ class DomainTypedef(object):
         self.__resolve_paths()
         return list(self._domain_typedef['extensionTemplates'])
 
+    def get_custom_extension_templates(self):
+        """
+        Get the list of custom extension templates to apply when create/extending the domain.
+        :return: the list of custom extension templates, or an empty list if no extension templates are needed.
+        :raises: CreateException: if an error occurs resolving the paths
+        """
+        self.__resolve_paths()
+        return list(self._domain_typedef['customExtensionTemplates'])
+
     def get_server_groups_to_target(self):
         """
         Get the list of server groups to target to the managed servers in the domain.
@@ -312,6 +321,15 @@ class DomainTypedef(object):
                 self._domain_typedef['extensionTemplates'] = resolved_templates
             else:
                 self._domain_typedef['extensionTemplates'] = []
+
+            if 'customExtensionTemplates' in self._domain_typedef:
+                extension_templates = self._domain_typedef['customExtensionTemplates']
+                resolved_templates = []
+                for extension_template in extension_templates:
+                    resolved_templates.append(self._model_context.replace_token_string(extension_template))
+                self._domain_typedef['customExtensionTemplates'] = resolved_templates
+            else:
+                self._domain_typedef['customExtensionTemplates'] = []
 
             if 'serverGroupsToTarget' not in self._domain_typedef:
                 self._domain_typedef['serverGroupsToTarget'] = []

--- a/core/src/main/python/wlsdeploy/tool/util/wlst_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/wlst_helper.py
@@ -504,6 +504,23 @@ class WlstHelper(object):
             raise ex
         return
 
+    def select_custom_template(self, template_name):
+        """
+        Select the custom template from the specified location.
+        :param template_name: the custom template to select
+        :raises: BundleAwareException of the specified type: if an error occurs
+        """
+        _method_name = 'select_custom_template'
+
+        try:
+            wlst_helper.select_custom_template(template_name)
+        except PyWLSTException, pwe:
+            ex = exception_helper.create_exception(self.__exception_type, 'WLSDPLY-19148', template_name,
+                                                   pwe.getLocalizedMessage(), error=pwe)
+            self.__logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
+            raise ex
+        return
+
     def add_template(self, template_name):
         """
         Add the domain extension template from the specified location.

--- a/core/src/main/python/wlsdeploy/util/wlst_helper.py
+++ b/core/src/main/python/wlsdeploy/util/wlst_helper.py
@@ -538,6 +538,25 @@ def select_template(template):
     _logger.exiting(class_name=_class_name, method_name=_method_name)
 
 
+def select_custom_template(template):
+    """
+    Select an existing custom domain template or application template for create a domain. This is
+    available only in WebLogic 12c versions
+    :param template: to be selected and loaded into the current session
+    :raises: PyWLSTException: if a WLST error occurs
+    """
+    _method_name = 'select_custom_template'
+    _logger.entering(template, class_name=_class_name, method_name=_method_name)
+
+    try:
+        wlst.selectCustomTemplate(template)
+    except offlineWLSTException, e:
+        pwe = exception_helper.create_pywlst_exception('WLSDPLY-00095', template, e.getLocalizedMessage(), error=e)
+        _logger.throwing(class_name=_class_name, method_name=_method_name, error=pwe)
+        raise pwe
+    _logger.exiting(class_name=_class_name, method_name=_method_name)
+
+
 def load_templates():
     """
     Load all the selected templates.

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -99,7 +99,7 @@ WLSDPLY-00091=Unable to return the list of unsaved changes for the edit session 
 WLSDPLY-00092=In the wrong state to activate saved changes for the edit session : {0}
 WLSDPLY-00093=In the wrong state to change to start an edit session : {0}
 WLSDPLY-00094=Checking the editor in online with current configuration manager failed: {0}
-
+WLSDPLY-00095=wlst.selectCustomTemplate({0}) failed : {1}
 
 
 ###############################################################################
@@ -1051,6 +1051,8 @@ WLSDPLY-12242=The assignment of servers to server groups map is {0}
 WLSDPLY-12243=Server group list found for {0} in domainInfo : {1}
 WLSDPLY-12244=Targeting JRF resources to a dynamic cluster(s), {0}, for a Restricted JRF domain type is not valid \
   when updating in online mode
+WLSDPLY-12245=Selecting custom extension template named {0}
+WLSDPLY-12246=Adding custom extension template file {0} to domain
 
 # domain_typedef.py
 WLSDPLY-12300={0} got the domain type {1} but the domain type definition file {2} was not valid: {3}
@@ -1222,6 +1224,7 @@ WLSDPLY-19144=Unable to reopen the domain session : {0}
 WLSDPLY-19145=Unable to save current changes and close the domain session : {0}
 WLSDPLY-19146=Unable to apply JRF resources to the domain : {0}
 WLSDPLY-19147=Unable to save current online changes : {0}
+WLSDPLY-19148=Failed to select custom template ({0}): {1}
 
 # wlsdeploy/tool/util/attribute_setter.py
 WLSDPLY-19200=No target found with name {0}

--- a/core/src/main/typedefs/JRF.json
+++ b/core/src/main/typedefs/JRF.json
@@ -21,6 +21,7 @@
                 "@@ORACLE_HOME@@/oracle_common/common/templates/applications/oracle.em_11_1_1_0_0_template.jar"
             ],
             "serverGroupsToTarget" : [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
+            "customExtensionTemplates": [ ],
             "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS" ]
         },
         "JRF_1212" : {
@@ -31,6 +32,7 @@
                 "@@ORACLE_HOME@@/oracle_common/common/templates/wls/oracle.wsmpm_template_12.1.2.jar",
                 "@@ORACLE_HOME@@/em/common/templates/wls/oracle.em_wls_template_12.1.2.jar"
             ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget" : [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
             "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
         },
@@ -42,6 +44,7 @@
                 "@@ORACLE_HOME@@/oracle_common/common/templates/wls/oracle.wsmpm_template_12.1.3.jar",
                 "@@ORACLE_HOME@@/em/common/templates/wls/oracle.em_wls_template_12.1.3.jar"
             ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget" : [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
             "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
         },
@@ -52,6 +55,7 @@
                 "Oracle WSM Policy Manager",
                 "Oracle Enterprise Manager"
             ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
             "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
         },
@@ -62,6 +66,7 @@
                 "Oracle WSM Policy Manager",
                 "Oracle Enterprise Manager"
             ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
             "rcuSchemas": [ "WLS", "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB"]
         },
@@ -72,6 +77,7 @@
                 "Oracle WSM Policy Manager",
                 "Oracle Enterprise Manager"
             ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
             "rcuSchemas": [ "WLS", "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB"]
         }

--- a/core/src/main/typedefs/RestrictedJRF.json
+++ b/core/src/main/typedefs/RestrictedJRF.json
@@ -12,18 +12,21 @@
         "RJRF_12CR2": {
             "baseTemplate": "Basic WebLogic Server Domain",
             "extensionTemplates": [ "Oracle Restricted JRF", "Oracle Enterprise Manager-Restricted JRF" ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSM-CACHE-SVR", "JRF-WS-CORE-MAN-SVR"],
             "rcuSchemas": [ ]
         },
         "RJRF_12213": {
             "baseTemplate": "Basic WebLogic Server Domain",
             "extensionTemplates": [ "Oracle Restricted JRF",  "Oracle Enterprise Manager-Restricted JRF" ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSM-CACHE-SVR", "JRF-WS-CORE-MAN-SVR" ],
             "rcuSchemas": [ ]
         },
         "RJRF_19CR1": {
             "baseTemplate": "Basic WebLogic Server Domain",
             "extensionTemplates": [ "Oracle Restricted JRF",  "Oracle Enterprise Manager-Restricted JRF"],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSM-CACHE-SVR", "JRF-WS-CORE-MAN-SVR" ],
             "rcuSchemas": [ ]
         }

--- a/core/src/main/typedefs/WLS.json
+++ b/core/src/main/typedefs/WLS.json
@@ -15,24 +15,28 @@
         "WLS_11G": {
             "baseTemplate": "@@WL_HOME@@/common/templates/domains/wls.jar",
             "extensionTemplates": [ ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
             "rcuSchemas": [ ]
         },
         "WLS_12CR1": {
             "baseTemplate": "@@WL_HOME@@/common/templates/wls/wls.jar",
             "extensionTemplates": [ ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
             "rcuSchemas": [ ]
         },
         "WLS_12CR2": {
             "baseTemplate": "Basic WebLogic Server Domain",
             "extensionTemplates": [ ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
             "rcuSchemas": [ ]
         },
         "WLS_19CR1": {
             "baseTemplate": "Basic WebLogic Server Domain",
             "extensionTemplates": [ ],
+            "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
             "rcuSchemas": [ ]
         }

--- a/site/create.md
+++ b/site/create.md
@@ -207,5 +207,31 @@ topology:
         NodeManagerPasswordEncrypted: welcome1
 ```
 
+The `customExtensionTemplates` attribute can be used to specify custom extension templates to be applied to the domain. These should be specified as absolute file paths, and can use tokens.  
+
+```json
+{
+    "name": "MyCustom",
+    "description": "My custom type domain definitions",
+    "versions": {
+        "12.2.1.3": "My_12213"
+    },
+    "definitions": {
+        "My_12213": {
+            "baseTemplate": "Basic WebLogic Server Domain",
+            "extensionTemplates": [ ],
+            "customExtensionTemplates": [
+                "/user/me/templates/my-template.jar",
+                "@@ORACLE_HOME@@/user_templates/other-template.jar"
+            ],
+            "serverGroupsToTarget": [ "MY-MAN-SVR" ],
+            "rcuSchemas": [ ]
+        }
+    }
+}
+```
+
+If there are any server groups in the custom template that should be targeted to managed servers, they should be specified in the `serverGroupsToTarget` attribute, similar to `MY_MAN_SVR` in the example above.
+
 One last note is that if the model or variables file contains encrypted passwords, add the `-use_encryption` flag to the command line to tell the Create Domain Tool that encryption is being used and to prompt for the encryption passphrase.  As with the database passwords, the tool can also read the passphrase from standard input (for example, `stdin`) to allow the tool to run without any user input.
 


### PR DESCRIPTION
Added customExtensionTemplates property to typedefs.
For 12c, custom extension templates are selected using selectCustomTemplate().
For 11g, they are treated the same as extension templates.
Fix to update the domain after adding templates for 11g non-JRF.
Fixes #359