### PR TITLE
WDT#479 sort variable file and remove old debug prints

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/util/variable_injector.py
+++ b/core/src/main/python/wlsdeploy/tool/util/variable_injector.py
@@ -894,10 +894,7 @@ def sort_dictionary_by_keys(dictionary):
     sorted_props = dictionary.keys()
     sorted_props.sort()
     for prop in sorted_props:
-        print '******* what is the order ? ', prop
         sorted_dict[prop] = dictionary[prop]
-    for key, value in sorted_dict.iteritems():
-        print key, '=', value
     return sorted_dict
 
 


### PR DESCRIPTION
If the variable map is in a PyOrderedDict instance, print to file insuring order

Remove old debug prints left behind from previous PR