### PR TITLE
Wdt 433 compare model validation

### DIFF
--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -424,7 +424,7 @@ class ModelFileDiffer:
                 model_file_name = self.past_dict_file
                 FileToPython(model_file_name, True).parse()
 
-#            self.model_context.set_validation_method('lax')
+            self.model_context.set_validation_method('lax')
 
             aliases = Aliases(model_context=self.model_context, wlst_mode=WlstModes.OFFLINE)
 

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -424,7 +424,7 @@ class ModelFileDiffer:
                 model_file_name = self.past_dict_file
                 FileToPython(model_file_name, True).parse()
 
-            self.model_context.set_validation_method('lax')
+#            self.model_context.set_validation_method('lax')
 
             aliases = Aliases(model_context=self.model_context, wlst_mode=WlstModes.OFFLINE)
 
@@ -443,9 +443,13 @@ class ModelFileDiffer:
             # references a file in an archive, the compareModel will fail if
             # running in the stricter tool mode (even with lax).
             #
-            return_code = validator.validate_in_standalone_mode(model_dictionary,
-                                                                None,
-                                                                archive_file_name=None)
+            arg_map = dict()
+            arg_map[CommandLineArgUtil.MODEL_FILE_SWITCH] = model_file_name
+            model_context_copy = self.model_context.copy(arg_map)
+            val_copy = Validator(model_context_copy, aliases, wlst_mode=WlstModes.OFFLINE)
+            return_code = val_copy.validate_in_standalone_mode(model_dictionary,
+                                                               None,
+                                                               archive_file_name=None)
 
             if return_code == Validator.ReturnCode.STOP:
                 _logger.severe('WLSDPLY-05705', model_file_name)
@@ -457,9 +461,12 @@ class ModelFileDiffer:
             model_dictionary = cla_helper.merge_model_files(model_file_name, variable_map)
             variables.substitute(model_dictionary, variable_map, self.model_context)
 
-            return_code = validator.validate_in_tool_mode(model_dictionary,
-                                            variables_file_name=None,
-                                            archive_file_name=None)
+            arg_map[CommandLineArgUtil.MODEL_FILE_SWITCH] = model_file_name
+            model_context_copy = self.model_context.copy(arg_map)
+            val_copy = Validator(model_context_copy, aliases, wlst_mode=WlstModes.OFFLINE)
+            return_code = val_copy.validate_in_standalone_mode(model_dictionary,
+                                                               None,
+                                                               archive_file_name=None)
 
             if return_code == Validator.ReturnCode.STOP:
                 _logger.severe('WLSDPLY-05705', model_file_name)

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -129,6 +129,7 @@ class Validator(object):
         self._logger.entering(archive_file_name, class_name=_class_name, method_name=_method_name)
         self.__validate_model_file(cloned_model_dict, variable_map, archive_file_name)
 
+        status = Validator.ValidationStatus.VALID
         summary_handler = SummaryHandler.findInstance()
         if summary_handler is not None:
             summary_level = summary_handler.getMaximumMessageLevel()
@@ -137,7 +138,6 @@ class Validator(object):
             elif summary_level == Level.WARNING:
                 status = Validator.ValidationStatus.WARNINGS_INVALID
 
-        status = Validator.ValidationStatus.VALID
         if status == Validator.ValidationStatus.VALID or status == Validator.ValidationStatus.INFOS_VALID \
                 or status == Validator.ValidationStatus.WARNINGS_INVALID:
             return_code = Validator.ReturnCode.PROCEED

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -116,6 +116,7 @@ class Validator(object):
 
         # If standalone, log file will not be passed, so get a new logger with correct mode type
         self._validation_mode = _ValidationModes.STANDALONE
+        return_code = Validator.ReturnCode.STOP
         self._logger = ValidatorLogger(self._logger.get_name(), _ValidationModes.from_value(self._validation_mode))
         self._logger.entering(archive_file_name, class_name=_class_name, method_name=_method_name)
 
@@ -128,7 +129,20 @@ class Validator(object):
         self._logger.entering(archive_file_name, class_name=_class_name, method_name=_method_name)
         self.__validate_model_file(cloned_model_dict, variable_map, archive_file_name)
 
