### PR TITLE
Document the boot.properties behavior in the README

### DIFF
--- a/site/create.md
+++ b/site/create.md
@@ -33,7 +33,7 @@ The Create Domain Tool supports the use of multiple models, as described in [Usi
 
 ### Development Domain and "boot.properties"
 
-When creating a development domain, WDT provides the convenience of creating a boot.properties for each of the servers in the domain. The boot.properties will contain encrypted values of the Admin Server username and password. If the Admin server or managed server has a boot.properties, WebLogic Server will bypass the prompt for credentials when starting the server, instead using the credentials from the boot.properties.
+When creating a development domain, WDT provides the convenience of creating a boot.properties for each of the servers in the domain. The boot.properties will contain encrypted values of the Admin Server username and password. When the Admin server or Managed server has a boot.properties, WebLogic Server will bypass the prompt for credentials when starting the server, instead using the credentials from the boot.properties.
 
 A domain is considered production mode if the ServerStartMode option is set to 'prod' and/or the domain ProductionModeEnabled is set to true. The default value for both of these attributes is development.
 

--- a/site/create.md
+++ b/site/create.md
@@ -30,3 +30,24 @@ If the model or variables file contains encrypted passwords, add the `-use_encry
 ### Using Multiple Models
 
 The Create Domain Tool supports the use of multiple models, as described in [Using Multiple Models](../README.md#using-multiple-models).
+
+### Development Domain and "boot.properties"
+
+When creating a development domain, WDT provides the convenience of creating a boot.properties for each of the servers in the domain. The boot.properties will contain encrypted values of the Admin Server username and password. If the Admin server or managed server has a boot.properties, WebLogic Server will bypass the prompt for credentials when starting the server, instead using the credentials from the boot.properties.
+
+A domain is considered production mode if the ServerStartMode option is set to 'prod' and/or the domain ProductionModeEnabled is set to true. The default value for both of these attributes is development.
+
+The boot.properties is stored in the domain home on the machine where WDT runs. It is stored for each server as <domain_home>/servers/<server_name>/security/boot.properties.
+
+The following is a model example with both attributes explicitly set to development.
+
+```yaml
+domainInfo:
+    AdminUserName: weblogic
+    AdminPassword: welcome1
+    ServerStartMode: dev
+topology:
+    Name: "my-domain"
+    AdminServerName: "admin-server"
+    ProductionModeEnabled: false
+```

--- a/site/create.md
+++ b/site/create.md
@@ -33,11 +33,11 @@ The Create Domain Tool supports the use of multiple models, as described in [Usi
 
 ### Development Domain and `boot.properties`
 
-When creating a development domain, WDT provides the convenience of creating a `boot.properties` for each of the servers in the domain. The `boot.properties` will contain encrypted values of the Administration Server user name and password. When the Administration Server or Managed Server is started, WebLogic Server will bypass the prompt for credentials, and instead use the credentials from the `boot.properties`.
+When creating a development domain, WDT provides the convenience of making a `boot.properties` file for each of the servers in the domain. The `boot.properties` file will contain encrypted values of the Administration Server user name and password. When the Administration Server or Managed Server is started, WebLogic Server will bypass the prompt for credentials, and instead use the credentials from the `boot.properties` file.
 
 A domain is in production mode if the `ServerStartMode` option is set to `prod` or the domain `ProductionModeEnabled` is set to `true`. The default value for both of these attributes is development mode.
 
-The `boot.properties` is stored in the domain home on the machine where WDT runs. It is stored for each server as `<domain_home>/servers/<server_name>/security/boot.properties`.
+The `boot.properties` file is stored in the domain home on the machine where WDT runs. It is stored for each server as `<domain_home>/servers/<server_name>/security/boot.properties`.
 
 The following is a model example with both attributes explicitly set to development mode.
 

--- a/site/create.md
+++ b/site/create.md
@@ -33,7 +33,7 @@ The Create Domain Tool supports the use of multiple models, as described in [Usi
 
 ### Development Domain and `boot.properties`
 
-When creating a development domain, WDT provides the convenience of creating a `boot.properties` for each of the servers in the domain. The `boot.properties` will contain encrypted values of the Administration Server username and password. When the Administration Server or Managed Server is started, WebLogic Server will bypass the prompt for credentials, and instead use the credentials from the `boot.properties`.
+When creating a development domain, WDT provides the convenience of creating a `boot.properties` for each of the servers in the domain. The `boot.properties` will contain encrypted values of the Administration Server user name and password. When the Administration Server or Managed Server is started, WebLogic Server will bypass the prompt for credentials, and instead use the credentials from the `boot.properties`.
 
 A domain is in production mode if the `ServerStartMode` option is set to `prod` or the domain `ProductionModeEnabled` is set to `true`. The default value for both of these attributes is development mode.
 

--- a/site/create.md
+++ b/site/create.md
@@ -33,7 +33,7 @@ The Create Domain Tool supports the use of multiple models, as described in [Usi
 
 ### Development Domain and "boot.properties"
 
-When creating a development domain, WDT provides the convenience of creating a boot.properties for each of the servers in the domain. The boot.properties will contain encrypted values of the Admin Server username and password. When the Admin server or Managed server has a boot.properties, WebLogic Server will bypass the prompt for credentials when starting the server, instead using the credentials from the boot.properties.
+When creating a development domain, WDT provides the convenience of creating a boot.properties for each of the servers in the domain. The boot.properties will contain encrypted values of the Admin Server username and password. When the Admin server or Managed server is started, WebLogic Server will bypass the prompt for credentials, instead using the credentials from the boot.properties.
 
 A domain is considered production mode if the ServerStartMode option is set to 'prod' and/or the domain ProductionModeEnabled is set to true. The default value for both of these attributes is development.
 

--- a/site/create.md
+++ b/site/create.md
@@ -31,15 +31,15 @@ If the model or variables file contains encrypted passwords, add the `-use_encry
 
 The Create Domain Tool supports the use of multiple models, as described in [Using Multiple Models](../README.md#using-multiple-models).
 
-### Development Domain and "boot.properties"
+### Development Domain and `boot.properties`
 
-When creating a development domain, WDT provides the convenience of creating a boot.properties for each of the servers in the domain. The boot.properties will contain encrypted values of the Admin Server username and password. When the Admin server or Managed server is started, WebLogic Server will bypass the prompt for credentials, instead using the credentials from the boot.properties.
+When creating a development domain, WDT provides the convenience of creating a `boot.properties` for each of the servers in the domain. The `boot.properties` will contain encrypted values of the Administration Server username and password. When the Administration Server or Managed Server is started, WebLogic Server will bypass the prompt for credentials, and instead use the credentials from the `boot.properties`.
 
-A domain is considered production mode if the ServerStartMode option is set to 'prod' and/or the domain ProductionModeEnabled is set to true. The default value for both of these attributes is development.
+A domain is in production mode if the `ServerStartMode` option is set to `prod` or the domain `ProductionModeEnabled` is set to `true. The default value for both of these attributes is development mode.
 
-The boot.properties is stored in the domain home on the machine where WDT runs. It is stored for each server as <domain_home>/servers/<server_name>/security/boot.properties.
+The `boot.properties` is stored in the domain home on the machine where WDT runs. It is stored for each server as `<domain_home>/servers/<server_name>/security/boot.properties`.
 
-The following is a model example with both attributes explicitly set to development.
+The following is a model example with both attributes explicitly set to development mode.
 
 ```yaml
 domainInfo:

--- a/site/create.md
+++ b/site/create.md
@@ -35,7 +35,7 @@ The Create Domain Tool supports the use of multiple models, as described in [Usi
 
 When creating a development domain, WDT provides the convenience of creating a `boot.properties` for each of the servers in the domain. The `boot.properties` will contain encrypted values of the Administration Server username and password. When the Administration Server or Managed Server is started, WebLogic Server will bypass the prompt for credentials, and instead use the credentials from the `boot.properties`.
 
-A domain is in production mode if the `ServerStartMode` option is set to `prod` or the domain `ProductionModeEnabled` is set to `true. The default value for both of these attributes is development mode.
+A domain is in production mode if the `ServerStartMode` option is set to `prod` or the domain `ProductionModeEnabled` is set to `true`. The default value for both of these attributes is development mode.
 
 The `boot.properties` is stored in the domain home on the machine where WDT runs. It is stored for each server as `<domain_home>/servers/<server_name>/security/boot.properties`.
 


### PR DESCRIPTION
Document that WDT creates a boot.properties with credentials for development domains