### PR TITLE
Verify that sections are dictionaries, and not single values

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -336,7 +336,7 @@ class Validator(object):
         """
         Validate a root-level section, such as topology, domainInfo
         :param model_section_key: the key for the section
-        :param model_dict: the dictionary under the section
+        :param model_dict: the top-level model dictionary
         :param valid_section_folders: folders that are valid for this section
         """
         _method_name = '__validate_model_section'
@@ -365,13 +365,16 @@ class Validator(object):
             self._logger.finer('WLSDPLY-05013', str(attribute_location), str(path_tokens_attr_keys),
                                class_name=_class_name, method_name=_method_name)
 
+        model_folder_path = model_section_key + ":/"
         model_section_dict = model_dict[model_section_key]
+        if not isinstance(model_section_dict, dict):
+            self._logger.severe('WLSDPLY-05038', model_folder_path, class_name=_class_name, method_name=_method_name)
+            return
+
         for section_dict_key, section_dict_value in model_section_dict.iteritems():
             # section_dict_key is either the name of a folder in the
             # section, or the name of an attribute in the section.
             validation_location = LocationContext()
-
-            model_folder_path = model_section_key + ":/"
 
             if variables.has_variables(section_dict_key):
                 self._report_unsupported_variable_usage(section_dict_key, model_folder_path)
@@ -452,6 +455,10 @@ class Validator(object):
         model_folder_path = self._aliases.get_model_folder_path(validation_location)
         self._logger.finest('1 model_folder_path={0}', model_folder_path,
                             class_name=_class_name, method_name=_method_name)
+
+        if not isinstance(model_node, dict):
+            self._logger.severe('WLSDPLY-05038', model_folder_path, class_name=_class_name, method_name=_method_name)
+            return
 
         if self._aliases.supports_multiple_mbean_instances(validation_location):
             self._logger.finer('2 model_node_type={0}',
@@ -537,9 +544,14 @@ class Validator(object):
     def __process_model_node(self, model_node, validation_location):
         _method_name = '__process_model_node'
 
+        model_folder_path = self._aliases.get_model_folder_path(validation_location)
+
+        if not isinstance(model_node, dict):
+            self._logger.severe('WLSDPLY-05038', model_folder_path, class_name=_class_name, method_name=_method_name)
+            return
+
         valid_folder_keys = self._aliases.get_model_subfolder_names(validation_location)
         valid_attr_infos = self._aliases.get_model_attribute_names_and_types(validation_location)
-        model_folder_path = self._aliases.get_model_folder_path(validation_location)
 
         self._logger.finest('5 model_node={0}', str(model_node), class_name=_class_name, method_name=_method_name)
         self._logger.finest('5 aliases.get_model_subfolder_names(validation_location) returned: {0}',

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -366,7 +366,7 @@ WLSDPLY-01803=Adding roles: {0}
 WLSDPLY-01804=Failed to convert role {0} with expression {1} because {2}
 WLSDPLY-01805=Unexpected {0} during role mapper processing: {1}
 
-# wlsdeploy/util/mbean_utils.py
+# wlsdeploy/tool/util/credential_map_helper.py
 WLSDPLY-01790=Creating default credential mapper initialization file {0}
 WLSDPLY-01791=Attribute "{0}" is required for {1} credential mapping {2}
 
@@ -457,15 +457,16 @@ WLSDPLY-05034=The value for attribute {0} in model location {1} should be a stri
 WLSDPLY-05035=The {0} attribute with value {1} in model location {2}, should be a string but was a {3}
 WLSDPLY-05036=Attribute {0} in model location {1}, uses the {2} macro expression for an integer or references to other another server template configuration element. The Oracle documentation for server templates, cites this as being not supported.
 WLSDPLY-05037=Custom folder {0} will not be validated
+WLSDPLY-05038=Expected a section with subfolders and attributes in model location {0}
 
 # wlsdeploy/tools/validate/validation_utils.py
-WLSDPLY-05300={0} variable is referenced in the value of the {1} variable, but is not defined in {2} 
+WLSDPLY-05300={0} variable is referenced in the value of the {1} variable, but is not defined in {2}
 
 # compare_model.py
 
 WLSDPLY-05701=Model Path: {0} does not exist in new model but exists in previous model
-WLSDPLY-05702=Found unsupported online update shape changes {0} for Kubernetes Operator 
-WLSDPLY-05703=Found unsupported online update network changes {0} for Kubernetes Operator 
+WLSDPLY-05702=Found unsupported online update shape changes {0} for Kubernetes Operator
+WLSDPLY-05703=Found unsupported online update network changes {0} for Kubernetes Operator
 WLSDPLY-05704=Error in compare model {0}
 WLSDPLY-05705=Model {0} is invalid for comparison
 WLSDPLY-05706=Comparing Models: new={0} vs old={1}


### PR DESCRIPTION
When a group is expected in the model, and a string is found, a stack trace occurs. This model has an indention problem, and and `Target` appears to be a JDBC name. The tools fail with a stack trace, expecting it to have a nested group instead of string.

    JDBCSystemResource:
        'Bubba-DS2':
        Target: mycluster
        JdbcResource:
stack trace snippet:

 File "/u01/wdt/weblogic-deploy/lib/python/wlsdeploy/tool/validate/validator.py", line 384, in _Validator__validate_model_section
 File "/u01/wdt/weblogic-deploy/lib/python/wlsdeploy/tool/validate/validator.py", line 461, in _Validator__validate_section_folder
 File "/u01/wdt/weblogic-deploy/lib/python/wlsdeploy/tool/validate/validator.py", line 532, in _Validator__process_model_node
AttributeError: 'string' object has no attribute 'iteritems'