### PR TITLE
Parser fixes

### DIFF
--- a/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
+++ b/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
@@ -102,12 +102,6 @@ obj_block
     | NEWLINE                                    // Handle an object with no attributes specified
     ;
 
-// the prefix for an assignment or open block, such as "domainInfo: ".
-// an extra level is needed here to prevent ambiguity in those two cases.
-//prefix
-//    : name ASSIGN_OP
-//    ;
-
 name
     : NAME
     ;

--- a/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
+++ b/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
@@ -102,6 +102,8 @@ obj_block
     | NEWLINE                                    // Handle an object with no attributes specified
     ;
 
+// the prefix for an assignment or open block, such as "domainInfo: ".
+// an extra level is needed here to prevent ambiguity in those two cases.
 prefix
     : name ASSIGN_OP
     ;
@@ -131,6 +133,8 @@ inline_list_item
     : (NEWLINE (INDENT)?)? value
     ;
 
+// look for trailing comments after assignment or open block.
+// don't close with NEWLINE, since we don't want to dedent yet.
 COMMENT
     : '#' ~[\r\n\f]* -> skip
     ;

--- a/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
+++ b/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
@@ -133,7 +133,7 @@ ATSTART
     : {atStartOfInput()}? ( (COMMENT | WS*) ('\r'? '\n' | '\r' | '\f') )+  -> skip
     ;
 
-// comments may appear on separate lines, or on the same line as an assignments or object starts.
+// comments may appear on separate lines, or on the same line as assignments or object starts.
 // don't close with NEWLINE here, needed to distinguish assign from object declaration.
 COMMENT
     : WS? '#' ~[\r\n\f]*  -> skip

--- a/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
+++ b/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
@@ -84,7 +84,7 @@ statement
     ;
 
 assign
-    : prefix value WS? COMMENT? COMMENT_LINE* NEWLINE
+    : name ASSIGN_OP value WS? COMMENT? COMMENT_LINE* NEWLINE
     ;
 
 list_item
@@ -94,7 +94,7 @@ list_item
     ;
 
 object
-    : prefix COMMENT? COMMENT_LINE* obj_block
+    : name ASSIGN_OP COMMENT? COMMENT_LINE* obj_block
     ;
 
 obj_block
@@ -104,9 +104,9 @@ obj_block
 
 // the prefix for an assignment or open block, such as "domainInfo: ".
 // an extra level is needed here to prevent ambiguity in those two cases.
-prefix
-    : name ASSIGN_OP
-    ;
+//prefix
+//    : name ASSIGN_OP
+//    ;
 
 name
     : NAME

