### PR TITLE
Issue #434 - Use separate rules for application version naming

### DIFF
--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -987,7 +987,9 @@ WLSDPLY-09324=Shared library {0} name has been updated to {1} to match the \
   implementation version in the MANIFEST.MF file
 WLSDPLY-09325=Failed to compute name for shared library {0} from archive at {1}: {2}
 WLSDPLY-09326=Deployment order is {0}
-WLSDPLY-09327=Failed to stop application (0): {1}
+WLSDPLY-09327=Failed to stop application {0}: {1}
+WLSDPLY-09328=Application {0} name has been updated to {1} to match the application version in the MANIFEST.MF file
+WLSDPLY-09329=Failed to compute name for application {0} from archive at {1}: {2}
 
 
 # wlsdeploy/tool/deploy/common_resources_deployer.py


### PR DESCRIPTION
The application name should match the model, and be appended with the version number when the "Weblogic-Application-Version" attribute is set in the ear/war manifest.

The rules for deployed libraries should remain as they are, but should not consider "Weblogic-Application-Version".

Fixed syntax error in message WLSDPLY-09327 .

Fixes #434 