### PR TITLE
Issue#690 unicode logging issue

### DIFF
--- a/core/src/main/python/wlsdeploy/logging/platform_logger.py
+++ b/core/src/main/python/wlsdeploy/logging/platform_logger.py
@@ -2,6 +2,7 @@
 Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
+import java.lang.Object as JObject
 import java.lang.System as JSystem
 import java.lang.Thread as JThread
 import java.lang.Throwable as Throwable
@@ -286,6 +287,14 @@ def _get_args_as_java_array(*args):
     result = JArrayList()
     if args is not None and len(args) > 0:
         for arg in args:
-            result.add(str(arg))
+            if arg is not None:
+                if isinstance(arg, unicode) or isinstance(arg, str):
+                    result.add(arg)
+                elif isinstance(arg, JObject):
+                    result.add(arg.toString())
+                else:
+                    result.add(unicode(arg))
+            else:
+                result.add(str(arg))
     return result.toArray()
 

--- a/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
@@ -8,7 +8,6 @@ from java.net import URI
 from java.net import URISyntaxException
 from java.net import MalformedURLException
 
-from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.discover import DiscoverException
 from oracle.weblogic.deploy.util import PyOrderedDict as OrderedDict
 from oracle.weblogic.deploy.util import StringUtils
@@ -157,7 +156,7 @@ class Discoverer(object):
             model_param, model_value = self._aliases.get_model_attribute_name_and_value(location,
                                                                                         wlst_param,
                                                                                         wlst_value)
-        except AliasException, de:
+        except DiscoverException, de:
             _logger.info('WLSDPLY-06106', wlst_param, wlst_path, de.getLocalizedMessage(),
                          class_name=_class_name, method_name=_method_name)
             return
@@ -668,7 +667,7 @@ class Discoverer(object):
                     wlst_attribute = self._aliases.get_wlst_attribute_name(location, model_attribute)
                     if wlst_attribute:
                         wlst_attributes.append(wlst_attribute)
-                except AliasException:
+                except DiscoverException:
                     continue
         return wlst_attributes
 


### PR DESCRIPTION
1. Fix for logging arguments that are unicode, such as internationalized WLSTException messages
2. Fix in discover for catching DiscoverException instead of AliasException
Fixes #690 