### PR TITLE
Wdt 427 wdt support graal

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/alias_utils.py
+++ b/core/src/main/python/wlsdeploy/aliases/alias_utils.py
@@ -111,7 +111,7 @@ def merge_model_and_existing_properties(model_props, existing_props, string_prop
             result = _properties_to_string(existing_props, string_props_separator_char)
     else:
         model_props_is_string = False
-        if type(model_props) is str:
+        if type(model_props) in [str, unicode]:
             model_props_is_string = True
             model_properties = _string_to_properties(model_props, string_props_separator_char)
         elif TypeUtils.isInstanceOfClass(Properties().getClass(), model_props):
@@ -121,7 +121,7 @@ def merge_model_and_existing_properties(model_props, existing_props, string_prop
             _logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
 
-        if type(existing_props) is str:
+        if type(existing_props) in [str, unicode]:
             existing_properties = _string_to_properties(existing_props, string_props_separator_char)
         elif TypeUtils.isInstanceOfClass(Properties().getClass(), existing_props):
             existing_properties = existing_props
@@ -1118,7 +1118,7 @@ def _create_set(list_item, string_list_separator_char, message_key):
     _method_name = '_create_set'
 
     item_type = type(list_item)
-    if item_type is str:
+    if item_type in [str, unicode]:
         item_set = Set([x.strip() for x in list_item.split(string_list_separator_char)])
     elif item_type is list or item_type is array:
         item_set = Set(list_item)

--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -553,7 +553,7 @@ class ApplicationsDeployer(Deployer):
                     model_src_path = dictionary_utils.get_element(lib_dict, SOURCE_PATH)
                     model_targets = dictionary_utils.get_element(lib_dict, TARGET)
                     # Model Target could be a comma-delimited string or a list...
-                    if type(model_targets) is str:
+                    if type(model_targets) in [str, unicode]:
                         model_targets = model_targets.split(',')
 
                     existing_lib_targets = dictionary_utils.get_element(existing_lib_ref, 'target')

--- a/core/src/main/python/wlsdeploy/tool/deploy/deployer_utils.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/deployer_utils.py
@@ -154,7 +154,7 @@ def merge_lists(existing_list, model_list, separator=',', return_as_string=True)
     method_name = 'merge_lists'
     _logger.entering(existing_list, model_list, separator, return_as_string, _class_name, method_name)
     if existing_list is not None and len(existing_list) > 0:
-        if type(existing_list) is str:
+        if type(existing_list) in [str, unicode]:
             existing_set = Set(existing_list.split(separator))
         else:
             existing_set = Set(existing_list)
@@ -162,7 +162,7 @@ def merge_lists(existing_list, model_list, separator=',', return_as_string=True)
         existing_set = Set()
 
     if model_list is not None and len(model_list) > 0:
-        if type(model_list) is str:
+        if type(model_list) in [str, unicode]:
             model_set = Set(model_list.split(separator))
         else:
             model_set = Set(model_list)

--- a/core/src/main/python/wlsdeploy/tool/util/wlst_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/wlst_helper.py
@@ -3,6 +3,8 @@ Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 
+import types
+
 import com.oracle.cie.domain.script.jython.WLSTException as offlineWLSTException
 import oracle.weblogic.deploy.util.StringUtils as StringUtils
 import weblogic.management.mbeanservers.edit.ValidationException as ValidationException
@@ -430,7 +432,7 @@ class WlstHelper(object):
             for entry in result.entrySet():
                 key = entry.getKey()
                 value = entry.getValue()
-                if value and type(value) is str:
+                if value and type(value) in [str, unicode]:
                     new_value = value.rstrip()
                     if new_value == 'null' or new_value == 'none':
                         make_dict[key] = None

--- a/installer/src/main/bin/shared.sh
+++ b/installer/src/main/bin/shared.sh
@@ -42,6 +42,7 @@ javaSetup() {
     esac
 
     JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
+
     # set JVM version to the major version, unless equal to 1, like 1.8.0, then use the minor version
     JVM_VERSION=`echo ${JVM_FULL_VERSION} | awk -F"." '{ print $1 }'`
 

--- a/installer/src/main/bin/shared.sh
+++ b/installer/src/main/bin/shared.sh
@@ -34,12 +34,22 @@ javaSetup() {
     fi
 
     JVM_OUTPUT=`${JAVA_EXE} -version 2>&1`
+
     case "${JVM_OUTPUT}" in
+      *GraalVM*)
+        setOracleVersion
+        if [ -z "${ORACLE_VERSION}" ] || [ ${ORACLE_VER_ONE} -lt 14 ] || [ ${ORACLE_VER_ONE} -eq 14 ] && [ ${ORACLE_VER_THREE} -lt 2 ]; then
+          echo "JAVA_HOME ${JAVA_HOME} contains GraalVM OpenJDK, which is not supported before 14.1.2" >&2
+          exit 2
+        fi
+        ;;
       *OpenJDK*)
         echo "JAVA_HOME ${JAVA_HOME} contains OpenJDK, which is not supported" >&2
         exit 2
         ;;
+
     esac
+
 
     JVM_FULL_VERSION=`${JAVA_EXE} -fullversion 2>&1 | awk -F"\"" '{ print $2 }'`
 
@@ -56,6 +66,13 @@ javaSetup() {
     else
       echo "JDK version is ${JVM_FULL_VERSION}"
     fi
+}
+
+setOracleVersion() {
+  ORACLE_VERSION=`${JAVA_HOME}/bin/java -cp $ORACLE_HOME/wlserver/server/lib/weblogic.jar weblogic.version | grep "WebLogic Server" | cut -d " " -f3 2>&1`
+  ORACLE_VER_ONE=`echo ${ORACLE_VERSION} | cut -d "." -f1`
+  ORACLE_VER_THREE=`echo ${ORACLE_VERSION} | cut -d "." -f3`
+  echo ORACLE_VERSION=$ORACLE_VERSION
 }
 
 checkArgs() {


### PR DESCRIPTION
Support GraalVM in 14.1.2 versions
1. Fix a jython 2.7 for online problem
2. Modify cmd and sh script to distinguish between openJDK and GraalVM and allow GraalVM for 14.1.2 and greater
3. Tested with JDK, GraalVM and OpenJDK