### PR TITLE
Jira WDT-385 Enable exploded app in archive

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/util/WLSDeployArchive.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/WLSDeployArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.util;
@@ -377,6 +377,24 @@ public class WLSDeployArchive {
      */
     public String extractFile(String path, File extractToLocation) throws WLSDeployArchiveIOException {
         return extractFile(path, extractToLocation, false);
+    }
+
+    /**
+     * Extract the specified directory to the specified location (which is typically the domain home).  For example,
+     * if the path is wlsdeploy/applications/myapp and the extractToLocation is the domain home, the directory
+     * will be written to $DOMAIN_HOME/wlsdeploy/applications/myapp .
+     *
+     * @param path              the path into the archive file to extract
+     * @param extractToLocation the base directory to which to write the extracted directory.
+     * @return the canonical extracted directory name
+     * @throws WLSDeployArchiveIOException if an error occurs reading the archive or writing the directory
+     * @throws IllegalArgumentException    if the path is null or empty or the extractToLocation
+     *                                     was not a valid, existing directory
+     */
+    public String extractDirectory(String path, File extractToLocation) throws WLSDeployArchiveIOException {
+        String result = FileUtils.getCanonicalFile(new File(extractToLocation, path)).getAbsolutePath();
+        this.extractDirectoryFromZip(path, extractToLocation);
+        return result;
     }
 
     /**

--- a/core/src/main/python/wlsdeploy/tool/deploy/deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/deployer.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os
@@ -385,6 +385,9 @@ class Deployer(object):
                         # The file does not exist so extract it from the archive.
                         self.archive_helper.extract_file(value)
                         result = True
+        elif self.archive_helper.contains_path(value):
+            # contents should have been extracted elsewhere, such as for apps and shared libraries
+            result = self.__process_directory_entry(fullpath)
         elif value.endswith('/'):
             # If the path is a directory in the wlsdeploy directory tree
             # but not in the archive, just create it to help the user.

--- a/core/src/main/python/wlsdeploy/tool/util/archive_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/archive_helper.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 from java.io import File
@@ -198,6 +198,32 @@ class ArchiveHelper(object):
             else:
                 extract_location = FileUtils.getCanonicalFile(File(location))
                 result = archive_file.extractFile(path, extract_location, True)
+        except (IllegalArgumentException, WLSDeployArchiveIOException), e:
+            ex = exception_helper.create_exception(self.__exception_type, "WLSDPLY-19303", path,
+                                                   self.__archive_files_text, e.getLocalizedMessage(), error=e)
+            self.__logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
+            raise ex
+        self.__logger.exiting(class_name=self.__class_name, method_name=_method_name, result=result)
+        return result
+
+    def extract_directory(self, path, location=None):
+        """
+        Extract the specified directory from the archive into the specified directory, or into Domain Home.
+        :param path: the path into the archive
+        :param location: the location to which to extract the directory
+        :return: path to the extracted directory
+        :raises: BundleAwareException of the appropriate type: if an error occurs
+        """
+        _method_name = 'extract_directory'
+        self.__logger.entering(path, class_name=self.__class_name, method_name=_method_name)
+
+        try:
+            archive_file = self._find_archive_for_path(path, True)
+            if location is None:
+                result = archive_file.extractDirectory(path, self.__domain_home)
+            else:
+                extract_location = FileUtils.getCanonicalFile(File(location))
+                result = archive_file.extractDirectory(path, extract_location, True)
         except (IllegalArgumentException, WLSDeployArchiveIOException), e:
             ex = exception_helper.create_exception(self.__exception_type, "WLSDPLY-19303", path,
                                                    self.__archive_files_text, e.getLocalizedMessage(), error=e)

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 # The Universal Permissive License (UPL), Version 1.0
 #
 #
@@ -990,7 +990,7 @@ WLSDPLY-09326=Deployment order is {0}
 WLSDPLY-09327=Failed to stop application {0}: {1}
 WLSDPLY-09328=Application {0} name has been updated to {1} to match the application version in the MANIFEST.MF file
 WLSDPLY-09329=Failed to compute name for application {0} from archive at {1}: {2}
-
+WLSDPLY-09330=Source path for {0} {1} not found in any archive: {2}
 
 # wlsdeploy/tool/deploy/common_resources_deployer.py
 WLSDPLY-09400=ResourceGroup was specified in the test file but are not supported in WebLogic Server version {0}


### PR DESCRIPTION
- unzip specified app directory in archive to wlsdeploy directory

- use the manifest from the file system if app is exploded

- for online, always redeploy exploded app, since hash can't be determined
