### PR TITLE
allow asterisk in yaml for logging properties

### DIFF
--- a/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
+++ b/core/src/main/antlr4/oracle/weblogic/deploy/yaml/Yaml.g4
@@ -305,7 +305,7 @@ fragment QUOTED_ID_START
 
 fragment QUOTED_ID_CONTINUE
     : ID_CONTINUE
-    | [@#\-(){}[\]:/]
+    | [@*#\-(){}[\]:/]
     ;
 
 fragment SQUOTED_STRING_CHARS

--- a/core/src/test/resources/unit-test.yaml
+++ b/core/src/test/resources/unit-test.yaml
@@ -20,7 +20,7 @@ topology:
                     com.oracle.something: Debug
                     # Adding test case for empty property key.  Logging properties can have an empty key
                     '': Info
-                    com.oracle.something.else: Debug
+                    'com.oracle.something.else.*': Debug
         s1:
             ListenAddress: 127.0.0.1
             ListenPort: 8001


### PR DESCRIPTION
Logging properties can have an asterisk in the name.  The YAML parser needs to support names with asterisks.  This change only allows asterisks in names with quotes.  Fixes #562 

Like:
```
managed-server-1:
    Log:
        LoggerSeverityProperties:
                    'my.package.*': Debug
```