### PR TITLE
Avoid dumping model and model sections in the logs

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
+++ b/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.yaml;
@@ -199,7 +199,9 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
                 throw ye;
             }
         }
-        getLogger().exiting(getClassName(), METHOD, fileDict);
+
+        // don't log the value on exit, it may be a password
+        getLogger().exiting(getClassName(), METHOD);
         return fileDict;
     }
 
@@ -274,7 +276,9 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
         } else {
             getLogger().severe("WLSDPLY-18006", name, valueClazz.getName());
         }
-        getLogger().exiting(getClassName(), METHOD, value);
+
+        // don't log the value on exit, it may be a password
+        getLogger().exiting(getClassName(), METHOD);
         return value;
     }
 

--- a/core/src/main/java/oracle/weblogic/deploy/yaml/YamlTranslator.java
+++ b/core/src/main/java/oracle/weblogic/deploy/yaml/YamlTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.yaml;
@@ -64,7 +64,9 @@ public class YamlTranslator extends AbstractYamlTranslator {
             LOGGER.throwing(CLASS, METHOD, ex);
             throw ex;
         }
-        LOGGER.exiting(CLASS, METHOD, result);
+
+        // don't log the model on exit, it may contain passwords
+        LOGGER.exiting(CLASS, METHOD);
         return result;
     }
 

--- a/core/src/main/python/wlsdeploy/json/json_translator.py
+++ b/core/src/main/python/wlsdeploy/json/json_translator.py
@@ -51,7 +51,9 @@ class JsonToPython(object):
         self._logger.entering(class_name=self._class_name, method_name=_method_name)
         # throws JsonException with details, nothing we can really add here...
         result_dict = self._translator.parse()
-        self._logger.exiting(class_name=self._class_name, method_name=_method_name, result=result_dict)
+
+        # don't log the model on exit, it may contain passwords
+        self._logger.exiting(class_name=self._class_name, method_name=_method_name)
         return result_dict
 
 

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os
@@ -32,6 +32,7 @@ from wlsdeploy.util.weblogic_helper import WebLogicHelper
 
 from wlsdeploy.aliases.model_constants import DOMAIN_INFO
 from wlsdeploy.aliases.model_constants import KUBERNETES
+from wlsdeploy.aliases.model_constants import MASKED_PASSWORD
 from wlsdeploy.aliases.model_constants import MODEL_LIST_DELIMITER
 from wlsdeploy.aliases.model_constants import NAME
 from wlsdeploy.aliases.model_constants import SERVER_GROUP_TARGETING_LIMITS
@@ -390,7 +391,8 @@ class Validator(object):
             if variables.has_variables(section_dict_key):
                 self._report_unsupported_variable_usage(section_dict_key, model_folder_path)
 
-            self._logger.finer('WLSDPLY-05011', section_dict_key, section_dict_value,
+            # don't log section_dict_value here, it may be a password or dict with password
+            self._logger.finer('WLSDPLY-05011', section_dict_key, MASKED_PASSWORD,
                                class_name=_class_name, method_name=_method_name)
 
             if section_dict_key in valid_attr_infos:

--- a/core/src/main/python/wlsdeploy/yaml/yaml_translator.py
+++ b/core/src/main/python/wlsdeploy/yaml/yaml_translator.py
@@ -53,7 +53,9 @@ class YamlToPython(object):
         self._logger.entering(class_name=self._class_name, method_name=_method_name)
         # throws YamlException with details, nothing we can really add here...
         result_dict = self._translator.parse()
-        self._logger.exiting(class_name=self._class_name, method_name=_method_name, result=result_dict)
+
+        # don't log the model on exit, it may contain passwords
+        self._logger.exiting(class_name=self._class_name, method_name=_method_name)
         return result_dict
 
 


### PR DESCRIPTION
Most of these are in parsers, so too early to distinguish password attributes.
Method in validator could do more checking, but not worth it for FINER logging.
