### PR TITLE
Enable ODL configuration for dynamic servers

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/deploy/odl_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/odl_deployer.py
@@ -17,6 +17,7 @@ from wlsdeploy.aliases.location_context import LocationContext
 from wlsdeploy.aliases.model_constants import ODL_CONFIGURATION
 from wlsdeploy.aliases.model_constants import MODEL_LIST_DELIMITER
 from wlsdeploy.aliases.wlst_modes import WlstModes
+from wlsdeploy.exception import exception_helper
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.util import dictionary_utils
 
@@ -114,9 +115,9 @@ class OdlDeployer(object):
                 source_file = File(log_template_dir, LOGGING_TEMPLATE_FILE)
                 FileUtils.validateExistingFile(source_file)
                 if not server_dir.exists() and not server_dir.mkdirs():
-                    self.logger.severe('WLSDPLY-19707', server_dir, class_name=self.__class_name,
-                                       method_name=_method_name)
-                    return
+                    ex = exception_helper.create_deploy_exception('WLSDPLY-19710', server_dir)
+                    self.logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
+                    raise ex
                 FileUtils.validateWritableDirectory(server_dir.getPath())
 
             document = LoggingConfigurationDocument(FileInputStream(source_file))

--- a/core/src/main/python/wlsdeploy/tool/deploy/odl_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/odl_deployer.py
@@ -35,6 +35,8 @@ _PROPERTIES = "Properties"
 _SERVERS = "Servers"
 _USE_PARENT_HANDLERS = "UseParentHandlers"
 
+LOGGING_TEMPLATE_FILE = "logging-template.xml"
+
 
 class OdlDeployer(object):
     """
@@ -100,10 +102,24 @@ class OdlDeployer(object):
         config_dir = File(self.model_context.get_domain_home(), CONFIG_DIR)
         server_dir = File(config_dir, name)
         config_file = File(server_dir, CONFIG_FILE)
+        log_template_dir = config_dir.getParentFile()
 
         try:
-            FileUtils.validateWritableFile(config_file.getPath())
-            document = LoggingConfigurationDocument(FileInputStream(config_file))
+            if config_file.exists():
+                source_file = config_file
+                FileUtils.validateWritableFile(config_file.getPath())
+            else:
+                # for dynamic servers, the logging config does not exist until the server is started.
+                # read the from template file, verify that the server directory is present and writable.
+                source_file = File(log_template_dir, LOGGING_TEMPLATE_FILE)
+                FileUtils.validateExistingFile(source_file)
+                if not server_dir.exists() and not server_dir.mkdirs():
+                    self.logger.severe('WLSDPLY-19707', server_dir, class_name=self.__class_name,
+                                       method_name=_method_name)
+                    return
+                FileUtils.validateWritableDirectory(server_dir.getPath())
+
+            document = LoggingConfigurationDocument(FileInputStream(source_file))
 
             # configure AddJvmNumber
             add_jvm_number = dictionary_utils.get_element(dictionary, _ADD_JVM_NUMBER)

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1505,6 +1505,7 @@ WLSDPLY-19706=Unable to set property {0} to "{1}" at location {2}: {3}
 WLSDPLY-19707=Unable to update ODL configuration for server {0}: {1}
 WLSDPLY-19708=Applying {0} {1} to server {2}
 WLSDPLY-19709=ODL configuration for non-JRF domains is not supported, skipping
+WLSDPLY-19710=Unable to create logging configuration directory {0}
 
 # Common tooling messages used by multiple tools
 WLSDPLY-20000={0} encountered an unexpected validation error: {1}


### PR DESCRIPTION
Use logging configuration template to configure ODL when server has not been created.