### PR TITLE
Skip RCUDBInfo processing if the domain type is not JRF

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -246,6 +246,7 @@ class DomainCreator(Creator):
         java_home = self.model_context.get_java_home()
 
         if RCU_DB_INFO in self.model.get_model_domain_info():
+
             rcu_properties_map = self.model.get_model_domain_info()[RCU_DB_INFO]
             rcu_db_info = RcuDbInfo(self.alias_helper, rcu_properties_map)
 
@@ -806,6 +807,10 @@ class DomainCreator(Creator):
         """
         _method_name = '__configure_fmw_infra_database'
         self.logger.entering(class_name=self.__class_name, method_name=_method_name)
+
+        if not self._domain_typedef.is_jrf_domain_type():
+            self.logger.warning('WLSDPLY-12249')
+            return
 
         has_atp = 0
         # For ATP databases :  we need to set all the property for each datasource

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1133,6 +1133,7 @@ WLSDPLY-12246=Adding custom extension template file {0} to domain
 WLSDPLY-12247=WebLogic does not support targeting resources to dynamic servers. JRF product related resources \
   will be targeted to the dynamic cluster using the applyJRF function.
 WLSDPLY-12248=The server group(s) {0} will not be targeted to the Admin server or a configured manage server
+WLSDPLY-12249=RCUDBInfo section is specified in the model but the domain type used is not JRF, RCU processing skipped
 
 # domain_typedef.py
 WLSDPLY-12300={0} got the domain type {1} but the domain type definition file {2} was not valid: {3}


### PR DESCRIPTION
This prevent error out when a model with RCUDbinfo is used when creating non-jrf domain.  A warning will be printed instead.