### PR TITLE
Issue #585 Improve error messages for token syntax errors

### DIFF
--- a/core/src/main/python/wlsdeploy/util/variables.py
+++ b/core/src/main/python/wlsdeploy/util/variables.py
@@ -209,13 +209,13 @@ def _process_node(nodes, variables, model_context):
             for member in value:
                 if type(member) in [str, unicode]:
                     index = value.index(member)
-                    value[index] = _substitute(member, variables, model_context)
+                    value[index] = _substitute(member, variables, model_context, key)
 
         elif type(value) in [str, unicode]:
-            nodes[key] = _substitute(value, variables, model_context)
+            nodes[key] = _substitute(value, variables, model_context, key)
 
 
-def _substitute(text, variables, model_context):
+def _substitute(text, variables, model_context, attribute_name=None):
     """
     Substitute token placeholders with their derived values.
     :param text: the text to process for token placeholders
@@ -287,7 +287,11 @@ def _substitute(text, variables, model_context):
             if token == "SECRET":
                 sample += ":<key>"
             sample += "@@"
-            _report_token_issue("WLSDPLY-01745", method_name, model_context, token, sample)
+
+            if attribute_name is None:
+                _report_token_issue("WLSDPLY-01745", method_name, model_context, text, sample)
+            else:
+                _report_token_issue("WLSDPLY-01746", method_name, model_context, attribute_name, text, sample)
 
     return text
 

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -302,7 +302,8 @@ WLSDPLY-01740=Encryption failed: Unable to locate SerializedSystemIni
 WLSDPLY-01741=Encryption failed: Unable to initialize encryption service
 
 # wlsdeploy/util/variables.py (cont'd)
-WLSDPLY-01745=Invalid syntax for token {0}, should be "{1}"
+WLSDPLY-01745=Invalid token syntax for name "{0}", should match "{1}"
+WLSDPLY-01746=Invalid token syntax for {0} value "{1}", should match "{2}"
 
 # oracle.weblogic.deploy.util.WebLogicDeployToolingVersion.java (in src/main/resources/templates)
 WLSDPLY-01750=The WebLogic Deploy Tooling {0} version is {1}


### PR DESCRIPTION
Fixes #585 

Revised message examples:
```
<WLSDPLY-01746> <Invalid token syntax for ProductionModeEnabled value "@@PROP: ProductionModeEnabled@@", should match "@@PROP:<name>@@">

<WLSDPLY-01745> <Invalid token syntax for name "@@PROP: my-cluster", should match "@@PROP:<name>@@"
```