-        self._logger.exiting(class_name=_class_name, method_name=_method_name)
+        summary_handler = SummaryHandler.findInstance()
+        if summary_handler is not None:
+            summary_level = summary_handler.getMaximumMessageLevel()
+            if summary_level == Level.SEVERE:
+                status = Validator.ValidationStatus.INVALID
+            elif summary_level == Level.WARNING:
+                status = Validator.ValidationStatus.WARNINGS_INVALID
+
+        status = Validator.ValidationStatus.VALID
+        if status == Validator.ValidationStatus.VALID or status == Validator.ValidationStatus.INFOS_VALID \
+                or status == Validator.ValidationStatus.WARNINGS_INVALID:
+            return_code = Validator.ReturnCode.PROCEED
+        self._logger.exiting(class_name=_class_name, method_name=_method_name, result=return_code)
+        return return_code
 
     def validate_in_tool_mode(self, model_dict, variables_file_name=None, archive_file_name=None):
         """

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -2,6 +2,8 @@
 Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
+
+import copy
 import os
 import tempfile
 
@@ -88,6 +90,17 @@ class ModelContext(object):
 
         self._trailing_args = []
 
+        if self._wl_version is None:
+            self._wl_version = self._wls_helper.get_actual_weblogic_version()
+
+        if self._wlst_mode is None:
+            self._wlst_mode = WlstModes.OFFLINE
+
+        self.__copy_from_args(arg_map)
+
+        return
+
+    def __copy_from_args(self, arg_map):
         if CommandLineArgUtil.ORACLE_HOME_SWITCH in arg_map:
             self._oracle_home = arg_map[CommandLineArgUtil.ORACLE_HOME_SWITCH]
             self._wl_home = self._wls_helper.get_weblogic_home(self._oracle_home)
@@ -200,10 +213,13 @@ class ModelContext(object):
 
         if CommandLineArgUtil.TARGET_MODE_SWITCH in arg_map:
             wlst_mode_string = arg_map[CommandLineArgUtil.TARGET_MODE_SWITCH]
-            if wlst_mode_string.lower() == 'online':
-                self._wlst_mode = WlstModes.ONLINE
+            if type(wlst_mode_string) == int:
+                self._wlst_mode = wlst_mode_string
             else:
-                self._wlst_mode = WlstModes.OFFLINE
+                if wlst_mode_string.lower() == 'online':
+                    self._wlst_mode = WlstModes.ONLINE
+                else:
+                    self._wlst_mode = WlstModes.OFFLINE
 
         if CommandLineArgUtil.OUTPUT_DIR_SWITCH in arg_map:
             self._output_dir = arg_map[CommandLineArgUtil.OUTPUT_DIR_SWITCH]
@@ -217,13 +233,91 @@ class ModelContext(object):
         if CommandLineArgUtil.VARIABLE_PROPERTIES_FILE_SWITCH in arg_map:
             self._variable_properties_file = arg_map[CommandLineArgUtil.VARIABLE_PROPERTIES_FILE_SWITCH]
 
-        if self._wl_version is None:
-            self._wl_version = self._wls_helper.get_actual_weblogic_version()
-
-        if self._wlst_mode is None:
-            self._wlst_mode = WlstModes.OFFLINE
-
-        return
+    def __copy__(self):
+        arg_map = dict()
+        if self._oracle_home is not None:
+            arg_map[CommandLineArgUtil.ORACLE_HOME_SWITCH] = self._oracle_home
+        if self._java_home is not None:
+            arg_map[CommandLineArgUtil.JAVA_HOME_SWITCH] = self._java_home
+        if self._domain_home is not None:
+            arg_map[CommandLineArgUtil.DOMAIN_HOME_SWITCH] = self._domain_home
+        if self._domain_parent_dir is not None:
+            arg_map[CommandLineArgUtil.DOMAIN_PARENT_SWITCH] = self._domain_parent_dir
+        if self._domain_type is not None:
+            arg_map[CommandLineArgUtil.DOMAIN_TYPE_SWITCH] = self._domain_type
+        if self._admin_url is not None:
+            arg_map[CommandLineArgUtil.ADMIN_URL_SWITCH] = self._admin_url
+        if self._admin_user is not None:
+            arg_map[CommandLineArgUtil.ADMIN_USER_SWITCH] = self._admin_user
+        if self._admin_password is not None:
+            arg_map[CommandLineArgUtil.ADMIN_PASS_SWITCH] = self._admin_password
+        if self._archive_file_name is not None:
+            arg_map[CommandLineArgUtil.ARCHIVE_FILE_SWITCH] = self._archive_file_name
+        if self._model_file is not None:
+            arg_map[CommandLineArgUtil.MODEL_FILE_SWITCH] = self._model_file
+        if self._previous_model_file is not None:
+            arg_map[CommandLineArgUtil.PREVIOUS_MODEL_FILE_SWITCH] = self._previous_model_file
+        if self._attributes_only is not None:
+            arg_map[CommandLineArgUtil.ATTRIBUTES_ONLY_SWITCH] = self._attributes_only
+        if self._folders_only is not None:
+            arg_map[CommandLineArgUtil.FOLDERS_ONLY_SWITCH] = self._folders_only
+        if self._recursive is not None:
+            arg_map[CommandLineArgUtil.RECURSIVE_SWITCH] = self._recursive
+        if self._variable_file_name is not None:
+            arg_map[CommandLineArgUtil.VARIABLE_FILE_SWITCH] = self._variable_file_name
+        if self._run_rcu is not None:
+            arg_map[CommandLineArgUtil.RUN_RCU_SWITCH]= self._run_rcu
+        if self._rcu_database is not None:
+            arg_map[CommandLineArgUtil.RCU_DB_SWITCH] = self._rcu_database
+        if self._rcu_prefix is not None:
+            arg_map[CommandLineArgUtil.RCU_PREFIX_SWITCH] = self._rcu_prefix
+        if self._rcu_sys_pass is not None:
+            arg_map[CommandLineArgUtil.RCU_SYS_PASS_SWITCH] = self._rcu_sys_pass
+        if self._rcu_db_user is not None:
+            arg_map[CommandLineArgUtil.RCU_DB_USER_SWITCH] = self._rcu_db_user
+        if self._rcu_schema_pass is not None:
+            arg_map[CommandLineArgUtil.RCU_SCHEMA_PASS_SWITCH] = self._rcu_schema_pass
+        if self._domain_typedef is not None:
+            arg_map[CommandLineArgUtil.DOMAIN_TYPEDEF] = self._domain_typedef
+        if self._encryption_passphrase is not None:
+            arg_map[CommandLineArgUtil.PASSPHRASE_SWITCH] = self._encryption_passphrase
+        if self._encrypt_manual is not None:
+            arg_map[CommandLineArgUtil.ENCRYPT_MANUAL_SWITCH] = self._encrypt_manual
+        if self._encrypt_one_pass is not None:
+            arg_map[CommandLineArgUtil.ONE_PASS_SWITCH] = self._encrypt_one_pass
+        if self._rollback_if_restart_required is not None:
+            arg_map[CommandLineArgUtil.ROLLBACK_IF_RESTART_REQ_SWITCH] = self._rollback_if_restart_required
+        if self._use_encryption is not None:
+            arg_map[CommandLineArgUtil.USE_ENCRYPTION_SWITCH] = self._use_encryption
+        if self._archive_file is not None:
+            arg_map[CommandLineArgUtil.ARCHIVE_FILE] = self._archive_file
+        if self._opss_wallet_passphrase is not None:
+            arg_map[CommandLineArgUtil.OPSS_WALLET_PASSPHRASE] = self._opss_wallet_passphrase
+        if self._opss_wallet is not None:
+            arg_map[CommandLineArgUtil.OPSS_WALLET_SWITCH] = self._opss_wallet
+        if self._update_rcu_schema_pass is not None:
+            arg_map[CommandLineArgUtil.UPDATE_RCU_SCHEMA_PASS_SWITCH] = self._update_rcu_schema_pass
+        if self._validation_method is not None:
+            arg_map[CommandLineArgUtil.VALIDATION_METHOD] = self._validation_method
+        if self._wl_version is not None:
+            arg_map[CommandLineArgUtil.TARGET_VERSION_SWITCH] = self._wl_version
+        if self._domain_resource_file is not None:
+            arg_map[CommandLineArgUtil.DOMAIN_RESOURCE_FILE_SWITCH] = self._domain_resource_file
+        if self._trailing_args is not None:
+            arg_map[CommandLineArgUtil.TRAILING_ARGS_SWITCH] = self._trailing_args
+        if self._target is not None:
+            arg_map[CommandLineArgUtil.TARGET_SWITCH] = self._target
+        if self._wlst_mode is not None:
+            arg_map[CommandLineArgUtil.TARGET_MODE_SWITCH] = self._wlst_mode
+        if self._output_dir is not None:
+            arg_map[CommandLineArgUtil.OUTPUT_DIR_SWITCH] = self._output_dir
+        if self._variable_injector_file is not None:
+            arg_map[CommandLineArgUtil.VARIABLE_INJECTOR_FILE_SWITCH] = self._variable_injector_file
+        if self._variable_keywords_file is not None:
+            arg_map[CommandLineArgUtil.VARIABLE_KEYWORDS_FILE_SWITCH] = self._variable_keywords_file
+        if self._variable_properties_file is not None:
+            arg_map[CommandLineArgUtil.VARIABLE_PROPERTIES_FILE_SWITCH] = self._variable_properties_file
+        return ModelContext(self._program_name, arg_map)
 
     def get_program_name(self):
         """
