### PR TITLE
Add the domain name and domainInfo admin credentials automatically in…

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/discover/domain_info_discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/domain_info_discoverer.py
@@ -10,6 +10,7 @@ from java.io import File
 from oracle.weblogic.deploy.util import WLSDeployArchiveIOException
 from oracle.weblogic.deploy.util import FileUtils
 
+from wlsdeploy.aliases import alias_constants
 from wlsdeploy.aliases import model_constants
 from wlsdeploy.aliases.wlst_modes import WlstModes
 from wlsdeploy.exception import exception_helper
@@ -40,12 +41,17 @@ class DomainInfoDiscoverer(Discoverer):
         """
         _method_name = 'discover'
         _logger.entering(class_name=_class_name, method_name=_method_name)
+        self.add_admin_credentials()
         model_top_folder_name, result = self.get_domain_libs()
         discoverer.add_to_model_if_not_empty(self._dictionary, model_top_folder_name, result)
         model_top_folder_name, result = self.get_user_env_scripts()
         discoverer.add_to_model_if_not_empty(self._dictionary, model_top_folder_name, result)
         _logger.exiting(class_name=_class_name, method_name=_method_name)
         return self._dictionary
+
+    def add_admin_credentials(self):
+        self._dictionary[model_constants.ADMIN_USERNAME] = alias_constants.PASSWORD_TOKEN
+        self._dictionary[model_constants.ADMIN_PASSWORD] = alias_constants.PASSWORD_TOKEN
 
     def get_domain_libs(self):
         """

--- a/core/src/main/python/wlsdeploy/tool/discover/topology_discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/topology_discoverer.py
@@ -256,7 +256,13 @@ class TopologyDiscoverer(Discoverer):
         """
         _method_name = 'discover_domain_parameters'
         _logger.entering(class_name=_class_name, method_name=_method_name)
+        domain_home = '/'
         location = LocationContext(self._base_location)
+        # This is temporary until a do not ignore is created for DomainName
+        success, wlst_value = self._get_attribute_value_with_get(model_constants.DOMAIN_NAME, domain_home)
+        if success and wlst_value:
+            self._dictionary[model_constants.DOMAIN_NAME] = wlst_value
+
         self._populate_model_parameters(self._dictionary, location)
 
         model_folder_name, folder_result = self._get_admin_console()


### PR DESCRIPTION
The discover tool will now add the admin credentials and the domain name to the persisted model. Have attached an example.
[domain-info.txt](https://github.com/oracle/weblogic-deploy-tooling/files/3779686/domain-info.txt)

