### PR TITLE
Issue #486 - Allow identifiers to begin with a digit, allowed by WLS

### DIFF
--- a/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
+++ b/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
@@ -275,6 +275,7 @@ fragment ID_START
     : [_]
     | [A-Z]
     | [a-z]
+    | [0-9]
     | '!'
     ;
 


### PR DESCRIPTION
Fixes #486 