--- a/core/src/main/java/oracle/weblogic/deploy/logging/LoggingUtils.java
+++ b/core/src/main/java/oracle/weblogic/deploy/logging/LoggingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.logging;
@@ -17,7 +17,9 @@ public class LoggingUtils {
         Class<T> handler = null;
         try {
             Class<?> checkClass = Class.forName(handlerName);
-            handler = (Class<T>)checkClass.asSubclass(Class.forName(handlerName));
+            @SuppressWarnings("unchecked")
+            Class<T> castHandler = (Class<T>)checkClass.asSubclass(Class.forName(handlerName));
+            handler = castHandler;
         } catch(ClassNotFoundException | ClassCastException cnf) {
             exitWithError(
                     MessageFormat.format("Unable to find handler class {0} so skipping logging configuration",

--- a/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
+++ b/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.yaml;
@@ -68,7 +68,7 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
      */
     @Override
     public void enterAssign(YamlParser.AssignContext ctx) {
-        String name = getQuotedStringText(ctx.name().getText());
+        String name = getQuotedStringText(ctx.prefix().name().getText());
         PyObject value = getAssignValue(name, ctx);
 
         PyDictionary container = currentDict.peek();
@@ -119,7 +119,7 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
      */
     @Override
     public void enterObject(YamlParser.ObjectContext ctx) {
-        String name = getQuotedStringText(ctx.name().getText());
+        String name = getQuotedStringText(ctx.prefix().name().getText());
         PyDictionary objDict;
         if (useOrderedDict) {
             objDict = new PyOrderedDict();

--- a/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
+++ b/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.yaml;

--- a/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
+++ b/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
@@ -68,7 +68,7 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
      */
     @Override
     public void enterAssign(YamlParser.AssignContext ctx) {
-        String name = getQuotedStringText(ctx.prefix().name().getText());
+        String name = getQuotedStringText(ctx.name().getText());
         PyObject value = getAssignValue(name, ctx);
 
         PyDictionary container = currentDict.peek();
@@ -119,7 +119,7 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
      */
     @Override
     public void enterObject(YamlParser.ObjectContext ctx) {
-        String name = getQuotedStringText(ctx.prefix().name().getText());
+        String name = getQuotedStringText(ctx.name().getText());
         PyDictionary objDict;
         if (useOrderedDict) {
             objDict = new PyOrderedDict();

--- a/core/src/test/java/oracle/weblogic/deploy/yaml/YamlJavaTranslator.java
+++ b/core/src/test/java/oracle/weblogic/deploy/yaml/YamlJavaTranslator.java
@@ -159,7 +159,7 @@ public class YamlJavaTranslator extends YamlBaseListener {
 
     @Override
     public void enterObject(YamlParser.ObjectContext ctx) {
-        String name = StringUtils.stripQuotes(ctx.prefix().name().getText());
+        String name = StringUtils.stripQuotes(ctx.name().getText());
         Map<String, Object> objDict = new HashMap<>();
 
         Map<String, Object> container = currentDict.peek();
@@ -204,7 +204,7 @@ public class YamlJavaTranslator extends YamlBaseListener {
 
     private String getAssignName(YamlParser.AssignContext ctx) {
         String name = null;
-        String text = ctx.prefix().name().getText();
+        String text = ctx.name().getText();
         if (!StringUtils.isEmpty(text)) {
             name = StringUtils.stripQuotes(text.trim());
         }

--- a/core/src/test/java/oracle/weblogic/deploy/yaml/YamlJavaTranslator.java
+++ b/core/src/test/java/oracle/weblogic/deploy/yaml/YamlJavaTranslator.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+ */
+package oracle.weblogic.deploy.yaml;
+
+import oracle.weblogic.deploy.logging.PlatformLogger;
+import oracle.weblogic.deploy.logging.WLSDeployLogFactory;
+import oracle.weblogic.deploy.util.FileUtils;
+import oracle.weblogic.deploy.util.StringUtils;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.junit.Assert;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.*;
+
+/**
+ * An implementation of the YAML parser/translator that reads the YAML input from an input stream.
+ * A tree of Java objects is created, unlike the WDT parser, which creates a tree of Python objects
+ */
+public class YamlJavaTranslator extends YamlBaseListener {
+    private static final boolean DEBUG = System.getProperty("DEBUG") != null;
+    private static final String CLASS = YamlJavaTranslator.class.getName();
+    private static final PlatformLogger LOGGER = WLSDeployLogFactory.getLogger("wlsdeploy.yaml");
+
+    private File yamlFile;
+
+    private YamlErrorListener errorListener;
+
+    private Map<String, Object> fileDict;
+    private Stack<Map<String, Object>> currentDict;
+
+    private String lastObjectName;
+    private List<Object> openObjectList;
+
+    private String[] ruleNames;
+
+    /**
+     * Constructor for parsing YAML file into a Python dictionary and controlling ordering.
+     *
+     * @param fileName the name of the existing YAML file to parse
+     * @throws IllegalArgumentException if the file name is null or does not point to a valid, existing file.
+     */
+    public YamlJavaTranslator(String fileName) {
+        this.yamlFile = FileUtils.validateExistingFile(fileName);
+        this.errorListener = new YamlErrorListener(fileName, false);
+    }
+
+    /**
+     * This method triggers parsing of the file and conversion into the Python dictionary.
+     *
+     * @return the python dictionary corresponding to the YAML input file
+     * @throws YamlException if an error occurs while reading the input file
+     */
+    public Map<String, Object> parse() throws YamlException {
+        final String METHOD = "parse";
+        LOGGER.entering(CLASS, METHOD);
+
+        fileDict = new HashMap<>();
+        try (FileInputStream fis = new FileInputStream(yamlFile)) {
+
+            CharStream input = CharStreams.fromStream(fis);
+            YamlLexer lexer = new YamlLexer(input);
+
+            CommonTokenStream tokens = new CommonTokenStream(lexer);
+            YamlParser parser = new YamlParser(tokens);
+            ruleNames = parser.getRuleNames();
+
+            parser.removeErrorListeners();
+            parser.addErrorListener(errorListener);
+            parser.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
+
+            ParseTree tree = parser.file();
+            ParseTreeWalker walker = new ParseTreeWalker();
+            walker.walk(this, tree);
+
+        } catch (IOException ioe) {
+            YamlException ex = new YamlException("WLSDPLY-18007", ioe, "YAML", yamlFile.getPath(),
+                    ioe.getLocalizedMessage());
+            LOGGER.throwing(CLASS, METHOD, ex);
+            throw ex;
+        }
+
+        LOGGER.exiting(CLASS, METHOD, fileDict);
+        return fileDict;
+    }
+
+    public void checkForParseErrors() throws Exception {
+        int errorCount = errorListener.getErrorCount();
+        Assert.assertEquals("Parser error count was " + errorCount, 0, errorCount);
+    }
+
+    public void ensureStackIsEmpty() {
+        Assert.assertTrue("currentDict stack is not empty", currentDict.isEmpty());
+    }
+
+    // -------------------------------------------
+    // implement YamlBaseListener
+    // -------------------------------------------
+
+    @Override
+    public void enterFile(YamlParser.FileContext ctx) {
+        this.fileDict = new HashMap<>();
+        currentDict = new Stack<>();
+        currentDict.push(fileDict);
+    }
+
+    @Override
+    public void enterAssign(YamlParser.AssignContext ctx) {
+        String name = getAssignName(ctx);
+        Object value = getAssignValue(name, ctx);
+
+        Map<String, Object> container = currentDict.peek();
+        container.put(name, value);
+    }
+
+    @Override
+    public void enterYamlListItemAssign(YamlParser.YamlListItemAssignContext ctx) {
+        YamlParser.AssignContext assignCtx = ctx.assign();
+
+        // The only type of list item we treat differently is a list of values.
+        enterAssign(assignCtx);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void enterYamlListItemValue(YamlParser.YamlListItemValueContext ctx) {
+        YamlParser.ValueContext valueCtx = ctx.value();
+
+        List<Object> myList = getOpenObjectList();
+        String madeUpName = MessageFormat.format("{0}[{1}]", lastObjectName, myList.size());
+        Object value = getScalarValue(madeUpName, valueCtx);
+        myList.add(value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void enterYamlListItemObject(YamlParser.YamlListItemObjectContext ctx) {
+        YamlParser.ObjectContext objCtx = ctx.object();
+
+        // The only type of list item we treat differently is a list of values.
+        enterObject(objCtx);
+    }
+
+    @Override
+    public void enterObject(YamlParser.ObjectContext ctx) {
+        String name = StringUtils.stripQuotes(ctx.name().getText());
+        Map<String, Object> objDict = new HashMap<>();
+
+        Map<String, Object> container = currentDict.peek();
+        container.put(name, objDict);
+        currentDict.push(objDict);
+
+        // In case this is the name for a list of values, save it off...
+        lastObjectName = name;
+    }
+
+    @Override
+    public void exitObj_block(YamlParser.Obj_blockContext ctx) {
+        if (openObjectList != null) {
+            // Pop off the dictionary that is created by default for all new objects off the current stack
+            currentDict.pop();
+
+            Map<String, Object> container = currentDict.peek();
+            container.put(lastObjectName, openObjectList);
+
+            // zero out the open list
+            openObjectList = null;
+        } else {
+            currentDict.pop();
+        }
+    }
+
+    @Override
+    public void exitFile(YamlParser.FileContext ctx) {
+        currentDict.pop();
+    }
+
+    @Override public void enterEveryRule(ParserRuleContext ctx) {
+        if(DEBUG) {
+            System.err.println("RULE: " + ctx.toString(Arrays.asList(ruleNames))
+                    + " " + ctx.getText() + " " + ctx.getStart() + " " + ctx.getChildCount());
+        }
+    }
+
+    // -------------------------------------------
+    // private methods
+    // -------------------------------------------
+
+    private String getAssignName(YamlParser.AssignContext ctx) {
+        String name = null;
+        String text = ctx.name().getText();
+        if (!StringUtils.isEmpty(text)) {
+            name = StringUtils.stripQuotes(text.trim());
+        }
+        return name;
+    }
+
+    private Object getAssignValue(String name, YamlParser.AssignContext ctx) {
+        YamlParser.ValueContext valueCtx = ctx.value();
+        Object value;
+
+        if (YamlParser.YamlInlineListValueContext.class.isAssignableFrom(valueCtx.getClass())) {
+            YamlParser.YamlInlineListValueContext inlineListCtx =
+                    YamlParser.YamlInlineListValueContext.class.cast(valueCtx);
+            List<Object> pyObjList = new ArrayList<>();
+
+            YamlParser.Inline_listContext listCtx = inlineListCtx.inline_list();
+            for (int i = 0; i < listCtx.getChildCount(); i++) {
+                ParseTree obj = listCtx.getChild(i);
+                // This code is not handling arrays of objects or arrays of arrays since we do not need it
+                // for our use case.  If we encounter it, we will log an error and return None.
+                // We really should do something better if Antlr has a more graceful way to handle it...
+                //
+                if (!YamlParser.Inline_list_itemContext.class.isAssignableFrom(obj.getClass())) {
+                    continue;
+                }
+                YamlParser.Inline_list_itemContext liCtx = YamlParser.Inline_list_itemContext.class.cast(obj);
+                YamlParser.ValueContext arrayElementValueContext = liCtx.value();
+                String madeUpName = MessageFormat.format("{0}[{1}]", name, pyObjList.size());
+                Object arrayElement = getScalarValue(madeUpName, arrayElementValueContext);
+                pyObjList.add(arrayElement);
+            }
+            value = pyObjList;
+        } else {
+            value = getScalarValue(name, valueCtx);
+        }
+        return value;
+    }
+
+    private Object getScalarValue(String name, YamlParser.ValueContext valueContext) {
+        Object value = null;
+
+        Class<?> valueClazz = valueContext.getClass();
+        String text;
+        if (YamlParser.YamlNullValueContext.class.isAssignableFrom(valueClazz)) {
+            value = null;
+        } else if (YamlParser.YamlNameValueContext.class.isAssignableFrom(valueClazz)) {
+            YamlParser.YamlNameValueContext nameCtx = YamlParser.YamlNameValueContext.class.cast(valueContext);
+            text = nameCtx.NAME().getText();
+            if (!StringUtils.isEmpty(text)) {
+                value = text.trim();
+                value = StringUtils.stripQuotes(value.toString());  // similar to AbstractYamlTranslator
+            } else {
+                value = null;
+            }
+        } else if (YamlParser.YamlUnquotedStringValueContext.class.isAssignableFrom(valueClazz)) {
+            YamlParser.YamlUnquotedStringValueContext strCtx =
+                    YamlParser.YamlUnquotedStringValueContext.class.cast(valueContext);
+            text = strCtx.UNQUOTED_STRING().getText();
+            if (!StringUtils.isEmpty(text)) {
+                value = text.trim();
+            } else {
+                value = null;
+            }
+        } else if (YamlParser.YamlQuotedStringValueContext.class.isAssignableFrom(valueClazz)) {
+            YamlParser.YamlQuotedStringValueContext strCtx =
+                    YamlParser.YamlQuotedStringValueContext.class.cast(valueContext);
+            text = strCtx.QUOTED_STRING().getText();
+            if (!StringUtils.isEmpty(text)) {
+                // trim off any leading/trailing white space
+                text = text.trim();
+                // trim off the quotes
+                value = text.substring(1, text.length() - 1);
+            } else {
+                value = null;
+            }
+        } else if (YamlParser.YamlBooleanValueContext.class.isAssignableFrom(valueClazz)) {
+            YamlParser.YamlBooleanValueContext boolCtx = YamlParser.YamlBooleanValueContext.class.cast(valueContext);
+            text = boolCtx.BOOLEAN().getText();
+
+            String booleanValue = "False";
+            if (!StringUtils.isEmpty(text)) {
+                text = text.trim();
+                if ("true".equalsIgnoreCase(text)) {
+                    booleanValue = "True";
+                } else if ("false".equalsIgnoreCase(text)) {
+                    booleanValue = "False";
+                } else {
+                    Assert.fail("Boolean value for " + name + " attribute was not true or false (" + text + ")");
+                }
+            } else {
+                Assert.fail("Boolean value for " + name + " attribute was empty");
+            }
+            value = booleanValue;
+        } else if (YamlParser.YamlIntegerValueContext.class.isAssignableFrom(valueClazz)) {
+            YamlParser.YamlIntegerValueContext intCtx = YamlParser.YamlIntegerValueContext.class.cast(valueContext);
+            text = intCtx.INTEGER().getText();
+
+            int intValue = 0;
+            if (!StringUtils.isEmpty(text)) {
+                text = text.trim();
+                try {
+                    intValue = Integer.valueOf(text);
+                } catch (NumberFormatException nfe) {
+                    Assert.fail(name + " attribute is not an integer: " + nfe.getLocalizedMessage());
+                    nfe.printStackTrace();
+                }
+            } else {
+                Assert.fail(name + " attribute value was empty");
+            }
+            value = intValue;
+        } else if (YamlParser.YamlFloatValueContext.class.isAssignableFrom(valueClazz)) {
+            YamlParser.YamlFloatValueContext floatCtx = YamlParser.YamlFloatValueContext.class.cast(valueContext);
+            text = floatCtx.FLOAT().getText();
+
+            float floatValue = 0;
+            if (!StringUtils.isEmpty(text)) {
+                text = text.trim();
+                try {
+                    floatValue = Float.valueOf(text);
+                } catch (NumberFormatException nfe) {
+                    Assert.fail(name + " attribute is not a float: " + nfe.getLocalizedMessage());
+                    nfe.printStackTrace();
+                }
+            } else {
+                Assert.fail(name + " attribute value was empty");
+            }
+            value = floatValue;
+        } else {
+            Assert.fail(name + " attribute was an unexpected context type: " + valueClazz.getName());
+        }
+        return value;
+    }
+
+    private synchronized List<Object> getOpenObjectList() {
+        if (openObjectList == null) {
+            openObjectList = new ArrayList<>();
+        }
+        return openObjectList;
+    }
+}

--- a/core/src/test/java/oracle/weblogic/deploy/yaml/YamlJavaTranslator.java
+++ b/core/src/test/java/oracle/weblogic/deploy/yaml/YamlJavaTranslator.java
@@ -45,22 +45,24 @@ public class YamlJavaTranslator extends YamlBaseListener {
     private String[] ruleNames;
 
     /**
-     * Constructor for parsing YAML file into a Python dictionary and controlling ordering.
+     * Constructor for parsing YAML file into a Java map.
      *
      * @param fileName the name of the existing YAML file to parse
      * @throws IllegalArgumentException if the file name is null or does not point to a valid, existing file.
      */
+    @SuppressWarnings("WeakerAccess")
     public YamlJavaTranslator(String fileName) {
         this.yamlFile = FileUtils.validateExistingFile(fileName);
         this.errorListener = new YamlErrorListener(fileName, false);
     }
 
     /**
-     * This method triggers parsing of the file and conversion into the Python dictionary.
+     * This method triggers parsing of the file and conversion into the Java map.
      *
-     * @return the python dictionary corresponding to the YAML input file
+     * @return the Java map corresponding to the YAML input file
      * @throws YamlException if an error occurs while reading the input file
      */
+    @SuppressWarnings("WeakerAccess")
     public Map<String, Object> parse() throws YamlException {
         final String METHOD = "parse";
         LOGGER.entering(CLASS, METHOD);
@@ -94,12 +96,12 @@ public class YamlJavaTranslator extends YamlBaseListener {
         return fileDict;
     }
 
-    public void checkForParseErrors() throws Exception {
+    void checkForParseErrors() {
         int errorCount = errorListener.getErrorCount();
         Assert.assertEquals("Parser error count was " + errorCount, 0, errorCount);
     }
 
-    public void ensureStackIsEmpty() {
+    void ensureStackIsEmpty() {
         Assert.assertTrue("currentDict stack is not empty", currentDict.isEmpty());
     }
 
@@ -157,7 +159,7 @@ public class YamlJavaTranslator extends YamlBaseListener {
 
     @Override
     public void enterObject(YamlParser.ObjectContext ctx) {
-        String name = StringUtils.stripQuotes(ctx.name().getText());
+        String name = StringUtils.stripQuotes(ctx.prefix().name().getText());
         Map<String, Object> objDict = new HashMap<>();
 
         Map<String, Object> container = currentDict.peek();
@@ -191,7 +193,7 @@ public class YamlJavaTranslator extends YamlBaseListener {
 
     @Override public void enterEveryRule(ParserRuleContext ctx) {
         if(DEBUG) {
-            System.err.println("RULE: " + ctx.toString(Arrays.asList(ruleNames))
+            LOGGER.info("RULE: " + ctx.toString(Arrays.asList(ruleNames))
                     + " " + ctx.getText() + " " + ctx.getStart() + " " + ctx.getChildCount());
         }
     }
@@ -202,7 +204,7 @@ public class YamlJavaTranslator extends YamlBaseListener {
 
     private String getAssignName(YamlParser.AssignContext ctx) {
         String name = null;
-        String text = ctx.name().getText();
+        String text = ctx.prefix().name().getText();
         if (!StringUtils.isEmpty(text)) {
             name = StringUtils.stripQuotes(text.trim());
         }

--- a/core/src/test/java/oracle/weblogic/deploy/yaml/YamlParserCommentTest.java
+++ b/core/src/test/java/oracle/weblogic/deploy/yaml/YamlParserCommentTest.java
@@ -35,7 +35,7 @@ public class YamlParserCommentTest {
     }
 
     @Test
-    public void testParseComments() throws Exception {
+    public void testParseComments() {
         translator.checkForParseErrors();
         if (DEBUG) {
             StringBuilder builder = new StringBuilder("\n");
@@ -49,10 +49,10 @@ public class YamlParserCommentTest {
         for(Object key: map.keySet()) {
             Object value = map.get(key);
             if(value instanceof Map) {
-                builder.append(indent + key + ":\n");
+                builder.append(indent).append(key).append(":\n");
                 dumpMap((Map<?, ?>) value, builder, indent + "    ");
             } else {
-                builder.append(indent + key + ": " + value + "\n");
+                builder.append(indent).append(key).append(": ").append(value).append("\n");
             }
         }
     }

--- a/core/src/test/java/oracle/weblogic/deploy/yaml/YamlParserCommentTest.java
+++ b/core/src/test/java/oracle/weblogic/deploy/yaml/YamlParserCommentTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+ */
+package oracle.weblogic.deploy.yaml;
+
+import oracle.weblogic.deploy.logging.PlatformLogger;
+import oracle.weblogic.deploy.logging.WLSDeployLogFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * Verifies the parsing of files with an assortment of comment styles.
+ */
+public class YamlParserCommentTest {
+    private static final boolean DEBUG = System.getProperty("DEBUG") != null;
+    private static final PlatformLogger LOGGER = WLSDeployLogFactory.getLogger("wlsdeploy.yaml");
+    private static final File YAML_FILE =
+            new File("src/test/resources/yaml/comment-model.yaml").getAbsoluteFile();
+
+    private YamlJavaTranslator translator;
+    private Map<String, Object> fileDict;
+
+    @Before
+    public void init() throws Exception {
+        translator = new YamlJavaTranslator(YAML_FILE.getPath());
+        fileDict = translator.parse();
+
+        if (DEBUG) {
+            LOGGER.info("fileDict = " + fileDict.toString());
+        }
+    }
+
+    @Test
+    public void testParseComments() throws Exception {
+        translator.checkForParseErrors();
+        if (DEBUG) {
+            StringBuilder builder = new StringBuilder("\n");
+            dumpMap(fileDict, builder, "");
+            LOGGER.info(builder.toString());
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    static void dumpMap(Map<?, ?> map, StringBuilder builder, String indent) {
+        for(Object key: map.keySet()) {
+            Object value = map.get(key);
+            if(value instanceof Map) {
+                builder.append(indent + key + ":\n");
+                dumpMap((Map<?, ?>) value, builder, indent + "    ");
+            } else {
+                builder.append(indent + key + ": " + value + "\n");
+            }
+        }
+    }
+}

--- a/core/src/test/java/oracle/weblogic/deploy/yaml/YamlParserTest.java
+++ b/core/src/test/java/oracle/weblogic/deploy/yaml/YamlParserTest.java
@@ -1,32 +1,19 @@
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.yaml;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
-
-import oracle.weblogic.deploy.util.StringUtils;
-
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.atn.PredictionMode;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class YamlParserTest extends YamlBaseListener {
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class YamlParserTest {
     private static final boolean DEBUG = System.getProperty("DEBUG") != null;
     private static final File YAML_FILE = new File("src/test/resources/unit-test.yaml").getAbsoluteFile();
 
@@ -80,45 +67,28 @@ public class YamlParserTest extends YamlBaseListener {
     private static final int EXPECTED_S2_LISTEN_PORT = 8101;
     private static final String EXPECTED_S2_CLUSTER = "mycluster";
 
+    private YamlJavaTranslator translator;
     private Map<String, Object> fileDict;
-    private Stack<Map<String, Object>> currentDict;
-
-    private String lastObjectName;
-    private List<Object> openObjectList;
-
-    private YamlErrorListener errorListener = new YamlErrorListener(YAML_FILE.getPath(), false);
 
     @Before
     public void init() throws Exception {
-        try (FileInputStream fis = new FileInputStream(YAML_FILE)) {
-            CharStream input = CharStreams.fromStream(fis);
-            YamlLexer lexer = new YamlLexer(input);
-            CommonTokenStream tokens = new CommonTokenStream(lexer);
-            YamlParser parser = new YamlParser(tokens);
+        this.translator = new YamlJavaTranslator(YAML_FILE.getPath());
+        fileDict = translator.parse();
 
-            parser.removeErrorListeners();
-            parser.addErrorListener(errorListener);
-            parser.getInterpreter().setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);
-
-            ParseTree tree = parser.file();
-            ParseTreeWalker walker = new ParseTreeWalker();
-            walker.walk(this, tree);
-        }
         if (DEBUG) {
-            System.out.println("fileDict = " + fileDict.toString());
+            System.err.println("fileDict = " + fileDict.toString());
         }
     }
 
     @Test
     public void ensureStackIsEmpty() throws Exception {
-        checkForParseErrors();
-
-        Assert.assertTrue("currentDict stack is not empty", currentDict.isEmpty());
+        translator.checkForParseErrors();
+        translator.ensureStackIsEmpty();
     }
 
     @Test
     public void testTopLevelFolders() throws Exception {
-        checkForParseErrors();
+        translator.checkForParseErrors();
 
         for (String key : fileDict.keySet()) {
             Assert.assertTrue("Unexpected key (" + key + ") in fileDict", EXPECTED_TOP_LEVEL_KEYS.contains(key));
@@ -127,7 +97,7 @@ public class YamlParserTest extends YamlBaseListener {
 
     @Test
     public void testSingleQuotedStrings() throws Exception {
-        checkForParseErrors();
+        translator.checkForParseErrors();
 
         Map<String, Object> map = fileDict;
         for (String key : PATH_TO_GENERIC1_DRIVER_PARAMS) {
@@ -162,7 +132,7 @@ public class YamlParserTest extends YamlBaseListener {
 
     @Test
     public void testEndOfLineComments() throws Exception {
-        checkForParseErrors();
+        translator.checkForParseErrors();
 
         Map<String, Object> map = fileDict;
         for (String key : PATH_TO_GENERIC2_CONN_POOL_PARAMS) {
@@ -184,7 +154,7 @@ public class YamlParserTest extends YamlBaseListener {
 
     @Test
     public void testUnquotedStringWithWhitespace() throws Exception {
-        checkForParseErrors();
+        translator.checkForParseErrors();
 
         Map<String, Object> map = fileDict;
         for (String key : PATH_TO_GENERIC2_CONN_POOL_PARAMS) {
@@ -199,7 +169,7 @@ public class YamlParserTest extends YamlBaseListener {
 
     @Test
     public void testInlineSingleLineList() throws Exception {
-        checkForParseErrors();
+        translator.checkForParseErrors();
 
         Map<String, Object> map = fileDict;
         for (String key : PATH_TO_GENERIC1_DATASOURCE_PARAMS) {
@@ -219,7 +189,7 @@ public class YamlParserTest extends YamlBaseListener {
 
     @Test
     public void testInlineMultiLineList() throws Exception {
-        checkForParseErrors();
+        translator.checkForParseErrors();
 
         Map<String, Object> map = fileDict;
         for (String key : PATH_TO_GENERIC2_DATASOURCE_PARAMS) {
@@ -239,7 +209,7 @@ public class YamlParserTest extends YamlBaseListener {
 
     @Test
     public void testYamlStyleList() throws Exception {
-        checkForParseErrors();
+        translator.checkForParseErrors();
 
         Map<String, Object> map = fileDict;
         for (String key : PATH_TO_GENERIC1) {
@@ -259,7 +229,7 @@ public class YamlParserTest extends YamlBaseListener {
 
     @Test
     public void testEmptyObject() throws Exception {
-        checkForParseErrors();
+        translator.checkForParseErrors();
 
         Map<String, Object> map = fileDict;
         for (String key : PATH_TO_MYCLUSTER) {
@@ -276,9 +246,7 @@ public class YamlParserTest extends YamlBaseListener {
             Assert.assertNotNull("AdminServer path key (" + key +") not found", map);
         }
 
-        @SuppressWarnings("unchecked")
         String listenAddress = (String)map.get("ListenAddress");
-        @SuppressWarnings("unchecked")
         int listenPort = (int)map.get("ListenPort");
 
         Assert.assertNotNull("AdminServer ListenAddress should not be null", listenAddress);
@@ -292,11 +260,8 @@ public class YamlParserTest extends YamlBaseListener {
             Assert.assertNotNull("S1 path key (" + key +") not found", map);
         }
 
-        @SuppressWarnings("unchecked")
         String s1ListenAddress = (String)map.get("ListenAddress");
-        @SuppressWarnings("unchecked")
         int s1ListenPort = (int)map.get("ListenPort");
-        @SuppressWarnings("unchecked")
         String cluster = (String)map.get("Cluster");
 
         Assert.assertNotNull("S1 ListenAddress should not be null", s1ListenAddress);
@@ -311,11 +276,8 @@ public class YamlParserTest extends YamlBaseListener {
             Assert.assertNotNull("S2 path key (" + key +") not found", map);
         }
 
-        @SuppressWarnings("unchecked")
         String s2ListenAddress = (String)map.get("ListenAddress");
-        @SuppressWarnings("unchecked")
         int s2ListenPort = (int)map.get("ListenPort");
-        @SuppressWarnings("unchecked")
         String s2Cluster = (String)map.get("Cluster");
 
         Assert.assertNotNull("S2 ListenAddress should not be null", s2ListenAddress);
@@ -329,239 +291,8 @@ public class YamlParserTest extends YamlBaseListener {
     //                            End of tests                               //
     ///////////////////////////////////////////////////////////////////////////
 
-    @Override
-    public void enterFile(YamlParser.FileContext ctx) {
-        this.fileDict = new HashMap<>();
-        currentDict = new Stack<>();
-        currentDict.push(fileDict);
-    }
-
-    @Override
-    public void enterAssign(YamlParser.AssignContext ctx) {
-        String name = getAssignName(ctx);
-        Object value = getAssignValue(name, ctx);
-
-        Map<String, Object> container = currentDict.peek();
-        container.put(name, value);
-    }
-
-    @Override
-    public void enterYamlListItemAssign(YamlParser.YamlListItemAssignContext ctx) {
-        YamlParser.AssignContext assignCtx = ctx.assign();
-
-        // The only type of list item we treat differently is a list of values.
-        enterAssign(assignCtx);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void enterYamlListItemValue(YamlParser.YamlListItemValueContext ctx) {
-        YamlParser.ValueContext valueCtx = ctx.value();
-
-        List<Object> myList = getOpenObjectList();
-        String madeUpName = MessageFormat.format("{0}[{1}]", lastObjectName, myList.size());
-        Object value = getScalarValue(madeUpName, valueCtx);
-        myList.add(value);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void enterYamlListItemObject(YamlParser.YamlListItemObjectContext ctx) {
-        YamlParser.ObjectContext objCtx = ctx.object();
-
-        // The only type of list item we treat differently is a list of values.
-        enterObject(objCtx);
-    }
-
-    @Override
-    public void enterObject(YamlParser.ObjectContext ctx) {
-        String name = StringUtils.stripQuotes(ctx.name().getText());
-        Map<String, Object> objDict = new HashMap<>();
-
-        Map<String, Object> container = currentDict.peek();
-        container.put(name, objDict);
-        currentDict.push(objDict);
-
-        // In case this is the name for a list of values, save it off...
-        lastObjectName = name;
-    }
-
-    @Override
-    public void exitObj_block(YamlParser.Obj_blockContext ctx) {
-        if (openObjectList != null) {
-            // Pop off the dictionary that is created by default for all new objects off the current stack
-            currentDict.pop();
-
-            Map<String, Object> container = currentDict.peek();
-            container.put(lastObjectName, openObjectList);
-
-            // zero out the open list
-            openObjectList = null;
-        } else {
-            currentDict.pop();
-        }
-    }
-
-    @Override
-    public void exitFile(YamlParser.FileContext ctx) {
-        currentDict.pop();
-    }
-
-
-    private String getAssignName(YamlParser.AssignContext ctx) {
-        String name = null;
-        String text = ctx.name().getText();
-        if (!StringUtils.isEmpty(text)) {
-            name = StringUtils.stripQuotes(text.trim());
-        }
-        return name;
-    }
-
-    private Object getAssignValue(String name, YamlParser.AssignContext ctx) {
-        YamlParser.ValueContext valueCtx = ctx.value();
-        Object value;
-
-        if (YamlParser.YamlInlineListValueContext.class.isAssignableFrom(valueCtx.getClass())) {
-            YamlParser.YamlInlineListValueContext inlineListCtx =
-                YamlParser.YamlInlineListValueContext.class.cast(valueCtx);
-            List<Object> pyObjList = new ArrayList<>();
-
-            YamlParser.Inline_listContext listCtx = inlineListCtx.inline_list();
-            for (int i = 0; i < listCtx.getChildCount(); i++) {
-                ParseTree obj = listCtx.getChild(i);
-                // This code is not handling arrays of objects or arrays of arrays since we do not need it
-                // for our use case.  If we encounter it, we will log an error and return None.
-                // We really should do something better if Antlr has a more graceful way to handle it...
-                //
-                if (!YamlParser.Inline_list_itemContext.class.isAssignableFrom(obj.getClass())) {
-                    continue;
-                }
-                YamlParser.Inline_list_itemContext liCtx = YamlParser.Inline_list_itemContext.class.cast(obj);
-                YamlParser.ValueContext arrayElementValueContext = liCtx.value();
-                String madeUpName = MessageFormat.format("{0}[{1}]", name, pyObjList.size());
-                Object arrayElement = getScalarValue(madeUpName, arrayElementValueContext);
-                pyObjList.add(arrayElement);
-            }
-            value = pyObjList;
-        } else {
-            value = getScalarValue(name, valueCtx);
-        }
-        return value;
-    }
-
-    private Object getScalarValue(String name, YamlParser.ValueContext valueContext) {
-        Object value = null;
-
-        Class<?> valueClazz = valueContext.getClass();
-        String text;
-        if (YamlParser.YamlNullValueContext.class.isAssignableFrom(valueClazz)) {
-            value = null;
-        } else if (YamlParser.YamlNameValueContext.class.isAssignableFrom(valueClazz)) {
-            YamlParser.YamlNameValueContext nameCtx = YamlParser.YamlNameValueContext.class.cast(valueContext);
-            text = nameCtx.NAME().getText();
-            if (!StringUtils.isEmpty(text)) {
-                value = text.trim();
-                value = StringUtils.stripQuotes(value.toString());  // similar to AbstractYamlTranslator
-            } else {
-                value = null;
-            }
-        } else if (YamlParser.YamlUnquotedStringValueContext.class.isAssignableFrom(valueClazz)) {
-            YamlParser.YamlUnquotedStringValueContext strCtx =
-                YamlParser.YamlUnquotedStringValueContext.class.cast(valueContext);
-            text = strCtx.UNQUOTED_STRING().getText();
-            if (!StringUtils.isEmpty(text)) {
-                value = text.trim();
-            } else {
-                value = null;
-            }
-        } else if (YamlParser.YamlQuotedStringValueContext.class.isAssignableFrom(valueClazz)) {
-            YamlParser.YamlQuotedStringValueContext strCtx =
-                YamlParser.YamlQuotedStringValueContext.class.cast(valueContext);
-            text = strCtx.QUOTED_STRING().getText();
-            if (!StringUtils.isEmpty(text)) {
-                // trim off any leading/trailing white space
-                text = text.trim();
-                // trim off the quotes
-                value = text.substring(1, text.length() - 1);
-            } else {
-                value = null;
-            }
-        } else if (YamlParser.YamlBooleanValueContext.class.isAssignableFrom(valueClazz)) {
-            YamlParser.YamlBooleanValueContext boolCtx = YamlParser.YamlBooleanValueContext.class.cast(valueContext);
-            text = boolCtx.BOOLEAN().getText();
-
-            String booleanValue = "False";
-            if (!StringUtils.isEmpty(text)) {
-                text = text.trim();
-                if ("true".equalsIgnoreCase(text)) {
-                    booleanValue = "True";
-                } else if ("false".equalsIgnoreCase(text)) {
-                    booleanValue = "False";
-                } else {
-                    Assert.fail("Boolean value for " + name + " attribute was not true or false (" + text + ")");
-                }
-            } else {
-                Assert.fail("Boolean value for " + name + " attribute was empty");
-            }
-            value = booleanValue;
-        } else if (YamlParser.YamlIntegerValueContext.class.isAssignableFrom(valueClazz)) {
-            YamlParser.YamlIntegerValueContext intCtx = YamlParser.YamlIntegerValueContext.class.cast(valueContext);
-            text = intCtx.INTEGER().getText();
-
-            int intValue = 0;
-            if (!StringUtils.isEmpty(text)) {
-                text = text.trim();
-                try {
-                    intValue = Integer.valueOf(text);
-                } catch (NumberFormatException nfe) {
-                    Assert.fail(name + " attribute is not an integer: " + nfe.getLocalizedMessage());
-                    nfe.printStackTrace();
-                }
-            } else {
-                Assert.fail(name + " attribute value was empty");
-            }
-            value = intValue;
-        } else if (YamlParser.YamlFloatValueContext.class.isAssignableFrom(valueClazz)) {
-            YamlParser.YamlFloatValueContext floatCtx = YamlParser.YamlFloatValueContext.class.cast(valueContext);
-            text = floatCtx.FLOAT().getText();
-
-            float floatValue = 0;
-            if (!StringUtils.isEmpty(text)) {
-                text = text.trim();
-                try {
-                    floatValue = Float.valueOf(text);
-                } catch (NumberFormatException nfe) {
-                    Assert.fail(name + " attribute is not a float: " + nfe.getLocalizedMessage());
-                    nfe.printStackTrace();
-                }
-            } else {
-                Assert.fail(name + " attribute value was empty");
-            }
-            value = floatValue;
-        } else {
-            Assert.fail(name + " attribute was an unexpected context type: " + valueClazz.getName());
-        }
-        return value;
-    }
-
-    private synchronized List<Object> getOpenObjectList() {
-        if (openObjectList == null) {
-            openObjectList = new ArrayList<>();
-        }
-        return openObjectList;
-    }
-
     @SuppressWarnings("unchecked")
     private Map<String, Object> getMap(Map<String, Object> container, String key) {
         return (Map<String, Object>) container.get(key);
-    }
-
-    private void checkForParseErrors() throws Exception {
-        int errorCount = errorListener.getErrorCount();
-        Assert.assertEquals("Parser error count was " + errorCount, 0, errorCount);
     }
 }

--- a/core/src/test/resources/yaml/comment-model.yaml
+++ b/core/src/test/resources/yaml/comment-model.yaml
@@ -1,3 +1,13 @@
+# Copyright (c) 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+#  there can be comments and blank lines at the top
+
+  #
+   #  indent is OK
+
+#
+
 domainInfo:  # used for create
     #
     # these should be in properties file
@@ -32,4 +42,6 @@ topology:  # beta test
         m1:
           ListenPort: 9003
       # ListenAddress: 123.0.0.546
+
+
           Cluster: mycluster

--- a/core/src/test/resources/yaml/comment-model.yaml
+++ b/core/src/test/resources/yaml/comment-model.yaml
@@ -1,0 +1,35 @@
+domainInfo:  # used for create
+    #
+    # these should be in properties file
+    #
+    AdminUserName: 'weblogic'
+    AdminPassword: 'welcome1'  # sample only
+# configure for your database configuration
+    RCUDbInfo:
+      useATP : 1
+      rcu_prefix : DEV
+      rcu_schema_password : xxxxx
+#
+# different password
+      rcu_admin_password : xxxx  # from sys admin
+      tns.alias : dbatp_tp
+
+# the topology section
+# do not delete
+   # without permission
+topology:  # beta test
+  # don't change without permission
+    Cluster:
+        mycluster: # no customized properties
+    Server:
+        AdminServer:
+            ListenPort: 9001
+            SSL:
+               Enabled: true
+            ServerStart:
+              # system dependent
+              Arguments: '-Dosgi=true'
+        m1:
+          ListenPort: 9003
+      # ListenAddress: 123.0.0.546
+          Cluster: mycluster


### PR DESCRIPTION
Fix several problems with YAML parsing:
- blank lines and comments at the top of the file
- empty comment lines like #
- comments after object block open, like domainInfo:  # mine
- single-line comments throwing off indentation

See new model comment-model.yaml for examples

Broke out YamlJavaTranslator for use in multiple unit tests.

Fixed compiler warning in LoggingUtils.

Fixes #236 
