### PR TITLE
Issue#503 add java home global token

### DIFF
--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 The entry point for the discoverDomain tool.

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -69,6 +69,7 @@ __optional_arguments = [
     # Used by shell script to locate WLST
     CommandLineArgUtil.MODEL_FILE_SWITCH,
     CommandLineArgUtil.DOMAIN_TYPE_SWITCH,
+    CommandLineArgUtil.JAVA_HOME_SWITCH,
     CommandLineArgUtil.VARIABLE_FILE_SWITCH,
     CommandLineArgUtil.ADMIN_URL_SWITCH,
     CommandLineArgUtil.ADMIN_USER_SWITCH,
@@ -92,6 +93,7 @@ def __process_args(args):
     __wlst_mode = __process_online_args(optional_arg_map)
     __process_archive_filename_arg(required_arg_map)
     __process_variable_filename_arg(optional_arg_map)
+    __process_java_home(optional_arg_map)
 
     combined_arg_map = optional_arg_map.copy()
     combined_arg_map.update(required_arg_map)
@@ -197,6 +199,22 @@ def __process_variable_filename_arg(optional_arg_map):
             raise ex
     return
 
+
+def __process_java_home(optional_arg_map):
+    _method_name = '__process_java_home'
+    if CommandLineArgUtil.JAVA_HOME_SWITCH in optional_arg_map:
+        java_home_name = optional_arg_map[CommandLineArgUtil.JAVA_HOME_SWITCH]
+    else:
+        java_home_name = os.environ.get('JAVA_HOME')
+
+    try:
+        FileUtils.validateExistingDirectory(java_home_name)
+    except IllegalArgumentException, iae:
+        # this value is used for java home global token in attributes.
+        # If this was passed as command line, it might no longer exist.
+        # The JAVA_HOME environment variable was validated by script.
+        __logger.info('WLSDPLY-06027', java_home_name, iae.getLocalizedMessage(),
+                      class_name=_class_name, method_name=_method_name)
 
 def __discover(model_context, aliases, injector):
     """

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -23,6 +23,7 @@ class ModelContext(object):
     __ORACLE_HOME_TOKEN = '@@ORACLE_HOME@@'
     __WL_HOME_TOKEN = '@@WL_HOME@@'
     __DOMAIN_HOME_TOKEN = '@@DOMAIN_HOME@@'
+    __JAVA_HOME_TOKEN = '@@JAVA_HOME@@'
     __CURRENT_DIRECTORY_TOKEN = '@@PWD@@'
     __TEMP_DIRECTORY_TOKEN = '@@TMP@@'
 
@@ -501,10 +502,11 @@ class ModelContext(object):
         :return: true if the path begins with a known prefix, false otherwise
         """
         return path.startswith(self.__ORACLE_HOME_TOKEN) or \
-               path.startswith(self.__WL_HOME_TOKEN) or \
-               path.startswith(self.__DOMAIN_HOME_TOKEN) or \
-               path.startswith(self.__CURRENT_DIRECTORY_TOKEN) or \
-               path.startswith(self.__TEMP_DIRECTORY_TOKEN)
+            path.startswith(self.__WL_HOME_TOKEN) or \
+            path.startswith(self.__DOMAIN_HOME_TOKEN) or \
+            path.startswith(self.__JAVA_HOME_TOKEN) or \
+            path.startswith(self.__CURRENT_DIRECTORY_TOKEN) or \
+            path.startswith(self.__TEMP_DIRECTORY_TOKEN)
 
     def replace_tokens(self, resource_type, resource_name, attribute_name, resource_dict):
         """
@@ -532,6 +534,12 @@ class ModelContext(object):
                               self.get_domain_home(), class_name=self._class_name, method_name='_replace_tokens')
             resource_dict[attribute_name] = attribute_value.replace(self.__DOMAIN_HOME_TOKEN,
                                                                     self.get_domain_home())
+        elif attribute_value.startswith(self.__JAVA_HOME_TOKEN):
+            message = "Replacing {0} in {1} {2} {3} with {4}"
+            self._logger.fine(message, self.__JAVA_HOME_TOKEN, resource_type, resource_name, attribute_name,
+                              self.get_domain_home(), class_name=self._class_name, method_name='_replace_tokens')
+            resource_dict[attribute_name] = attribute_value.replace(self.__JAVA_HOME_TOKEN,
+                                                                    self.get_java_home())
         elif attribute_value.startswith(self.__CURRENT_DIRECTORY_TOKEN):
             cwd = path_utils.fixup_path(os.getcwd())
             message = "Replacing {0} in {1} {2} {3} with {4}"
@@ -561,6 +569,8 @@ class ModelContext(object):
             result = _replace(string_value, self.__WL_HOME_TOKEN, self.get_wl_home())
         elif string_value.startswith(self.__DOMAIN_HOME_TOKEN):
             result = _replace(string_value, self.__DOMAIN_HOME_TOKEN, self.get_domain_home())
+        elif string_value.startswith(self.__JAVA_HOME_TOKEN):
+            result = _replace(string_value, self.__JAVA_HOME_TOKEN, self.get_java_home())
         elif string_value.startswith(self.__CURRENT_DIRECTORY_TOKEN):
             result = _replace(string_value, self.__CURRENT_DIRECTORY_TOKEN, path_utils.fixup_path(os.getcwd()))
         elif string_value.startswith(self.__TEMP_DIRECTORY_TOKEN):
@@ -582,6 +592,7 @@ class ModelContext(object):
         wl_home = path_utils.fixup_path(self.get_wl_home())
         domain_home = path_utils.fixup_path(self.get_domain_home())
         oracle_home = path_utils.fixup_path(self.get_oracle_home())
+        java_home = path_utils.fixup_path(self.get_java_home())
         tmp_dir = path_utils.fixup_path(tempfile.gettempdir())
         cwd = path_utils.fixup_path(os.path.dirname(os.path.abspath(__file__)))
 
@@ -594,6 +605,8 @@ class ModelContext(object):
                 result = my_path.replace(domain_home, self.__DOMAIN_HOME_TOKEN)
             elif oracle_home is not None and my_path.startswith(oracle_home):
                 result = my_path.replace(oracle_home, self.__ORACLE_HOME_TOKEN)
+            elif java_home is not None and my_path.startswith(java_home):
+                result = my_path.replace(java_home, self.__JAVA_HOME_TOKEN)
             elif my_path.startswith(cwd):
                 result = my_path.replace(cwd, self.__CURRENT_DIRECTORY_TOKEN)
             elif my_path.startswith(tmp_dir):

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -476,6 +476,7 @@ WLSDPLY-06024=No variable file provided. Model passwords will contain the token 
 WLSDPLY-06025=Variable file was provided. Model password attributes will be replaced with tokens and corresponding \
   values put into the variable file.
 WLSDPLY-06026=Target directory for archive file argument {0} does not exist
+WLSDPLY-06027=JAVA_HOME {0} is not a valid location: {1}
 
 # discoverer.py
 WLSDPLY-06100=Find attributes at location {0}

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 # The Universal Permissive License (UPL), Version 1.0
 #
 #

--- a/installer/src/main/bin/discoverDomain.cmd
+++ b/installer/src/main/bin/discoverDomain.cmd
@@ -63,6 +63,11 @@
 @rem                           For example, for SOA 12.1.3, -wlst_path should be
 @rem                           specified as %ORACLE_HOME%\soa
 @rem
+@rem     - -java_home          The path to the Java Home directory used for the
+@rem                           Oracle Home. This overrides the JAVA_HOME environment variable
+@rem                           when discovering attributes with a java home. Any attribute with this
+@rem                           value will be replaced with a java home global token in the model.
+@rem
 @rem This script uses the following variables:
 @rem
 @rem JAVA_HOME            - The location of the JDK to use.  The caller must set
@@ -169,7 +174,6 @@ IF "%~1" == "" (
 SET ORACLE_HOME=
 SET DOMAIN_TYPE=
 SET WLST_PATH_DIR=
-
 :arg_loop
 IF "%1" == "-help" (
   SET RETURN_CODE=0
@@ -190,7 +194,7 @@ IF "%1" == "-wlst_path" (
   SHIFT
   GOTO arg_continue
 )
-@REM If none of the above, unknown argument so skip it
+@REM If none of the above, a general argument so skip collecting it
 :arg_continue
 SHIFT
 IF NOT "%~1" == "" (
@@ -341,6 +345,7 @@ ECHO              [-model_file ^<model_file^>]
 ECHO              [-variable_file ^<variable_file^>]
 ECHO              [-domain_type ^<domain_type^>]
 ECHO              [-wlst_path ^<wlst_path^>]
+ECHO              [-java_home ^<java_home^>]
 ECHO              [-admin_url ^<admin_url^>
 ECHO               -admin_user ^<admin_user^>
 ECHO              ]
@@ -365,6 +370,9 @@ ECHO                          used to locate wlst.cmd if -wlst_path not specifie
 ECHO.
 ECHO         wlst_path      - the Oracle Home subdirectory of the wlst.cmd
 ECHO                          script to use (e.g., ^<ORACLE_HOME^>\soa)
+ECHO.
+ECHO         java_home      - overrides the JAVA_HOME value when discovering
+ECHO                          domain values to be replaced with the java home global token
 ECHO.
 ECHO         admin_url      - the admin server URL (used for online discovery)
 ECHO.

--- a/installer/src/main/bin/discoverDomain.cmd
+++ b/installer/src/main/bin/discoverDomain.cmd
@@ -2,7 +2,7 @@
 @rem **************************************************************************
 @rem discoverDomain.cmd
 @rem
-@rem Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+@rem Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 @rem Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 @rem
 @rem     NAME

--- a/installer/src/main/bin/discoverDomain.sh
+++ b/installer/src/main/bin/discoverDomain.sh
@@ -63,10 +63,15 @@
 #                         For example, for SOA 12.1.3, -wlst_path should be
 #                         specified as $ORACLE_HOME/soa
 #
+#     -wlst_path          The path to the Oracle Home product directory under
+#                         which to find the wlst script.  This is only
+#                         needed for pre-12.2.1 upper stack products like SOA.
+#
 # This script uses the following variables:
 #
-# JAVA_HOME             - The location of the JDK to use.  The caller must set
-#                         this variable to a valid Java 7 (or later) JDK.
+# JAVA_HOME             - The path to the Java Home directory used by the ORACLE HOME.
+#                         This overrides the JAVA_HOME value when locating attributes
+#                         which will be replaced with the java home global token in the model
 #
 # WLSDEPLOY_HOME        - The location of the WLS Deploy installation.
 #                         If the caller sets this, the callers location will be
@@ -89,6 +94,7 @@ usage() {
   echo "          [-variable_file <variable_file>]"
   echo "          [-domain_type <domain_type>]"
   echo "          [-wlst_path <wlst_path>]"
+  echo "          [-java_home <java_home>]"
   echo "          [-admin_url <admin_url>"
   echo "           -admin_user <admin_user>"
   echo "          ]"
@@ -114,6 +120,9 @@ usage() {
   echo ""
   echo "        wlst_path       - the Oracle Home subdirectory of the wlst.cmd"
   echo "                          script to use (e.g., <ORACLE_HOME>/soa)"
+  echo ""
+  echo "        java_home       - overrides the JAVA_HOME value when discovering"
+  echo "                          domain values to be replaced with the java home global token"
   echo ""
   echo "        admin_url       - the admin server URL (used for online deploy)"
   echo ""

--- a/installer/src/main/bin/discoverDomain.sh
+++ b/installer/src/main/bin/discoverDomain.sh
@@ -2,7 +2,7 @@
 # *****************************************************************************
 # discoverDomain.sh
 #
-# Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 #     NAME


### PR DESCRIPTION
Fix #503 

Add java home global token for ease of use when discovering attributes in the model that contain java home values.

Add -java_home argument to use a directory different than the one in JAVA_HOME when discovering such attributes (an oracle home domain with different java home)