### PR TITLE
Use server name for JTA migratable targets in offline mode

### DIFF
--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Server.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/Server.json
@@ -197,7 +197,7 @@
         "JTAMigratableTarget": {
             "wlst_type": "JTAMigratableTarget",
             "child_folders_type": "single_unpredictable",
-            "default_name_value": "${NO_NAME_0:%SERVER%}",
+            "default_name_value": "%SERVER%",
             "folders": {},
             "attributes": {
                 "AdditionalMigrationAttempts":  [ {"version": "[10,)",     "wlst_mode": "both",    "wlst_name": "AdditionalMigrationAttempts",  "wlst_path": "WP001", "value": {"default": 2       }, "wlst_type": "integer"  } ],


### PR DESCRIPTION
Fixes #678 

Use server name for JTA migratable targets for offline and online.

WLS 12.2.1.4+, 14.1+ used NO_NAME literally, older versions disregarded it.
All versions OK applying server name directly.
