### PR TITLE
fix for domain discover issue found in 10.3.6 but not 12.2.1.3

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
@@ -4,8 +4,6 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 """
 import os
 
-import java.lang.Exception as JException
-
 from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.discover import DiscoverException
 from oracle.weblogic.deploy.util import PyOrderedDict as OrderedDict

--- a/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
@@ -4,6 +4,8 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 """
 import os
 
+import java.lang.Exception as JException
+
 from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.discover import DiscoverException
 from oracle.weblogic.deploy.util import PyOrderedDict as OrderedDict
@@ -612,7 +614,7 @@ class Discoverer(object):
         _method_name = '_find_mbean_interface'
         mbean_name = None
         for interface in interfaces:
-            interface_name = str(interface.getTypeName())
+            interface_name = get_interface_name(interface)
             if 'MBean' in interface_name:
                 _logger.finer('WLSDPLY-06126', interface_name, self._alias_helper.get_model_folder_path(location),
                               class_name=_class_name, method_name=_method_name)
@@ -725,6 +727,15 @@ def _massage_online_folders(lsc_folders):
         _logger.fine('WLSDPLY-06145', folder_list, location, mbi_folder_list, class_name=_class_name,
                      method_name=_method_name)
     return folder_list
+
+
+def get_interface_name(mbean_interface):
+    try:
+        getname = getattr(mbean_interface, 'getTypeName')
+        result = getname()
+    except (Exception, JException):
+        result = str(mbean_interface)
+    return result
 
 
 def get_discover_logger_name():

--- a/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
@@ -20,6 +20,7 @@ from wlsdeploy.exception.expection_types import ExceptionType
 from wlsdeploy.logging.platform_logger import PlatformLogger
 
 from wlsdeploy.tool.util.mbean_utils import MBeanUtils
+from wlsdeploy.tool.util.mbean_utils import get_interface_name
 from wlsdeploy.tool.discover.custom_folder_helper import CustomFolderHelper
 from wlsdeploy.tool.util.alias_helper import AliasHelper
 from wlsdeploy.tool.util.wlst_helper import WlstHelper
@@ -727,15 +728,6 @@ def _massage_online_folders(lsc_folders):
         _logger.fine('WLSDPLY-06145', folder_list, location, mbi_folder_list, class_name=_class_name,
                      method_name=_method_name)
     return folder_list
-
-
-def get_interface_name(mbean_interface):
-    try:
-        getname = getattr(mbean_interface, 'getTypeName')
-        result = getname()
-    except (Exception, JException):
-        result = str(mbean_interface)
-    return result
 
 
 def get_discover_logger_name():

--- a/core/src/main/python/wlsdeploy/tool/util/mbean_utils.py
+++ b/core/src/main/python/wlsdeploy/tool/util/mbean_utils.py
@@ -403,7 +403,7 @@ class MBeanAttributes(object):
                                  class_name=self.__class__.__name__, method_name=_method_name)
                 self.__mbean_interface = interfaces[0]
                 self.__mbean_name = str(self.__mbean_interface.getSimpleName())
-                self.__mbean_interface_name = str(self.__mbean_interface.getTypeName())
+                self.__mbean_interface_name = get_interface_name(self._get_mbean_interface())
             _logger.exiting(class_name=self.__class__.__name__, method_name=_method_name,
                             result=self.__mbean_interface_name)
 
@@ -457,6 +457,15 @@ class MBeanAttributes(object):
 
     def _get_mbean_path(self):
         return self.__location.get_folder_path()
+
+
+def get_interface_name(mbean_interface):
+    try:
+        getname = getattr(mbean_interface, 'getTypeName')
+        result = getname()
+    except (Exception, JException):
+        result = str(mbean_interface)
+    return result
 
 
 def _is_empty(value):


### PR DESCRIPTION
14.1.1 version of jython does not create strings for instances the same as in the early version of jython. The change made to handle all versions worked for 14.1.1.0.0 and 12.2.1.3.0 but broke in 10.3.6. Made a fix to handle for all versions.