@@ -761,6 +855,11 @@ class ModelContext(object):
 
         return separator.join(cp_elements)
 
+    def copy(self, arg_map):
+        model_context_copy = copy.copy(self)
+        model_context_copy.__copy_from_args(arg_map)
+        return model_context_copy
+
     # private methods
 
 
@@ -778,3 +877,4 @@ def _replace(string_value, token, replace_token_string):
     else:
         result = string_value.replace(token, replace_token_string)
     return result
+

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 

--- a/core/src/test/python/wlsdeploy/util/model_context_test.py
+++ b/core/src/test/python/wlsdeploy/util/model_context_test.py
@@ -1,0 +1,30 @@
+"""
+Copyright (c) 2020, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+"""
+import unittest
+
+from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.model_context import ModelContext
+
+
+class ClaHelperTest(unittest.TestCase):
+
+    def testCopyModelContext(self):
+        __program_name = 'model_context_test'
+        __oracle_home = '/my/oracle/home'
+        __model_file = 'my_model_file.yaml'
+
+        arg_map = dict()
+        arg_map[CommandLineArgUtil.ORACLE_HOME_SWITCH] = __oracle_home
+        model_context = ModelContext(__program_name, arg_map)
+        self.assertEquals(model_context.get_program_name(), __program_name)
+        self.assertEquals(model_context.get_oracle_home(), __oracle_home)
+        self.assertEquals(model_context.get_model_file(), None)
+
+        arg_map = dict()
+        arg_map[CommandLineArgUtil.MODEL_FILE_SWITCH] = __model_file
+        model_context_copy = model_context.copy(arg_map)
+        self.assertEquals(model_context_copy.get_program_name(), __program_name)
+        self.assertEquals(model_context_copy.get_oracle_home(), __oracle_home)
+        self.assertEquals(model_context_copy.get_model_file(), __model_file)

--- a/core/src/test/resources/compare_model_model3.yaml
+++ b/core/src/test/resources/compare_model_model3.yaml
@@ -45,7 +45,7 @@ topology:
                     StrictOwnershipCheck: true
                     Cluster: "cluster-2"
                     'nosuchkey' : 'value'
-appDeployments:
+appDeployment:
      Application:
          myear:
              SourcePath: /home/johnny/dimtemp23/sample_app_stage/wlsdeploy/applications/sample_app.ear


### PR DESCRIPTION
1. validation called using model context without a model file. Added code to model_context to copy and add / override arguments. Created a model context copy for each model with the model file in the copied context.
2. compare model to run in validator in stand-alone-mode not completed. This was done becaause tool mode requires an archive file and other more strict policies. The second model file validate was not using stand alone tool mode. and stand alone tool mode not returning a return code from the validate. Fixed both
3. Fixed compare model test file to have something other than a requirement for archive file (not required anymore)