### PR TITLE
warn about not supported kss keystore type

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/model_constants.py
+++ b/core/src/main/python/wlsdeploy/aliases/model_constants.py
@@ -5,6 +5,8 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 # lists may be represented in the model as comma-separated strings
 MODEL_LIST_DELIMITER = ','
+KSS_KEYSTORE_TYPE = 'kss'
+KSS_KEYSTORE_FILE_INDICATOR = 'kss:'
 
 
 # names of model elements, alphabetically

--- a/core/src/main/python/wlsdeploy/aliases/model_constants.py
+++ b/core/src/main/python/wlsdeploy/aliases/model_constants.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 

--- a/core/src/main/python/wlsdeploy/tool/discover/topology_discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/topology_discoverer.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 from java.io import File

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -696,6 +696,11 @@ WLSDPLY-06637=Unable to locate and add node manager keystore file {0} to the arc
 WLSDPLY-06638=Unexpected exception attempting to add node manager keystore file {0} to the archive : {1}
 WLSDPLY-06639=Skipping Embedded LDAP Server Configuration
 WLSDPLY-06640=Adding Embedded LDAP Server Configuration
+WLSDPLY-06641=Custom Keystore file name at location {0} is {1}
+WLSDPLY-06642=Custom Keystore file {0} at location {1} is a kss type which is not currently supported. \
+  The Custom Keystore file will not be added to the archive file. Use export / import to \
+  add the file to the target domain
+
 
 # multi_tenant_discoverer.py, multi_tenant_resources_dsi
 WLSDPLY-06700=Discover Multi-tenant


### PR DESCRIPTION
Currently kss keystore files cannot be added to the archive and populated into the target domain. Warn instead of printing obscure message

        1. WLSDPLY-06642: Custom Keystore file kss://system/ylidentity at location /Server/NetworkAccessPoint is a kss type which is not currently supported. The Custom Keystore file will not be added to the archive file. Use export / import to add the file to the target domain

Total:       WARNING :     1    SEVERE :     0