### PR TITLE
Generate a shortened name when secret name exceeds 63 chars

### DIFF
--- a/core/src/main/python/wlsdeploy/util/target_configuration_helper.py
+++ b/core/src/main/python/wlsdeploy/util/target_configuration_helper.py
@@ -274,9 +274,9 @@ def _create_secret_name(variable_name, secret_length=SECRET_NAME_LENGTH):
     # if empty, just return "x".
     secret = '-'.join(secret_keys).strip('-')
     if len(secret) > secret_length:
-        __logger.warning('WLSDPLY-07000', secret_length, secret, class_name=__class_name, method_name=_method_name)
         secret = secret[:secret_length] + '%05d' % __long_key
         __long_key += 1
+        __logger.warning('WLSDPLY-07000', secret_length, secret, class_name=__class_name, method_name=_method_name)
 
     return secret or 'x'
 

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -811,6 +811,9 @@ WLSDPLY-06800=Byte buffer for encrypted field contains an invalid multi-string e
 
 WLSDPLY-06801=Unable to convert encrypted byte array to String value
 
+#oracle.weblogic.deploy.target_configuration.helper
+WLSDPLY-07000=Length of generated secret name exceeded length {0}. Name was truncated to {1}. \
+  Please inspect and modify the name as necessary.
 ###############################################################################
 #                     Aliases messages (08000 - 08999)                        #
 ###############################################################################

--- a/core/src/test/python/target_configuration_helper_test.py
+++ b/core/src/test/python/target_configuration_helper_test.py
@@ -65,6 +65,13 @@ class TargetConfigurationTests(unittest.TestCase):
 
         self.assertEqual('x', HELPER._create_secret_name('--??!!'))
 
+    def testCreateLongSecretName(self):
+        long_name = 'JMS.pretend this is a very very very very long jms resource name.PasswordEncrypted'
+        expected_name = 'jms-pretend-this-is-a-very-very-very-very-long-jms-res00001'
+        expected_name2 = 'jms-pretend-this-is-a-very-very-very-very-long-jms-res00002'
+        self.assertEqual(expected_name, HELPER._create_secret_name(long_name, len(expected_name)-5))
+        self.assertEqual(expected_name2, HELPER._create_secret_name(long_name, len(expected_name)-5))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If name exceeds secret name length (currently 63 chars), truncate the name and overlay the last 5 chars of the truncated name with a 5 char number. 

Log a warning about the truncation.