### PR TITLE
Issue #294 - Fixed directory problems for Cluster / DatabaseLessLeasi…

### DIFF
--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Cluster.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Cluster.json
@@ -53,7 +53,8 @@
         "DatabaseLessLeasingBasis" : {
             "wlst_type": "DatabaseLessLeasingBasis",
             "version": "[10.3.6,)",
-            "child_folders_type": "single",
+            "child_folders_type": "single_unpredictable",
+            "default_name_value": "${NO_NAME_0:%CLUSTER%}",
             "folders": {},
             "attributes" : {
                 "FenceTimeout":             [ {"version": "[10.3.6,)", "wlst_mode": "both",   "wlst_name": "FenceTimeout",                   "wlst_path": "WP001", "value": {"default": 5       }, "wlst_type": "integer", "get_method": "${LSA:GET}" } ],
@@ -66,7 +67,7 @@
             },
             "wlst_attributes_path": "WP001",
             "wlst_paths": {
-                "WP001": "/Cluster${:s}/%CLUSTER%/DatabaseLessLeasingBasis/${NO_NAME_0:%CLUSTER%}"
+                "WP001": "/Cluster${:s}/%CLUSTER%/${(DatabaseLessLeasingBasis):DatabaseLessLeasingBasis}/%DATABASELESSLEASINGBASIS%"
             }
         },
         "JTACluster" : {

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Cluster.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Cluster.json
@@ -1,5 +1,5 @@
 {
-    "copyright": "Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.",
+    "copyright": "Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.",
     "license": "The Universal Permissive License (UPL), Version 1.0",
     "wlst_type": "Cluster${:s}",
     "child_folders_type": "multiple",


### PR DESCRIPTION
Fixed directory problems for Cluster / DatabaseLessLeasingBasis.
Use parentheses around directory name for all offline, not for online.
Use single-unpredictable behavior, since MBean is given a name in offline.
Tested with 10.3.6, 12.1.2, 12.1.3, 12.2.1, 12.2.1.2, 12.2.1.3 online and offline with create, update, discover.
Fixes #294
