### PR TITLE
allow WLST directory property to be set in the environment

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,6 @@
     </parent>
 
     <properties>
-        <unit-test-wlst-dir>SET_VALUE_WITH_DASH_D_OR_SETTINGS_PROFILE</unit-test-wlst-dir>
         <!--
             Hack to get around Maven bug so that we can inject the build timestamp into the version class
          -->

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <sonar.java.source>7</sonar.java.source>
         <sonar.exclusions>.flattened-pom.xml,target/**</sonar.exclusions>
         <sonar.test.exclusions>src/test/**</sonar.test.exclusions>
+        <unit-test-wlst-dir>${env.WLST_DIR}</unit-test-wlst-dir>
     </properties>
 
     <modules>


### PR DESCRIPTION
The -D will continue to work.  But, this will allow the value to be set as an ENV variable (WLST_DIR), also.  This change will make it a little easier to deal with in Docker containers.