### PR TITLE
fix the collection and extraction of foreign connection binding files

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/model_constants.py
+++ b/core/src/main/python/wlsdeploy/aliases/model_constants.py
@@ -8,6 +8,8 @@ MODEL_LIST_DELIMITER = ','
 KSS_KEYSTORE_TYPE = 'kss'
 KSS_KEYSTORE_FILE_INDICATOR = 'kss:'
 
+# names used within model attributes
+FILE_URI = 'file:///'
 
 # names of model elements, alphabetically
 

--- a/core/src/main/python/wlsdeploy/tool/deploy/deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/deployer.py
@@ -178,6 +178,7 @@ class Deployer(object):
             if key in attribute_names and not key_excluded:
                 value = model_nodes[key]
                 if key in uses_path_tokens_attribute_names:
+                    value = deployer_utils.extract_from_uri(self.model_context, value)
                     self._extract_from_archive_if_needed(location, key, value)
 
                 wlst_merge_value = None
@@ -336,9 +337,10 @@ class Deployer(object):
 
         self.logger.entering(str(location), key, value, class_name=self._class_name, method_name=_method_name)
         result = False
-        if deployer_utils.is_path_into_archive(value):
+        short_value = deployer_utils.get_rel_path_from_uri(self.model_context, value)
+        if deployer_utils.is_path_into_archive(short_value):
             if self.archive_helper is not None:
-                result = self.__process_archive_entry(location, key, value)
+                result = self.__process_archive_entry(location, key, short_value)
             else:
                 path = self.alias_helper.get_model_folder_path(location)
                 ex = exception_helper.create_deploy_exception('WLSDPLY-09110', key, path, value)

--- a/core/src/main/python/wlsdeploy/tool/deploy/deployer_utils.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/deployer_utils.py
@@ -264,9 +264,9 @@ def get_rel_path_from_uri(model_context, path_value):
     uri = URI(path_value)
     if uri.getScheme() == 'file':
         value = model_context.tokenize_path(uri.getPath())
-        if value.startswith('@@DOMAIN_HOME@@'):
+        if value.startswith(model_context.DOMAIN_HOME_TOKEN):
             # point past the token and first slash
-            value = value[len('@@DOMAIN_HOME@@')+1:]
+            value = value[len(model_context.DOMAIN_HOME_TOKEN)+1:]
         return value
     return path_value
 

--- a/core/src/main/python/wlsdeploy/tool/discover/jms_resources_discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/jms_resources_discoverer.py
@@ -10,6 +10,7 @@ from oracle.weblogic.deploy.util import WLSDeployArchiveIOException
 
 from wlsdeploy.aliases import model_constants
 from wlsdeploy.aliases.location_context import LocationContext
+from wlsdeploy.aliases.model_constants import FILE_URI
 from wlsdeploy.aliases.wlst_modes import WlstModes
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.discover import discoverer
@@ -332,10 +333,12 @@ class JmsResourcesDiscoverer(Discoverer):
                 else:
                     group_param_name = attributes[wlst_subdeployment]
                     if group_param_name is None:
