### PR TITLE
Change guava version and run system tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>19.0</version>
+                <version>24.1.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>24.1.1</version>
+                <version>29.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Guava version is used as comparator in system test. Tested WDT in addition to running system test.