### PR TITLE
remove NO_NAME_0 from Log MBean types

### DIFF
--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Partition.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Partition.json
@@ -270,7 +270,7 @@
             "wlst_type": "PartitionLog",
             "version": "[12.2.1,)",
             "child_folders_type": "single_unpredictable",
-            "default_name_value": "${NO_NAME_0:%PARTITION%}",
+            "default_name_value": "%PARTITION%",
             "folders": {},
             "attributes": {
                 "EnabledServerDebugAttribute":     [ {"version": "[12.2.1,)",     "wlst_mode": "both",    "wlst_name": "EnabledServerDebugAttribute${:s}", "wlst_path": "WP001", "value": {"default": "[]"},      "wlst_type": "${list:jarray}",  "get_method": "${LSA:GET}" } ],

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
@@ -1149,7 +1149,7 @@
                 "WebServerLog": {
                     "wlst_type": "WebServerLog",
                     "child_folders_type": "single_unpredictable",
-                    "default_name_value": "%SERVERTEMPLATE%",
+                    "default_name_value": "%SERVERTEMPLATE_WEBSERVER%",
                     "version": "[12.1.2,)",
                     "folders": {},
                     "attributes": {

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
@@ -236,7 +236,7 @@
         "Log": {
             "wlst_type": "Log",
             "child_folders_type": "single_unpredictable",
-            "default_name_value": "%SERVERTEMPLATE%",
+            "default_name_value": "${serverName}",
             "version": "[12.1.2,)",
             "folders": {},
             "attributes": {

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
@@ -1148,6 +1148,8 @@
             "folders": {
                 "WebServerLog": {
                     "wlst_type": "WebServerLog",
+                    "child_folders_type": "single_unpredictable",
+                    "default_name_value": "%SERVERTEMPLATE%",
                     "version": "[12.1.2,)",
                     "folders": {},
                     "attributes": {

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/ServerTemplate.json
@@ -1178,7 +1178,7 @@
                     },
                     "wlst_attributes_path": "WP001",
                     "wlst_paths": {
-                        "WP001": "/ServerTemplate${:s}/%SERVERTEMPLATE%/WebServer/%SERVERTEMPLATE_WEBSERVER%/WebServerLog/${NO_NAME_0:%SERVERTEMPLATE%}"
+                        "WP001": "/ServerTemplate${:s}/%SERVERTEMPLATE%/WebServer/%SERVERTEMPLATE_WEBSERVER%/WebServerLog/%WEBSERVERLOG%"
                     }
                 }
             },

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/VirtualHost.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/VirtualHost.json
@@ -35,7 +35,7 @@
             },
             "wlst_attributes_path": "WP001",
             "wlst_paths": {
-                "WP001": "/VirtualHost${:s}/%VIRTUALHOST%/WebServerLog/${NO_NAME_0:%VIRTUALHOST%}"
+                "WP001": "/VirtualHost${:s}/%VIRTUALHOST%/WebServerLog/%WEBSERVERLOG%"
             }
         }
     },

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/VirtualHost.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/VirtualHost.json
@@ -7,6 +7,8 @@
     "folders": {
         "WebServerLog": {
             "wlst_type": "WebServerLog",
+            "child_folders_type": "single_unpredictable",
+            "default_name_value": "%VIRTUALHOST%",
             "folders": {},
             "attributes": {
                 "BufferSizeKb":         [ {"version": "[10,)",           "wlst_mode": "both",    "wlst_name": "BufferSize${Kb:KB}",   "wlst_path": "WP001", "value": {"default": 8                                                     }, "wlst_type": "integer"          } ],

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/VirtualTarget.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/VirtualTarget.json
@@ -15,7 +15,7 @@
                 "WebServerLog": {
                     "wlst_type": "WebServerLog",
                     "child_folders_type": "single_unpredictable",
-                    "default_name_value": "${NO_NAME_0:%VIRTUALTARGET%}",
+                    "default_name_value": "%VIRTUALTARGET%",
                     "version": "[12.2.1,)",
                     "folders": {},
                     "attributes": {


### PR DESCRIPTION
Remove NO_NAME_0 as offline name for any MBean Log type.

NOTE: Should ServerTemplate Log have Server for name instead of ServerTemplate name?