### PR TITLE
Rmarano

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ The following table specifies the supported WebLogic Server versions, along with
   |--------------------------|-------------------|
   | 10.3.6                   | 1.7               |
   | 12.1.1                   | 1.7, 1.8          |
-  | 12.1.2 [^1][^2]         | 1.7, 1.8          |
+  | 12.1.2 <sup>[1]</sup><sup>[2]</sup>         | 1.7, 1.8          |
   | 12.1.3                   | 1.7, 1.8          |
-  | 12.2.1 [^3]               | 1.8               |
-  | 12.2.1.1 [^4]             | 1.8               |
+  | 12.2.1 <sup>[3]</sup>               | 1.8               |
+  | 12.2.1.1 <sup>[4]</sup>             | 1.8               |
   | 12.2.1.2                 | 1.8               |
   | 12.2.1.3                 | 1.8               |
-  | 12.2.1.4 [^5]  | 1.8               |
+  | 12.2.1.4 <sup>[5]</sup>  | 1.8               |
   | 14.1.1                   | 1.8, 1.11         |    
 
-[^1]: First release dynamic clusters are supported  
-[^2]: First release Coherence clusters are supported  
-[^3]: First release WLS roles are supported  
-[^4]: First release multitenancy is supported  
-[^5]: Last release multitenancy is supported
+***1*** First release dynamic clusters are supported  
+***2*** First release Coherence clusters are supported  
+***3*** First release WLS roles are supported  
+***4*** First release multitenancy is supported  
+***5*** Last release multitenancy is supported
 
 ### Metadata model
 The metadata model, described in detail in the next section, is WebLogic Server version and WLST mode independent.  As such, a metadata model written for an earlier version of WebLogic Server is designed to work with a newer version.  There is no need to port your metadata model as part of the upgrade process.  Of course, you may wish to add data to your metadata model to take advantage of new features in newer versions of WebLogic Server.

--- a/README.md
+++ b/README.md
@@ -45,31 +45,31 @@ The Oracle WebLogic Server Deploy Tooling is designed to support a wide range of
 - The differences between WLST online and WLST offline for working with folders and attributes
 
 ### Supported WebLogic Server Versions
-The following table specifies the supported WebLogic Server versions, along with the JDK versions that must be used to run the WDT tool. You must set the `JAVA_HOME` environment variable to specify a JDK version different than the system default version. 
+The following table specifies the supported WebLogic Server versions, along with the JDK versions, that must be used to run the WDT tool. You must set the `JAVA_HOME` environment variable to specify a JDK version different from the system default version.
 
- To create a domain with the proper JDK (particularly if the `JAVA_HOME` is different than the one which will be used by the target domain), set the domain `JavaHome` attribute in the domain model.
- 
- Note that the WDT Encryption tool used to encrypt and decrypt clear text passwords in the model and variable file, requires WDT to run with a minimum JDK version of 1.8. 
+ To create a domain with the proper JDK (particularly if the `JAVA_HOME` is different from the one which will be used by the target domain), set the domain `JavaHome` attribute in the domain model.
 
-  | WebLogic Server Versions | Tool JDK Versions |
+ Note that the WDT Encryption Model Tool used to encrypt and decrypt clear text passwords in the model and variable files, requires WDT to run with a minimum JDK version of 1.8.
+
+  | WebLogic Server Version | Tool JDK Version |
   |--------------------------|-------------------|
   | 10.3.6                   | 1.7               |
   | 12.1.1                   | 1.7, 1.8          |
-  | 12.1.2 <sup>[1]</sup> <sup>[2]</sup>         | 1.7, 1.8          |
+  | 12.1.2 [^1][^2]         | 1.7, 1.8          |
   | 12.1.3                   | 1.7, 1.8          |
-  | 12.2.1 <sup>[3]</sup>               | 1.8               |
-  | 12.2.1.1 <sup>[4]</sup>             | 1.8               |
+  | 12.2.1 [^3]               | 1.8               |
+  | 12.2.1.1 [^4]             | 1.8               |
   | 12.2.1.2                 | 1.8               |
   | 12.2.1.3                 | 1.8               |
-  | 12.2.1.4 <sup>[5]</sup>  | 1.8               |
+  | 12.2.1.4 [^5]  | 1.8               |
   | 14.1.1                   | 1.8, 1.11         |    
