### PR TITLE
Warn when schema information not present for custom security provider

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/discover/custom_folder_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/custom_folder_helper.py
@@ -362,14 +362,19 @@ def security_provider_interface_name(mbean_instance, mbean_interface_name):
     :param mbean_interface_name: interface for the MBean
     :return: provider class name returned from the massaged MBean name
     """
+    _method_name = 'security_provider_interface_name'
     try:
         getter = getattr(mbean_instance, 'getProviderClassName')
         result = getter()
+        if result.endswith('ProviderMBean'):
+            result = mbean_interface_name
+            _logger.warning('WLSDPLY-06779', str(mbean_instance), class_name=_class_name, method_name=_method_name)
     except (Exception, JException):
+        _logger.warning('WLSDPLY-06778', mbean_interface_name, class_name=_class_name, method_name=_method_name)
         result = mbean_interface_name
-        idx = mbean_interface_name.rfind('MBean')
-        if idx > 0:
-            result = result[:idx]
+    idx = result.rfind('MBean')
+    if idx > 0:
+        result = result[:idx]
     return result
 
 

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -777,6 +777,10 @@ WLSDPLY-06775=If WLST offline model type {0} has an empty value {0} but the defa
 is not empty, consider the model value a default_value
 WLSDPLY-06776={0} attribute {1} read-only and will not be added to the model
 WLSDPLY-06777={0} attribute {1} is clear text encrypted and will not be added to the model
+WLSDPLY-06778=Unable to locate MBean information for Security Configuration Provider {0}
+WLSDPLY-06779=Unable to complete discover of Security Configuration Provider {0}. The mbean type jar and schema jar \
+  must be in the correct locations to discover the custom provider MBean. See documentation \
+  for more information.
 
 #oracle.weblogic.deploy.discover.CustomBeanUtils
 WLSDPLY-06800=Byte buffer for encrypted field contains an invalid multi-string encrypted value


### PR DESCRIPTION
Without schema jar in the correct location, offline WLST will not properly discover a custom security provider MBean. Warn the user that the MBean not discovered.