### PR TITLE
Allow target deletes for compareModel tool

### DIFF
--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -421,7 +421,7 @@ class ModelDiffer:
                 previous_text = ','.join(previous_list)
                 comment = attribute_name + ": '" + previous_text + "' -> '" + current_text + "'"
             elif not isinstance(previous_value, dict):
-                comment = attribute_name + ": '" + previous_value + "'"
+                comment = attribute_name + ": '" + str(previous_value) + "'"
 
         return change_value, comment
 

--- a/core/src/main/python/wlsdeploy/util/model_helper.py
+++ b/core/src/main/python/wlsdeploy/util/model_helper.py
@@ -36,3 +36,14 @@ def get_delete_item_name(name):
     ex = exception_helper.create_deploy_exception('WLSDPLY-09111', name)
     _logger.throwing(ex, class_name=_class_name, method_name=_method_name)
     raise ex
+
+
+def get_delete_name(name):
+    """
+    Returns the delete name for the specified name by adding a "!" prefix.
+    :param name: the name be adjusted
+    :return: the delete name for the name
+    """
+    _method_name = 'get_delete_name'
+
+    return "!" + name

--- a/core/src/main/python/wlsdeploy/yaml/yaml_translator.py
+++ b/core/src/main/python/wlsdeploy/yaml/yaml_translator.py
@@ -17,6 +17,7 @@ import oracle.weblogic.deploy.yaml.YamlStreamTranslator as JYamlStreamTranslator
 import oracle.weblogic.deploy.yaml.YamlTranslator as JYamlTranslator
 
 from wlsdeploy.exception import exception_helper
+from wlsdeploy.json.json_translator import COMMENT_MATCH
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.yaml.dictionary_list import DictionaryList
 
@@ -166,7 +167,9 @@ class PythonToYaml(object):
 
         for key, value in dictionary.iteritems():
             quoted_key = self._quotify_string(key)
-            if isinstance(value, DictionaryList):
+            if key.startswith(COMMENT_MATCH):
+                writer.println(indent + "# " + str(value))
+            elif isinstance(value, DictionaryList):
                 writer.println(indent + quoted_key + ':')
                 self._write_dictionary_list_to_yaml_file(value, writer, indent)
             elif isinstance(value, dict):

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -482,6 +482,7 @@ WLSDPLY-05708=An error occurred while trying to write file {0}: {1}
 WLSDPLY-05709=Fatal compare model error {0}
 WLSDPLY-05710=The models are identical
 WLSDPLY-05711=The model differences and output is written to the directory {0}
+WLSDPLY-05712=Unrecognized token {0} in path {1}
 
 # prepare_model.py
 WLSDPLY-05801=Error in prepare model {0}


### PR DESCRIPTION
Internal Jira WDT-474

Refine lists to reflect only deltas, including deletions, in change model.

Derive alias location and attribute name from change path.

Renamed some variables in compare_model._add_results() .

Allow more general model comments.

Use single aliases instance.