### PR TITLE
Allow AppDir in model domainInfo section

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -551,8 +551,8 @@ class DomainCreator(Creator):
         self.wlst_helper.load_templates()
 
         self.__set_core_domain_params()
+        self.__set_app_dir()
         if len(extension_templates) > 0:
-            self.__set_app_dir()
             self.__configure_fmw_infra_database()
             self.__configure_opss_secrets()
         topology_folder_list = self.aliases.get_model_topology_top_level_folder_names()

--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/DomainInfo.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/DomainInfo.json
@@ -1,11 +1,12 @@
 {
-    "copyright": "Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.",
+    "copyright": "Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.",
     "license": "Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl",
     "wlst_type": "DomainInfo",
     "folders": { },
     "attributes": {
         "AdminPassword":              [ {"version": "[10,)", "wlst_mode": "both", "wlst_name": "AdminPassword",              "wlst_path": "WP001", "value": {"default": "None" }, "wlst_type": "password"  } ],
         "AdminUserName":              [ {"version": "[10,)", "wlst_mode": "both", "wlst_name": "AdminUserName",              "wlst_path": "WP001", "value": {"default": "None" }, "wlst_type": "string" } ],
+        "AppDir":                     [ {"version": "[10,)", "wlst_mode": "both", "wlst_name": "AppDir",                     "wlst_path": "WP001", "value": {"default": "None" }, "wlst_type": "string", "uses_path_tokens": "true" } ],
         "OPSSSecrets":                [ {"version": "[10,)", "wlst_mode": "both", "wlst_name": "OPSSSecrets",                "wlst_path": "WP001", "value": {"default": "None" }, "wlst_type": "password" } ],
         "ServerGroupTargetingLimits": [ {"version": "[10,)", "wlst_mode": "both", "wlst_name": "ServerGroupTargetingLimits", "wlst_path": "WP001", "value": {"default": "None" }, "wlst_type": "dict" } ],
         "DynamicClusterServerGroupTargetingLimits": [ {"version": "[12.2.1.1,)", "wlst_mode": "both", "wlst_name": "dynamicClusterServerGroupTargetingLimits", "wlst_path": "WP001", "value": {"default": "None" }, "wlst_type": "dict" } ],


### PR DESCRIPTION
Was failing validation, not in modelHelp.

Set AppDir option regardless of extension templates