-  
-***1*** First release dynamic clusters are supported  
-***2*** First release Coherence clusters are supported  
-***3*** First release WLS roles are supported  
-***4*** First release multitenancy is supported  
-***5*** Last release multitenancy is supported
-             
+
+[^1]: First release dynamic clusters are supported  
+[^2]: First release Coherence clusters are supported  
+[^3]: First release WLS roles are supported  
+[^4]: First release multitenancy is supported  
+[^5]: Last release multitenancy is supported
+
 ### Metadata model
 The metadata model, described in detail in the next section, is WebLogic Server version and WLST mode independent.  As such, a metadata model written for an earlier version of WebLogic Server is designed to work with a newer version.  There is no need to port your metadata model as part of the upgrade process.  Of course, you may wish to add data to your metadata model to take advantage of new features in newer versions of WebLogic Server.
 
@@ -213,7 +213,7 @@ The file `/home/me/dbcs1.txt` would then contain this single line:
 ```yaml
 password#123
 ```
-As the model is processed, the value for the `PasswordEncrypted` would resolve to `password#123`. It is also possible to combine file placeholders with other types of tokens, to allow for variations in the name and location of the file, such as: 
+As the model is processed, the value for the `PasswordEncrypted` would resolve to `password#123`. It is also possible to combine file placeholders with other types of tokens, to allow for variations in the name and location of the file, such as:
 ```yaml
 PasswordEncrypted: '@@FILE:/dir/@@PROP:name@@.txt@@'
 ```
@@ -231,14 +231,14 @@ The root directories are configured as a comma-separated list of directories, us
 ```
 /etc/my-secrets/secrets/the-secret
 /etc/your-secrets/secrets/the-secret
-``` 
+```
 If either of these files is found, the secret is read from that file and substituted in the model.
 
-The second method for locating the Kubernetes secret file is to use the environment variable `WDT_MODEL_SECRETS_NAME_DIR_PAIRS` to map `<name>` values to specific directory locations. For example, if `WDT_MODEL_SECRETS_NAME_DIR_PAIRS` is set to `my-root=/etc/my-secrets,your-root=/etc/your-secrets`, then the token `@@SECRET:your-root:the-secret@@` will look for the secrets file at: 
+The second method for locating the Kubernetes secret file is to use the environment variable `WDT_MODEL_SECRETS_NAME_DIR_PAIRS` to map `<name>` values to specific directory locations. For example, if `WDT_MODEL_SECRETS_NAME_DIR_PAIRS` is set to `my-root=/etc/my-secrets,your-root=/etc/your-secrets`, then the token `@@SECRET:your-root:the-secret@@` will look for the secrets file at:
 ```
 /etc/your-secrets/the-secret
 ```
-If the `<name>` value has a corresponding mapped directory in `WDT_MODEL_SECRETS_NAME_DIR_PAIRS`, then that directory will take precedence over any roots specified in `WDT_MODEL_SECRETS_DIRS`. 
+If the `<name>` value has a corresponding mapped directory in `WDT_MODEL_SECRETS_NAME_DIR_PAIRS`, then that directory will take precedence over any roots specified in `WDT_MODEL_SECRETS_DIRS`.
 
 NOTE: It is important that the secrets directories contain only secrets files, because those files are examined to create a list of available name/key pairs.  
 
@@ -341,7 +341,7 @@ For example, if Model 1 looks like:
 topology:
     Server:
         m1:
-            ListenPort: 7000 
+            ListenPort: 7000
             Notes: "Server 1"
         m2:
             ListenPort: 9000
@@ -379,7 +379,7 @@ A named element using [delete notation](#declaring-named-mbeans-to-delete) will 
 topology:
     Server:
         m1:
-            ListenPort: 7000 
+            ListenPort: 7000
             Notes: "Server 1"
         m2:
             ListenPort: 9000
@@ -395,7 +395,7 @@ The resulting model would be:
 topology:
     Server:
         m1:
-            ListenPort: 7000 
+            ListenPort: 7000
             Notes: "Server 1"
 ```
 
@@ -410,7 +410,7 @@ and Model 2 looks like:
 topology:
     Server:
         m1:
-            ListenPort: 7000 
+            ListenPort: 7000
             Notes: "Server 1"
 ```
 The resulting model would be:
@@ -418,7 +418,7 @@ The resulting model would be:
 topology:
     Server:
         m1:
-            ListenPort: 7000 
+            ListenPort: 7000
             Notes: "Server 1"
 ```
 


### PR DESCRIPTION
Specified markdown for hot links [^1], [^1]:, did not appear to work. Made a few other edits but kept Carolyn's table footnotes.