-                        _logger.warning('WLSDPLY-06486', folder_name, self._alias_helper.get_model_folder_path(location),
+                        _logger.warning('WLSDPLY-06486', folder_name,
+                                        self._alias_helper.get_model_folder_path(location),
                                         class_name=_class_name, method_name=_method_name)
                     else:
-                        _logger.finer('WLSDPLY-06487', group_param_name, self._alias_helper.get_model_folder_path(location),
+                        _logger.finer('WLSDPLY-06487', group_param_name,
+                                      self._alias_helper.get_model_folder_path(location),
                                       class_name=_class_name, method_name=_method_name)
                         subfolder_result[group_param_name] = OrderedDict()
                         self._populate_model_parameters(subfolder_result[group_param_name], location)
@@ -401,6 +404,7 @@ class JmsResourcesDiscoverer(Discoverer):
                 _logger.finer('WLSDPLY-06495', server_name, file_name, class_name=_class_name, method_name=_method_name)
                 try:
                     new_name = archive_file.addForeignServerFile(server_name, File(file_name))
+                    new_name = FILE_URI + self._model_context.tokenize_path(self._convert_path(new_name))
                     _logger.info('WLSDPLY-06492', server_name, file_name, new_name, class_name=_class_name,
                                  method_name=_method_name)
                 except (IllegalArgumentException, WLSDeployArchiveIOException), wioe:

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -22,12 +22,12 @@ class ModelContext(object):
     """
     _class_name = "ModelContext"
 
-    __ORACLE_HOME_TOKEN = '@@ORACLE_HOME@@'
-    __WL_HOME_TOKEN = '@@WL_HOME@@'
-    __DOMAIN_HOME_TOKEN = '@@DOMAIN_HOME@@'
-    __JAVA_HOME_TOKEN = '@@JAVA_HOME@@'
-    __CURRENT_DIRECTORY_TOKEN = '@@PWD@@'
-    __TEMP_DIRECTORY_TOKEN = '@@TMP@@'
+    ORACLE_HOME_TOKEN = '@@ORACLE_HOME@@'
+    WL_HOME_TOKEN = '@@WL_HOME@@'
+    DOMAIN_HOME_TOKEN = '@@DOMAIN_HOME@@'
+    JAVA_HOME_TOKEN = '@@JAVA_HOME@@'
+    CURRENT_DIRECTORY_TOKEN = '@@PWD@@'
+    TEMP_DIRECTORY_TOKEN = '@@TMP@@'
 
     def __init__(self, program_name, arg_map):
         """
@@ -637,12 +637,12 @@ class ModelContext(object):
         :param path: the path to check for token prefix
         :return: true if the path begins with a known prefix, false otherwise
         """
-        return path.startswith(self.__ORACLE_HOME_TOKEN) or \
-            path.startswith(self.__WL_HOME_TOKEN) or \
-            path.startswith(self.__DOMAIN_HOME_TOKEN) or \
-            path.startswith(self.__JAVA_HOME_TOKEN) or \
-            path.startswith(self.__CURRENT_DIRECTORY_TOKEN) or \
-            path.startswith(self.__TEMP_DIRECTORY_TOKEN)
+        return path.startswith(self.ORACLE_HOME_TOKEN) or \
+            path.startswith(self.WL_HOME_TOKEN) or \
+            path.startswith(self.DOMAIN_HOME_TOKEN) or \
+            path.startswith(self.JAVA_HOME_TOKEN) or \
+            path.startswith(self.CURRENT_DIRECTORY_TOKEN) or \
+            path.startswith(self.TEMP_DIRECTORY_TOKEN)
 
     def replace_tokens(self, resource_type, resource_name, attribute_name, resource_dict):
         """
@@ -653,43 +653,44 @@ class ModelContext(object):
         :param resource_dict: the dictionary to use to lookup and replace the attribute value
         """
         attribute_value = resource_dict[attribute_name]
+        uri = URI(attribute_value)
         if uri.getScheme().startsWith('file'):
             attribute_value = uri.getPath()
-        if attribute_value.startswith(self.__ORACLE_HOME_TOKEN):
+        if attribute_value.startswith(self.ORACLE_HOME_TOKEN):
             message = "Replacing {0} in {1} {2} {3} with {4}"
-            self._logger.fine(message, self.__ORACLE_HOME_TOKEN, resource_type, resource_name, attribute_name,
+            self._logger.fine(message, self.ORACLE_HOME_TOKEN, resource_type, resource_name, attribute_name,
                               self.get_oracle_home(), class_name=self._class_name, method_name='_replace_tokens')
-            resource_dict[attribute_name] = attribute_value.replace(self.__ORACLE_HOME_TOKEN,
+            resource_dict[attribute_name] = attribute_value.replace(self.ORACLE_HOME_TOKEN,
                                                                     self.get_oracle_home())
-        elif attribute_value.startswith(self.__WL_HOME_TOKEN):
+        elif attribute_value.startswith(self.WL_HOME_TOKEN):
             message = "Replacing {0} in {1} {2} {3} with {4}"
-            self._logger.fine(message, self.__WL_HOME_TOKEN, resource_type, resource_name, attribute_name,
+            self._logger.fine(message, self.WL_HOME_TOKEN, resource_type, resource_name, attribute_name,
                               self.get_wl_home(), class_name=self._class_name, method_name='_replace_tokens')
-            resource_dict[attribute_name] = attribute_value.replace(self.__WL_HOME_TOKEN, self.get_wl_home())
-        elif attribute_value.startswith(self.__DOMAIN_HOME_TOKEN):
+            resource_dict[attribute_name] = attribute_value.replace(self.WL_HOME_TOKEN, self.get_wl_home())
+        elif attribute_value.startswith(self.DOMAIN_HOME_TOKEN):
             message = "Replacing {0} in {1} {2} {3} with {4}"
-            self._logger.fine(message, self.__DOMAIN_HOME_TOKEN, resource_type, resource_name, attribute_name,
+            self._logger.fine(message, self.DOMAIN_HOME_TOKEN, resource_type, resource_name, attribute_name,
                               self.get_domain_home(), class_name=self._class_name, method_name='_replace_tokens')
-            resource_dict[attribute_name] = attribute_value.replace(self.__DOMAIN_HOME_TOKEN,
+            resource_dict[attribute_name] = attribute_value.replace(self.DOMAIN_HOME_TOKEN,
                                                                     self.get_domain_home())
-        elif attribute_value.startswith(self.__JAVA_HOME_TOKEN):
+        elif attribute_value.startswith(self.JAVA_HOME_TOKEN):
             message = "Replacing {0} in {1} {2} {3} with {4}"
-            self._logger.fine(message, self.__JAVA_HOME_TOKEN, resource_type, resource_name, attribute_name,
+            self._logger.fine(message, self.JAVA_HOME_TOKEN, resource_type, resource_name, attribute_name,
                               self.get_domain_home(), class_name=self._class_name, method_name='_replace_tokens')
-            resource_dict[attribute_name] = attribute_value.replace(self.__JAVA_HOME_TOKEN,
+            resource_dict[attribute_name] = attribute_value.replace(self.JAVA_HOME_TOKEN,
                                                                     self.get_java_home())
-        elif attribute_value.startswith(self.__CURRENT_DIRECTORY_TOKEN):
+        elif attribute_value.startswith(self.CURRENT_DIRECTORY_TOKEN):
             cwd = path_utils.fixup_path(os.getcwd())
             message = "Replacing {0} in {1} {2} {3} with {4}"
-            self._logger.fine(message, self.__CURRENT_DIRECTORY_TOKEN, resource_type, resource_name,
+            self._logger.fine(message, self.CURRENT_DIRECTORY_TOKEN, resource_type, resource_name,
                               attribute_name, cwd, class_name=self._class_name, method_name='_replace_tokens')
-            resource_dict[attribute_name] = attribute_value.replace(self.__CURRENT_DIRECTORY_TOKEN, cwd)
-        elif attribute_value.startswith(self.__TEMP_DIRECTORY_TOKEN):
+            resource_dict[attribute_name] = attribute_value.replace(self.CURRENT_DIRECTORY_TOKEN, cwd)
+        elif attribute_value.startswith(self.TEMP_DIRECTORY_TOKEN):
             temp_dir = path_utils.fixup_path(tempfile.gettempdir())
             message = "Replacing {0} in {1} {2} {3} with {4}"
-            self._logger.fine(message, self.__TEMP_DIRECTORY_TOKEN, resource_type, resource_name, attribute_name,
+            self._logger.fine(message, self.TEMP_DIRECTORY_TOKEN, resource_type, resource_name, attribute_name,
                               temp_dir, class_name=self._class_name, method_name='_replace_tokens')
-            resource_dict[attribute_name] = attribute_value.replace(self.__TEMP_DIRECTORY_TOKEN, temp_dir)
+            resource_dict[attribute_name] = attribute_value.replace(self.TEMP_DIRECTORY_TOKEN, temp_dir)
 
         return
 
@@ -701,18 +702,18 @@ class ModelContext(object):
         """
         if string_value is None:
             result = None
-        elif string_value.startswith(self.__ORACLE_HOME_TOKEN):
-            result = _replace(string_value, self.__ORACLE_HOME_TOKEN, self.get_oracle_home())
-        elif string_value.startswith(self.__WL_HOME_TOKEN):
-            result = _replace(string_value, self.__WL_HOME_TOKEN, self.get_wl_home())
-        elif string_value.startswith(self.__DOMAIN_HOME_TOKEN):
-            result = _replace(string_value, self.__DOMAIN_HOME_TOKEN, self.get_domain_home())
-        elif string_value.startswith(self.__JAVA_HOME_TOKEN):
-            result = _replace(string_value, self.__JAVA_HOME_TOKEN, self.get_java_home())
-        elif string_value.startswith(self.__CURRENT_DIRECTORY_TOKEN):
-            result = _replace(string_value, self.__CURRENT_DIRECTORY_TOKEN, path_utils.fixup_path(os.getcwd()))
-        elif string_value.startswith(self.__TEMP_DIRECTORY_TOKEN):
-            result = _replace(string_value, self.__TEMP_DIRECTORY_TOKEN, path_utils.fixup_path(tempfile.gettempdir()))
+        elif string_value.startswith(self.ORACLE_HOME_TOKEN):
+            result = _replace(string_value, self.ORACLE_HOME_TOKEN, self.get_oracle_home())
+        elif string_value.startswith(self.WL_HOME_TOKEN):
+            result = _replace(string_value, self.WL_HOME_TOKEN, self.get_wl_home())
+        elif string_value.startswith(self.DOMAIN_HOME_TOKEN):
+            result = _replace(string_value, self.DOMAIN_HOME_TOKEN, self.get_domain_home())
+        elif string_value.startswith(self.JAVA_HOME_TOKEN):
+            result = _replace(string_value, self.JAVA_HOME_TOKEN, self.get_java_home())
+        elif string_value.startswith(self.CURRENT_DIRECTORY_TOKEN):
+            result = _replace(string_value, self.CURRENT_DIRECTORY_TOKEN, path_utils.fixup_path(os.getcwd()))
+        elif string_value.startswith(self.TEMP_DIRECTORY_TOKEN):
+            result = _replace(string_value, self.TEMP_DIRECTORY_TOKEN, path_utils.fixup_path(tempfile.gettempdir()))
         else:
             result = string_value
 
@@ -738,17 +739,17 @@ class ModelContext(object):
         result = my_path
         if not string_utils.is_empty(my_path):
             if wl_home is not None and my_path.startswith(wl_home):
-                result = my_path.replace(wl_home, self.__WL_HOME_TOKEN)
+                result = my_path.replace(wl_home, self.WL_HOME_TOKEN)
             elif domain_home is not None and my_path.startswith(domain_home):
-                result = my_path.replace(domain_home, self.__DOMAIN_HOME_TOKEN)
+                result = my_path.replace(domain_home, self.DOMAIN_HOME_TOKEN)
             elif oracle_home is not None and my_path.startswith(oracle_home):
-                result = my_path.replace(oracle_home, self.__ORACLE_HOME_TOKEN)
+                result = my_path.replace(oracle_home, self.ORACLE_HOME_TOKEN)
             elif java_home is not None and my_path.startswith(java_home):
-                result = my_path.replace(java_home, self.__JAVA_HOME_TOKEN)
+                result = my_path.replace(java_home, self.JAVA_HOME_TOKEN)
             elif my_path.startswith(cwd):
-                result = my_path.replace(cwd, self.__CURRENT_DIRECTORY_TOKEN)
+                result = my_path.replace(cwd, self.CURRENT_DIRECTORY_TOKEN)
             elif my_path.startswith(tmp_dir):
-                result = my_path.replace(tmp_dir, self.__TEMP_DIRECTORY_TOKEN)
+                result = my_path.replace(tmp_dir, self.TEMP_DIRECTORY_TOKEN)
 
         return result
 

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -5,6 +5,8 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 import os
 import tempfile
 
+import java.net.URI as URI
+
 from wlsdeploy.aliases.wlst_modes import WlstModes
 from wlsdeploy.logging import platform_logger
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
@@ -610,7 +612,8 @@ class ModelContext(object):
         :param resource_dict: the dictionary to use to lookup and replace the attribute value
         """
         separator = ':'
-        path_elements = resource_dict[attribute_name].split(':')
+        attribute_value = resource_dict[attribute_name]
+        path_elements = attribute_value.split(':')
         semicolon_path_elements = resource_dict[attribute_name].split(';')
         if len(semicolon_path_elements) > len(path_elements):
             separator = ';'
@@ -650,6 +653,8 @@ class ModelContext(object):
         :param resource_dict: the dictionary to use to lookup and replace the attribute value
         """
         attribute_value = resource_dict[attribute_name]
+        if uri.getScheme().startsWith('file'):
+            attribute_value = uri.getPath()
         if attribute_value.startswith(self.__ORACLE_HOME_TOKEN):
             message = "Replacing {0} in {1} {2} {3} with {4}"
             self._logger.fine(message, self.__ORACLE_HOME_TOKEN, resource_type, resource_name, attribute_name,


### PR DESCRIPTION
Issue #525 requested that WDT collect the MQ Bindings for foreign jms connections. The tool was already collecting, but the resulting MBean attribute in createDomain was not valid. This fix corrects the problem.

The issue requested that the files be collected under domainHome in the archive file, along with other application files. Please review to see if there is additional work to be done.

The MQBindings are collected in wlsdeploy/jms/foreignServer/name of foreign server/