### PR TITLE
Issue #484 - Use of model encryption with online update fails

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/aliases.py
+++ b/core/src/main/python/wlsdeploy/aliases/aliases.py
@@ -397,13 +397,7 @@ class Aliases(object):
         attribute_info = module_folder[ATTRIBUTES][model_attribute_name]
 
         if attribute_info and not self.__is_model_attribute_read_only(location, attribute_info):
-            password_attribute_name = \
-                password_utils.get_wlst_attribute_name(attribute_info, model_attribute_value, self._wlst_mode)
-
-            if password_attribute_name is not None:
-                wlst_attribute_name = password_attribute_name
-            else:
-                wlst_attribute_name = attribute_info[WLST_NAME]
+            wlst_attribute_name = attribute_info[WLST_NAME]
 
             if self._model_context and USES_PATH_TOKENS in attribute_info and \
                     string_utils.to_boolean(attribute_info[USES_PATH_TOKENS]):
@@ -413,6 +407,14 @@ class Aliases(object):
             if data_type == 'password':
                 try:
                     wlst_attribute_value = self.decrypt_password(model_attribute_value)
+
+                    # the attribute name may change for special cases, check against decrypted value
+                    password_attribute_name = \
+                        password_utils.get_wlst_attribute_name(attribute_info, wlst_attribute_value, self._wlst_mode)
+
+                    if password_attribute_name is not None:
+                        wlst_attribute_name = password_attribute_name
+
                 except EncryptionException, ee:
                     ex = exception_helper.create_alias_exception('WLSDPLY-08402', model_attribute_name,
                                                                  location.get_folder_path(),
@@ -1200,7 +1202,7 @@ class Aliases(object):
 
     def decrypt_password(self, text):
         """
-        Encrypt the specified password if encryption is used and the password is encrypted.
+        Decrypt the specified password if model encryption is used and the password is encrypted.
         :param text: the text to check and decrypt, if needed
         :return: the clear text
         :raises EncryptionException: if an error occurs while decrypting the password

--- a/core/src/test/python/alias_encrypted_model_test.py
+++ b/core/src/test/python/alias_encrypted_model_test.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import unittest
@@ -12,12 +12,13 @@ from wlsdeploy.aliases.model_constants import JDBC_SYSTEM_RESOURCE
 from wlsdeploy.aliases.model_constants import PASSWORD_ENCRYPTED
 from wlsdeploy.aliases.wlst_modes import WlstModes
 from wlsdeploy.logging.platform_logger import PlatformLogger
+from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.model_context import ModelContext
 
 
-class AliasPasswordTestCase(unittest.TestCase):
+class AliasEncryptedModelTestCase(unittest.TestCase):
     """
-    Test domain-encrypted passwords in a model.
+    Test cases for a the -use_encryption feature.
     """
 
     _logger = PlatformLogger('wlsdeploy.aliases')
@@ -25,11 +26,14 @@ class AliasPasswordTestCase(unittest.TestCase):
     _wlst_password_name = "Password"
     _wlst_password_encrypted_name = "PasswordEncrypted"
 
+    _passphrase = 'RE a drop of golden sun'
     _password = 'welcome1'
     _encrypted_password = '{AES}UC9rZld3blZFUnMraW12cHkydmtmdmpSZmNNMWVHajA6VERPYlJoeWxXU09IaHVrQzpBeWsrd2ZacVkyVT0='
 
     def setUp(self):
-        model_context = ModelContext("test", {})
+        # construct aliases as if the -use_encryption and -passphrase switches were used
+        model_context = ModelContext("test", {CommandLineArgUtil.USE_ENCRYPTION_SWITCH: 'true',
+                                              CommandLineArgUtil.PASSPHRASE_SWITCH: self._passphrase})
         self.aliases = Aliases(model_context, wlst_mode=WlstModes.OFFLINE, wls_version=self._wls_version)
         self.online_aliases = Aliases(model_context, wlst_mode=WlstModes.ONLINE, wls_version=self._wls_version)
 
@@ -39,57 +43,35 @@ class AliasPasswordTestCase(unittest.TestCase):
         self.location.append_location(JDBC_RESOURCE)
         self.location.append_location(JDBC_DRIVER_PARAMS)
 
-    def testOfflineModelNames(self):
-        # Using offline WLST, only PasswordEncrypted is an attribute, and its value is encrypted.
-        # The model name should be PasswordEncrypted.
-        model_name, model_value = \
-            self.aliases.get_model_attribute_name_and_value(self.location, self._wlst_password_encrypted_name,
-                                                            self._encrypted_password)
-        self.assertEquals(model_name, PASSWORD_ENCRYPTED)
-
-    def testOnlineModelNames(self):
-        # Using online WLST, both Password and PasswordEncrypted are WLST attributes.
-
-        # The PasswordEncrypted WLST attribute should translate to the PasswordEncrypted model attribute.
-        model_name, model_value = \
-            self.online_aliases.get_model_attribute_name_and_value(self.location, self._wlst_password_encrypted_name,
-                                                                   self._encrypted_password)
-        self.assertEqual(model_name, PASSWORD_ENCRYPTED)
-
-        # The Password WLST attribute should be skipped, since its value cannot be retrieved.
-        # This is accomplished by returning a model name of None.
-        model_name, model_value = \
-            self.online_aliases.get_model_attribute_name_and_value(self.location, self._wlst_password_name,
-                                                                   self._encrypted_password)
-        self.assertEquals(model_name, None)
-
     def testOfflineWlstNames(self):
         # Using offline WLST, the PasswordEncrypted model attribute should translate to the PasswordEncrypted WLST
-        # attribute, regardless of whether the password is encrypted.
+        # attribute, regardless of whether the password is encrypted. The password value should be plain text.
 
         # using encrypted password
         wlst_name, wlst_value = \
             self.aliases.get_wlst_attribute_name_and_value(self.location, PASSWORD_ENCRYPTED, self._encrypted_password)
         self.assertEqual(wlst_name, self._wlst_password_encrypted_name)
-        self.assertEqual(wlst_value, self._encrypted_password)
+        self.assertEqual(wlst_value, self._password)
 
         # using unencrypted password
         wlst_name, wlst_value = \
             self.aliases.get_wlst_attribute_name_and_value(self.location, PASSWORD_ENCRYPTED, self._password)
         self.assertEquals(wlst_name, self._wlst_password_encrypted_name)
+        self.assertEqual(wlst_value, self._password)
 
     def testOnlineWlstNames(self):
-        # Using online WLST, the PasswordEncrypted model attribute should translate to the PasswordEncrypted WLST
-        # attribute if the password is encrypted, otherwise to Password.
+        # Using online WLST, the PasswordEncrypted model attribute should always translate to the Password WLST
+        # attribute, and the value should translate to the unencrypted value.
 
         # using encrypted password
         wlst_name, wlst_value = \
             self.online_aliases.get_wlst_attribute_name_and_value(self.location, PASSWORD_ENCRYPTED,
                                                                   self._encrypted_password)
-        self.assertEqual(wlst_name, self._wlst_password_encrypted_name)
-        self.assertEqual(wlst_value, self._encrypted_password)
+        self.assertEqual(wlst_name, self._wlst_password_name)
+        self.assertEqual(wlst_value, self._password)
 
         # using unencrypted password
         wlst_name, wlst_value = \
             self.online_aliases.get_wlst_attribute_name_and_value(self.location, PASSWORD_ENCRYPTED, self._password)
         self.assertEquals(wlst_name, self._wlst_password_name)
+        self.assertEqual(wlst_value, self._password)

--- a/site/encrypt.md
+++ b/site/encrypt.md
@@ -4,6 +4,8 @@
 
 Models contain WebLogic Server domain configuration.  Certain types of resources and other configurations require passwords; for example, a JDBC data source requires the password for the user establishing the database connection.  When creating or configuring a resource that requires a password, that password must be specified either in the model directly or in the variable file.  Clear-text passwords are not conducive to storing configurations as source, so the Encrypt Model Tool gives the model author the ability to encrypt the passwords in the model and variable file using passphrase-based, reversible encryption.  When using a tool with a model containing encrypted passwords, the encryption passphrase must be provided, so that the tool can decrypt the password in memory to set the necessary WebLogic Server configuration (which supports its own encryption mechanism based on a domain-specific key).  While there is no requirement to use the Oracle WebLogic Server Deploy Tooling encryption mechanism, it is highly recommended because storing clear text passwords on disk is never a good idea.
 
+**NOTE: WebLogic Server Deploy Tooling also supports the use of domain-encrypted passwords directly in the model. The Encrypt Model Tool should not be used in tandem with this method.**  
+
 Start with the following example model:
 
 ```yaml


### PR DESCRIPTION
Use the model-decrypted value of password attributes to determine if the WLST attribute name should change.

Document that encryptModel should not be used in tandem with domain-encrypted model passwords.

Separated unit tests for password attributes and model encryption.

Fixes #484 
