### PR TITLE
Fix operator use case when domain needs to be recreated with updated …

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -1010,11 +1010,18 @@ class DomainCreator(Creator):
             self.wlst_helper.set_if_needed(wlst_name, wlst_value)
 
             self.logger.info('WLSDPLY-12223', class_name=self.__class_name, method_name=_method_name)
+            rcu_helper = None
             if self.wls_helper.is_database_defaults_supported():
+                # Need to update the shadow table password first, so that the get_database_default will setup
+                # all the datasource parameters correctly.
+
+                if self.model_context.get_update_rcu_schema_pass() is True:
+                    rcu_helper = RCUHelper(self.model, self.model_context, self.aliases, modifyBootStrapCredential=False)
+                    rcu_helper.update_stb_password()
                 self.wlst_helper.get_database_defaults()
 
-            if self.model_context.get_update_rcu_schema_pass() is True:
-                rcu_helper = RCUHelper(self.model, self.model_context, self.aliases, modifyBootStrapCredential=False)
+            # If there is an updated rcu schema, proceed to update all other passwords
+            if rcu_helper is not None:
                 rcu_helper.update_rcu_password()
 
         self.logger.exiting(class_name=self.__class_name, method_name=_method_name)

--- a/core/src/main/python/wlsdeploy/tool/util/rcu_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/rcu_helper.py
@@ -26,6 +26,51 @@ class RCUHelper(Deployer):
         self._exception_type = ExceptionType.DEPLOY
         self._modifyBootStrapCredential = modifyBootStrapCredential
 
+    def update_stb_password(self):
+        """
+        Update the stb datasource password
+        """
+
+        _method_name = 'update_stb_password'
+
+        domain_info = self.model.get_model_domain_info()
+        if RCU_DB_INFO in domain_info:
+            rcu_db_info = RcuDbInfo(self.alias_helper, domain_info[RCU_DB_INFO])
+            rcu_schema_pass = rcu_db_info.get_rcu_schema_password()
+            rcu_prefix = rcu_db_info.get_rcu_prefix()
+
+            location = LocationContext()
+            location.append_location(JDBC_SYSTEM_RESOURCE)
+
+            folder_path = self.alias_helper.get_wlst_list_path(location)
+            self.wlst_helper.cd(folder_path)
+            rcu_schemas = [ rcu_prefix + '_STB' ]
+
+            location = LocationContext()
+            location.append_location(JDBC_SYSTEM_RESOURCE)
+            token_name = self.alias_helper.get_name_token(location)
+            location.add_name_token(token_name, 'LocalSvcTblDataSource')
+
+            location.append_location(JDBC_RESOURCE)
+            location.append_location(JDBC_DRIVER_PARAMS)
+            password_location = LocationContext(location)
+
+            wlst_path = self.alias_helper.get_wlst_attributes_path(location)
+            self.wlst_helper.cd(wlst_path)
+
+            location.append_location(JDBC_DRIVER_PARAMS_PROPERTIES)
+            token_name = self.alias_helper.get_name_token(location)
+            if token_name is not None:
+                location.add_name_token(token_name, DRIVER_PARAMS_USER_PROPERTY)
+            wlst_path = self.alias_helper.get_wlst_attributes_path(location)
+            self.wlst_helper.cd(wlst_path)
+            wlst_path = self.alias_helper.get_wlst_attributes_path(password_location)
+            self.wlst_helper.cd(wlst_path)
+            wlst_name, wlst_value = \
+                self.alias_helper.get_wlst_attribute_name_and_value(password_location, PASSWORD_ENCRYPTED,
+                                                                    rcu_schema_pass, masked=True)
+            self.wlst_helper.set(wlst_name, wlst_value, masked=True)
+
     def update_rcu_password(self):
         """
         Update the password of each rcu schema and then update the bootstrap password


### PR DESCRIPTION
This fix is to support weblogic kubernetes operator model in image use case when a domain needs to be recreated but the schema password also changed.  We need to setup the shadow table with updated credentials, call get database defaults then reset all the schema passwords before writing the domain