### PR TITLE
Allow PyOrderedDict to work in Jython 2.7

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
@@ -519,6 +519,8 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
                 break;
 
             case "PyOrderedDict":
+            case "oracle.weblogic.deploy.util.PyOrderedDict":
+                // Jython 2.7 uses qualified class name
                 PyOrderedDict origOrderedDict = PyOrderedDict.class.cast(orig);
                 result = origOrderedDict.__deepcopy__(memo);
                 break;

--- a/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
@@ -347,7 +347,7 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
         for (Map.Entry<PyObject, PyObject> entry: entries) {
             l.add(new PyTuple(new PyObject[] { entry.getKey(), entry.getValue() }));
         }
-        return new PyList(l);
+        return new PyList(l.toArray(new PyObject[0]));
     }
 
     /**
@@ -390,7 +390,7 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
         Set<PyObject> keys = this.linkedHashMap.keySet();
         java.util.Vector<PyObject> v = new java.util.Vector<>(keys.size());
         v.addAll(keys);
-        return new PyList(v);
+        return new PyList(v.toArray(new PyObject[0]));
     }
 
     /**
@@ -461,7 +461,7 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
         Collection<PyObject> values = this.linkedHashMap.values();
         java.util.Vector<PyObject> v = new java.util.Vector<>(values.size());
         v.addAll(values);
-        return new PyList(v);
+        return new PyList(v.toArray(new PyObject[0]));
     }
 
     // private methods

--- a/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
@@ -41,6 +41,7 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
      * The no-args constructor.
      */
     public PyOrderedDict() {
+        super(PyType.fromClass(PyOrderedDict.class));
         this.linkedHashMap = new LinkedHashMap<>();
     }
 

--- a/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
@@ -455,9 +455,22 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
 
     /**
      * {@inheritDoc}
+     * This method is not supported, as it is not portable between versions of Jython.
+     * Jython 2.1 returns PyList, Jython 2.7 returns a Collection.
+     * WDT code should use getValues() to get ordered values.
      */
     @Override
     public PyList values() {
+        String message = ExceptionHelper.getMessage("WLSDPLY-01252");
+        throw new UnsupportedOperationException(message);
+    }
+
+    /**
+     * Because return type for values() is different between Jython 2.1 and Jython 2.7,
+     * WDT code should call this variant to get a list of values.
+     * @return an ordered list of values
+     */
+    public PyList getValues() {
         Collection<PyObject> values = this.linkedHashMap.values();
         java.util.Vector<PyObject> v = new java.util.Vector<>(values.size());
         v.addAll(values);

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -150,6 +150,7 @@ WLSDPLY-01208=Process for command {0} drainer thread failed: {1}
 # oracle.weblogic.deploy.util.PyOrderedDict.java
 WLSDPLY-01250="The memo argument was an instance of class {0} instead of an instance of class {1}"
 WLSDPLY-01251=While doing deepcopy of a PyOrderedDict, encountered unexpected type {0} that will not be copied
+WLSDPLY-01252=Use PyOrderedDict.getValues() instead of .values() for Jython version portability
 
 # oracle.weblogic.deploy.util.ScriptRunner.java
 WLSDPLY-01300=Executing {0}: {1}

--- a/core/src/test/python/collections_test.py
+++ b/core/src/test/python/collections_test.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import copy
@@ -42,7 +42,7 @@ class CollectionsTestCase(unittest.TestCase):
         my_ordered_dict['nba_finals_years'] = ['2015', '2016', '2017']
 
         expected_values = ['Steph Curry', 1, False, ['2015', '2016', '2017']]
-        values = my_ordered_dict.values()
+        values = my_ordered_dict.getValues()
         self.assertEqual(len(expected_values), len(values),
                          'expected the ordered dict values to be the same length as the expected values')
         for i, value in enumerate(values):
@@ -212,7 +212,7 @@ class CollectionsTestCase(unittest.TestCase):
         for key in sorted_keys:
             sorted_dict[key] = dict1[key]
 
-        self.assertEqual(sorted_dict.values()[-1], '8100',
+        self.assertEqual(sorted_dict.getValues()[-1], '8100',
                          'expected dictionary to be sorted by name')
 
 

--- a/core/src/test/python/collections_test.py
+++ b/core/src/test/python/collections_test.py
@@ -165,8 +165,6 @@ class CollectionsTestCase(unittest.TestCase):
         dict1['entry1'] = 'you'
         dict2 = OrderedDict()
         dict2['entry2'] = 'me'
-        print 'Before: OrderedDict() dict1=', dict1
-        print '        OrderedDict() dict2=', dict2
         dict1.update(dict2)
         self.assertEqual('entry1' in dict1 and 'entry2' in dict1, True,
                          "expected ordereddict1 to contain 'entry1' and 'entry2' keys")
@@ -176,9 +174,6 @@ class CollectionsTestCase(unittest.TestCase):
         dict1['entry1'] = 'you'
         dict2 = dict()
         dict2['entry2'] = 'me'
-        print 'Before: OrderedDict() dict1=', dict1
-        print '               dict() dict2=', dict2
-        print
         dict1.update(dict2)
         self.assertEqual('entry1' in dict1 and 'entry2' in dict1, True,
                          "expected ordereddict1 to contain 'entry1' and 'entry2' keys")
@@ -188,9 +183,6 @@ class CollectionsTestCase(unittest.TestCase):
         dict1['entry1'] = 'you'
         dict2 = OrderedDict()
         dict2['entry2'] = 'me'
-        print 'Before:         dict() dict1=', dict1
-        print '         OrderedDict() dict2=', dict2
-        print
         dict1.update(dict2)
         self.assertEqual('entry1' in dict1 and 'entry2' in dict1, True,
                          "expected ordereddict1 to contain 'entry1' and 'entry2' keys")

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
                 <plugin>
                     <groupId>io.rhpatrick.mojo</groupId>
                     <artifactId>wlst-test-maven-plugin</artifactId>
-                    <version>1.0.3</version>
+                    <version>1.0.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+    Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
     Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
In Jython 2.7, PyDictionary subclasses must set the type field in the parent class through the PyDictionary constructor.