### PR TITLE
Model help enhancements

### DIFF
--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -31,8 +31,9 @@ __required_arguments = [
 __optional_arguments = [
     CommandLineArgUtil.ATTRIBUTES_ONLY_SWITCH,
     CommandLineArgUtil.FOLDERS_ONLY_SWITCH,
-    CommandLineArgUtil.MODEL_SAMPLE_SWITCH,
-    CommandLineArgUtil.RECURSIVE_SWITCH
+    CommandLineArgUtil.RECURSIVE_SWITCH,
+    # deprecated
+    CommandLineArgUtil.MODEL_SAMPLE_SWITCH
 ]
 
 __output_types = [
@@ -65,6 +66,10 @@ def __process_args(args):
                 raise ex
             found = True
 
+    if CommandLineArgUtil.MODEL_SAMPLE_SWITCH in argument_map:
+        __logger.warning('WLSDPLY-10106', CommandLineArgUtil.MODEL_SAMPLE_SWITCH,
+                         class_name=_class_name, method_name=_method_name)
+
     return model_context_helper.create_context(_program_name, argument_map)
 
 
@@ -92,9 +97,8 @@ def print_help(model_path, model_context):
         control_option = ControlOptions.FOLDERS_ONLY
 
     aliases = Aliases(model_context)
-    as_sample = model_context.get_model_sample_option()
     printer = ModelHelpPrinter(aliases, __logger)
-    printer.print_model_help(model_path, control_option, as_sample)
+    printer.print_model_help(model_path, control_option)
 
     __logger.exiting(class_name=_class_name, method_name=_method_name)
     return CommandLineArgUtil.PROG_OK_EXIT_CODE

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_help_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_help_printer.py
@@ -5,16 +5,14 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 import re
 
 from oracle.weblogic.deploy.exception import ExceptionHelper
-from wlsdeploy.aliases.location_context import LocationContext
+
 from wlsdeploy.aliases.model_constants import KNOWN_TOPLEVEL_MODEL_SECTIONS
-from wlsdeploy.aliases.validation_codes import ValidationCodes
-from wlsdeploy.tool.modelhelp import model_help_utils
-from wlsdeploy.tool.modelhelp.model_help_utils import ControlOptions
-from wlsdeploy.tool.modelhelp.model_sample_printer import ModelSamplePrinter
-from wlsdeploy.util import model
 from wlsdeploy.exception import exception_helper
 from wlsdeploy.exception.expection_types import ExceptionType
+from wlsdeploy.tool.modelhelp.model_help_utils import ControlOptions
+from wlsdeploy.tool.modelhelp.model_sample_printer import ModelSamplePrinter
 from wlsdeploy.tool.util.alias_helper import AliasHelper
+from wlsdeploy.util import model
 
 _class_name = "ModelHelpPrinter"
 MODEL_PATH_PATTERN = re.compile(r'^([a-zA-Z]+:?)?((/[a-zA-Z0-9]+)*)?$')
@@ -33,7 +31,7 @@ class ModelHelpPrinter(object):
         self._logger = logger
         self._alias_helper = AliasHelper(aliases, self._logger, ExceptionType.CLA)
 
-    def print_model_help(self, model_path, control_option, as_sample=False):
+    def print_model_help(self, model_path, control_option):
         """
         Prints out the help information for a given '''model_path'''. '''model_path''' needs to be specified
         using the following pattern:
@@ -48,36 +46,26 @@ class ModelHelpPrinter(object):
 
         :param model_path: a formatted string containing the model path
         :param control_option: a command-line switch that controls what is output
-        :param as_sample: specifies that a model sample should be output
         :raises CLAException: if a problem is encountered
         """
 
-        # print filter information, if not NORMAL
-        if control_option == ControlOptions.RECURSIVE:
-            print
-            print _format_message('WLSDPLY-10102')
-        elif control_option == ControlOptions.FOLDERS_ONLY:
-            print
-            print _format_message('WLSDPLY-10103')
-        elif control_option == ControlOptions.ATTRIBUTES_ONLY:
-            print
-            print _format_message('WLSDPLY-10104')
-
         model_path_tokens = self._parse_model_path(model_path)
+        folder_path = '/'.join(model_path_tokens[1:])
+        model_path = '%s:/%s' % (model_path_tokens[0], folder_path)
 
-        section_name = model_path_tokens[0]
-        valid_section_folder_keys = self._alias_helper.get_model_section_top_level_folder_names(section_name)
-
-        if as_sample:
-            sample_printer = ModelSamplePrinter(self._alias_helper, self._logger)
-            sample_printer.print_model_sample(model_path_tokens, control_option)
+        # print format information
+        print
+        if control_option == ControlOptions.RECURSIVE:
+            print _format_message('WLSDPLY-10102', model_path)
+        elif control_option == ControlOptions.FOLDERS_ONLY:
+            print _format_message('WLSDPLY-10103', model_path)
+        elif control_option == ControlOptions.ATTRIBUTES_ONLY:
+            print _format_message('WLSDPLY-10104', model_path)
         else:
-            if model_path_tokens[0] == 'top':
-                self._print_model_top_level_help()
-            elif len(model_path_tokens) == 1:
-                self._print_model_section_help(section_name, valid_section_folder_keys, control_option)
-            else:
-                self._print_model_folder_help(model_path_tokens, valid_section_folder_keys, control_option)
+            print _format_message('WLSDPLY-10105', model_path)
+
+        sample_printer = ModelSamplePrinter(self._alias_helper, self._logger)
+        sample_printer.print_model_sample(model_path_tokens, control_option)
 
     def _parse_model_path(self, model_path):
         """
@@ -150,206 +138,6 @@ class ModelHelpPrinter(object):
         self._logger.throwing(ex, class_name=_class_name, method_name=_method_name)
         raise ex
 
-    def _print_model_top_level_help(self):
-        """
-        Prints out all the valid section names for a model.
-        The -recursive flag is disregarded for this case.
-        """
-        _method_name = '_print_model_top_level_help'
-        self._logger.finest('sections={0}', KNOWN_TOPLEVEL_MODEL_SECTIONS, class_name=_class_name,
-                            method_name=_method_name)
-
-        title = _format_message('WLSDPLY-10113')
-
-        # Print 'All Sections:' header
-        print
-        _print_indent(title, 0)
-        print
-
-        for section in KNOWN_TOPLEVEL_MODEL_SECTIONS:
-            _print_indent(section, 1)
-
-    def _print_model_section_help(self, section_name, valid_section_folder_keys, control_option):
-        """
-        Prints the help for a section of a model, when just the section_name[:] is provided
-        :param section_name: the name of the model section
-        :param valid_section_folder_keys: list of the valid top folders in the specified section
-        :param control_option: A command-line switch that controls what is output to STDOUT
-        """
-        _method_name = '_print_model_section_help'
-
-        self._logger.finest('1 section_name={0}', section_name, class_name=_class_name, method_name=_method_name)
-
-        location_path = '%s:' % section_name
-        self._logger.finest('1 location_path={0}', location_path, class_name=_class_name, method_name=_method_name)
-
-        model_section = _format_message('WLSDPLY-10106', location_path)
-
-        # Print 'Section: <model_section>' label and field
-        print
-        _print_indent(model_section, 0)
-
-        if model_help_utils.show_attributes(control_option):
-            attributes_location = self._alias_helper.get_model_section_attribute_location(section_name)
-            if attributes_location is not None:
-                self._print_attributes_help(attributes_location, 1)
-
-        if model_help_utils.show_folders(control_option):
-            print
-            _print_indent(_format_message('WLSDPLY-10107'), 1)
-            valid_section_folder_keys.sort()
-
-            for section_folder_key in valid_section_folder_keys:
-                _print_indent(section_folder_key, 2)
-
-                if control_option == ControlOptions.RECURSIVE:
-                    model_location = LocationContext().append_location(section_folder_key)
-                    self._print_subfolders_help(model_location, control_option, 2)
-
-    def _print_model_folder_help(self, model_path_tokens, valid_section_folder_keys, control_option):
-        """
-        Prints the help for a folder in a model, when more than just the section_name[:] is provided.
-        The section name in the first token was already validated.
-        :param model_path_tokens: a Python list of path elements built from model path
-        :param valid_section_folder_keys: A list of valid folder names for the model section in the path
-        :param control_option: A command-line switch that controls what is output to STDOUT
-        """
-        _method_name = '_print_model_folder_help'
-
-        self._logger.finest('1 model_path_tokens={0}, control_option={1}, valid_section_folder_keys={0}',
-                            str(model_path_tokens), ControlOptions.from_value(control_option),
-                            str(valid_section_folder_keys), class_name=_class_name, method_name=_method_name)
-
-        print
-
-        section_name = model_path_tokens[0]
-        top_folder = model_path_tokens[1]
-        if top_folder not in valid_section_folder_keys:
-            ex = exception_helper.create_cla_exception('WLSDPLY-10110', section_name + ':', top_folder,
-                                                       ', '.join(valid_section_folder_keys))
-            self._logger.throwing(ex, class_name=_class_name, method_name=_method_name)
-            raise ex
-
-        # Populate the location context using model_path_tokens[1:]
-        model_location = LocationContext()
-        for folder_key in model_path_tokens[1:]:
-            code, message = self._alias_helper.is_valid_model_folder_name(model_location, folder_key)
-            if code != ValidationCodes.VALID:
-                ex = exception_helper.create_cla_exception("WLSDPLY-05027", message)
-                self._logger.throwing(ex, class_name=_class_name, method_name=_method_name)
-                raise ex
-
-            model_location.append_location(folder_key)
-            name_token = self._alias_helper.get_name_token(model_location)
-            if name_token is not None:
-                model_location.add_name_token(name_token, '%s-0' % folder_key)
-
-            self._logger.finest('2 model_location={0}', model_location, class_name=_class_name,
-                                method_name=_method_name)
-
-        folder_path = '/'.join(model_path_tokens[1:])
-        model_path = _format_message('WLSDPLY-10105', '%s:/%s' % (section_name, folder_path))
-        type_name = self._get_folder_type_name(model_location)
-        if type_name is not None:
-            model_path += " (" + type_name + ")"
-
-        # Print 'Path: <model_section>' header
-        _print_indent(model_path, 0)
-
-        if model_help_utils.show_attributes(control_option):
-            # Print the attributes associated with location context
-            self._print_attributes_help(model_location, 1)
-
-        if model_help_utils.show_folders(control_option):
-            # Print the folders associated with location context
-            print
-            _print_indent(_format_message('WLSDPLY-10107'), 1)
-            self._print_subfolders_help(model_location, control_option, 1)
-
-        self._logger.exiting(class_name=_class_name, method_name=_method_name)
-        return
-
-    def _print_subfolders_help(self, model_location, control_option, indent_level):
-        """
-        Prints the help for the folders in a model location, without header or leading space.
-        :param model_location: the model location being worked on
-        :param control_option: a command-line switch that controls what is output to STDOUT
-        :param indent_level: the level to indent by, before printing output
-        """
-        _method_name = '_print_subfolders_help'
-
-        valid_subfolder_keys = self._alias_helper.get_model_subfolder_names(model_location)
-        self._logger.finest('3 aliases.get_model_subfolder_names(model_location) returned: {0}',
-                            str(valid_subfolder_keys), class_name=_class_name, method_name=_method_name)
-
-        if not valid_subfolder_keys:
-            return
-
-        valid_subfolder_keys.sort()
-
-        for key in valid_subfolder_keys:
-            model_location.append_location(key)
-            name_token = self._alias_helper.get_name_token(model_location)
-            if name_token is not None:
-                model_location.add_name_token(name_token, '%s-0' % key)
-
-            self._logger.finest('3 model_location={0}', model_location, class_name=_class_name,
-                                method_name=_method_name)
-
-            text = key
-            type_name = self._get_folder_type_name(model_location)
-            if type_name is not None:
-                text += " (" + type_name + ")"
-
-            _print_indent(text, indent_level + 1)
-
-            if control_option == ControlOptions.RECURSIVE:
-                # Call this method recursively
-                self._print_subfolders_help(model_location, control_option, indent_level + 1)
-
-            model_location.pop_location()
-
-    def _print_attributes_help(self, model_location, indent_level):
-        """
-        Prints out the help for the attributes in a model location
-        :param model_location: An object containing data about the model location being worked on
-        :param indent_level: The level to indent by, before printing output
-        """
-        _method_name = '_print_attributes_help'
-
-        attr_infos = self._alias_helper.get_model_attribute_names_and_types(model_location)
-        self._logger.finer('WLSDPLY-05012', str(model_location), str(attr_infos),
-                           class_name=_class_name, method_name=_method_name)
-
-        # Print 'Valid Attributes:' area label
-        print
-        _print_indent(_format_message('WLSDPLY-10111'), indent_level)
-
-        if attr_infos:
-            maxlen = 0
-            for key in attr_infos:
-                if len(key) > maxlen:
-                    maxlen = len(key)
-            formatted_string = '%-' + str(maxlen) + 's\t%s'
-
-            attr_list = attr_infos.keys()
-            attr_list.sort()
-            for attr_name in attr_list:
-                msg = formatted_string % (attr_name, attr_infos[attr_name])
-                _print_indent(msg, indent_level + 1)
-
-    def _get_folder_type_name(self, location):
-        """
-        Return text indicating the type of a folder, such as "multiple".
-        :param location: the location to be checked
-        :return: name of the folder type to be displayed, or None
-        """
-        if self._alias_helper.is_artificial_type_folder(location):
-            return None
-        if self._alias_helper.supports_multiple_mbean_instances(location):
-            return "multiple"
-        return None
-
 
 def _format_message(key, *args):
     """
@@ -358,17 +146,3 @@ def _format_message(key, *args):
     :return: the formatted text message
     """
     return ExceptionHelper.getMessage(key, list(args))
-
-
-def _print_indent(msg, level=1):
-    """
-    Print a message at the specified indent level.
-    :param msg: the message to be printed
-    :param level: the indent level
-    """
-    result = ''
-    i = 0
-    while i < level:
-        result += '  '
-        i += 1
-    print '%s%s' % (result, msg)

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
@@ -192,8 +192,16 @@ class ModelSamplePrinter(object):
         if attr_infos:
             attr_list = attr_infos.keys()
             attr_list.sort()
+
+            maxlen = 0
+            for name in attr_list:
+                if len(name) > maxlen:
+                    maxlen = len(name)
+
+            format_string = '%-' + str(maxlen + 1) + 's # %s'
             for attr_name in attr_list:
-                _print_indent(attr_name + ": # " + attr_infos[attr_name], indent_level)
+                line = format_string % (attr_name + ":", attr_infos[attr_name])
+                _print_indent(line, indent_level)
         else:
             _print_indent("# no attributes", indent_level)
 

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
@@ -100,6 +100,8 @@ class ModelSamplePrinter(object):
         indent = 0
         model_location = LocationContext()
         for token in model_path_tokens:
+            last_location = LocationContext(model_location);
+
             if indent > 0:
                 code, message = self._alias_helper.is_valid_model_folder_name(model_location, token)
                 if code != ValidationCodes.VALID:
@@ -108,12 +110,16 @@ class ModelSamplePrinter(object):
                     raise ex
                 model_location.append_location(token)
 
+            if self._alias_helper.is_artificial_type_folder(model_location):
+                name = self._get_member_name(last_location, 0)
+                _print_indent(name + ":", indent)
+                indent += 1
+
             _print_indent(token + ":", indent)
             indent += 1
 
             if self._has_multiple_folders(model_location):
-                short_name = self._get_short_name(model_location)
-                name = "'" + short_name + "-1'"
+                name = self._get_member_name(model_location, 0)
                 _print_indent(name + ":", indent)
                 indent += 1
 
@@ -153,6 +159,9 @@ class ModelSamplePrinter(object):
         """
         _method_name = '_print_subfolder_keys_sample'
 
+        artificial_index = 0
+        parent_location = LocationContext(model_location)
+
         for key in subfolder_keys:
             model_location.append_location(key)
             name_token = self._alias_helper.get_name_token(model_location)
@@ -162,12 +171,18 @@ class ModelSamplePrinter(object):
             if control_option != ControlOptions.RECURSIVE:
                 print("")
 
-            _print_indent(key + ":", indent_level )
+            key_level = indent_level
+            if self._alias_helper.is_artificial_type_folder(model_location):
+                name = self._get_member_name(parent_location, artificial_index)
+                artificial_index += 1
+                _print_indent(name + ":", indent_level)
+                key_level += 1
 
-            child_level = indent_level
+            _print_indent(key + ":", key_level )
+
+            child_level = key_level
             if self._has_multiple_folders(model_location):
-                short_name = self._get_short_name(model_location)
-                name = "'" + short_name + "-1'"
+                name = self._get_member_name(model_location, 0)
                 child_level += 1
                 _print_indent(name + ":", child_level)
 
@@ -211,21 +226,23 @@ class ModelSamplePrinter(object):
         :param location: the location to be checked
         :return: True if the location has multiple children
         """
+        # check this first to avoid errors on subsequent checks
         if self._alias_helper.is_artificial_type_folder(location):
             return False
 
         return self._alias_helper.supports_multiple_mbean_instances(location)
 
-    def _get_short_name(self, location):
+    def _get_member_name(self, location, index):
         """
-        Return the short name of the last folder in the location, if available.
-        :param location: the location to be checked
-        :return: the short name of the last folder, or the full name if not available
+        Return a name to be used for member of a model folder with multiple values.
+        :param location: the location of the folder
+        :param index: the index of the member in the folder
+        :return: the member name
         """
         short_name = self._alias_helper.get_folder_short_name(location)
-        if len(short_name) > 0:
-            return short_name
-        return location.get_current_model_folder()
+        if len(short_name) == 0:
+            short_name = location.get_current_model_folder()
+        return "'" + short_name + "-" + str(index + 1) + "'"
 
 
 def _print_indent(msg, level=1):

--- a/core/src/main/python/wlsdeploy/util/cla_utils.py
+++ b/core/src/main/python/wlsdeploy/util/cla_utils.py
@@ -72,6 +72,7 @@ class CommandLineArgUtil(object):
     TRAILING_ARGS_SWITCH       = '-trailing_arguments'
     ATTRIBUTES_ONLY_SWITCH     = '-attributes_only'
     FOLDERS_ONLY_SWITCH        = '-folders_only'
+    # deprecated
     MODEL_SAMPLE_SWITCH        = '-model_sample'
     RECURSIVE_SWITCH           = '-recursive'
     UPDATE_RCU_SCHEMA_PASS_SWITCH = '-updateRCUSchemaPassword'

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -56,7 +56,6 @@ class ModelContext(object):
         self._archive_file_name = None
         self._archive_file = None
         self._model_file = None
-        self._model_sample = False
         self._previous_model_file = None
         self._variable_file_name = None
         self._run_rcu = False
@@ -120,9 +119,6 @@ class ModelContext(object):
 
         if CommandLineArgUtil.MODEL_FILE_SWITCH in arg_map:
             self._model_file = arg_map[CommandLineArgUtil.MODEL_FILE_SWITCH]
-
-        if CommandLineArgUtil.MODEL_SAMPLE_SWITCH in arg_map:
-            self._model_sample = arg_map[CommandLineArgUtil.MODEL_SAMPLE_SWITCH]
 
         if CommandLineArgUtil.PREVIOUS_MODEL_FILE_SWITCH in arg_map:
             self._previous_model_file = arg_map[CommandLineArgUtil.PREVIOUS_MODEL_FILE_SWITCH]
@@ -422,13 +418,6 @@ class ModelContext(object):
         :return: the -recursive command-line switch
         """
         return self._recursive
-
-    def get_model_sample_option(self):
-        """
-        Get the -model_sample command-line switch for model help tool.
-        :return: the -recursive command-line switch
-        """
-        return self._model_sample
 
     def get_variable_file(self):
         """

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1098,20 +1098,17 @@ WLSDPLY-10002=Adding cluster {0} to domain resource file with server count {1}
 # /model_help.py
 WLSDPLY-10100=Only one of these arguments can be specified: {0}
 WLSDPLY-10101=Unable to determine model section for folder {0}
-WLSDPLY-10102=Filtering output to recursively display the sub-folders of the specified model section or path
-WLSDPLY-10103=Filtering output to only display the sub-folders of the specified model section or path
-WLSDPLY-10104=Filtering output to only display the attributes of the specified model section or path
-WLSDPLY-10105=Path: {0}
-WLSDPLY-10106=Section: {0}
-WLSDPLY-10107=Valid Folders:
+WLSDPLY-10102=Recursive sub-folders only for {0}
+WLSDPLY-10103=Sub-folders only for {0}
+WLSDPLY-10104=Attributes only for {0}
+WLSDPLY-10105=Attributes and sub-folders for {0}
+WLSDPLY-10106=The {0} argument has been deprecated, model sample is the default format
 WLSDPLY-10108={0} does not adhere to [<model_section>[:]][/<section_folder>]... pattern \
   for the path argument. For example: domainInfo, resources:, topology:/Server, \
   topology:/Server/ServerStart, /Server/ServerStart
 WLSDPLY-10109={0} is not a recognized top level section name. The recognized top level section names are {1}
 WLSDPLY-10110=Model section {0} has no folder {1} beneath it. Valid folders are: {2}
-WLSDPLY-10111=Valid Attributes:
 WLSDPLY-10112={0} encountered an error: {1}
-WLSDPLY-10113=All Sections:
 
 ###############################################################################
 #                    create messages (12000 - 14999)                          #

--- a/installer/src/main/bin/modelHelp.cmd
+++ b/installer/src/main/bin/modelHelp.cmd
@@ -70,7 +70,6 @@ ECHO Usage: %SCRIPT_NAME%
 ECHO         [-help]
 ECHO         [-oracle_home ^<oracle_home^>]
 ECHO         [-attributes_only ^| -folders_only ^| -recursive]
-ECHO         [-model_sample]
 ECHO         ^<model_path^>
 ECHO.
 ECHO     where:
@@ -100,9 +99,6 @@ ECHO.
 ECHO     The -recursive switch will cause the tool to list only the folders
 ECHO     for the specified model path, and recursively include the folders below
 ECHO     that path.
-ECHO.
-ECHO     The -model_sample switch will output a sample model section that can be
-ECHO     used to create a domain model.
 ECHO.
 
 :exit_script

--- a/installer/src/main/bin/modelHelp.sh
+++ b/installer/src/main/bin/modelHelp.sh
@@ -35,7 +35,6 @@ usage() {
   echo "Usage: $1 [-help]"
   echo "          [-oracle_home <oracle_home>]"
   echo "          [-attributes_only | -folders_only | -recursive]"
-  echo "          [-model_sample]"
   echo "          <model_path>"
   echo ""
   echo "    where:"
@@ -65,9 +64,6 @@ usage() {
   echo "    The -recursive switch will cause the tool to list only the folders"
   echo "    for the specified model path, and recursively include the folders below"
   echo "    that path."
-  echo ""
-  echo "    The -model_sample switch will output a sample model section that can be"
-  echo "    used to create a domain model."
   echo ""
 }
 


### PR DESCRIPTION
Use model sample output always, deprecate -model_sample command-line option.
Align attribute data type comments.
Correct security provider output.
Clarify output format comments.

Internal Jira WDT-435
