### PR TITLE
Issue #739 library deploy manifest

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -989,12 +989,32 @@ class ApplicationsDeployer(Deployer):
 
     def __deploy_app_online(self, application_name, source_path, targets, plan=None, partition=None,
                             resource_group=None, resource_group_template=None, options=None):
+        """
+        Deploy an application or shared library in online mode.
+        :param application_name: the name of the app or library from the model
+        :param source_path: the source path of the app or library
+        :param targets: the intended targets
+        :param plan: optional, the path to the plan
+        :param partition: optional, the partition
+        :param resource_group: optional, the resource group
+        :param resource_group_template: optional, the resource group template
+        :param options: optional, extra options for the WLST deploy() call
+        """
         _method_name = '__deploy_app_online'
 
-        self.logger.info('WLSDPLY-09316', application_name, class_name=self._class_name, method_name=_method_name)
+        is_library = False
+        if options is not None:
+            is_library = dictionary_utils.get_element(options, 'libraryModule') == 'true'
+
+        type_name = APPLICATION
+        if is_library:
+            type_name = LIBRARY
+
+        self.logger.info('WLSDPLY-09316', type_name, application_name, class_name=self._class_name,
+                         method_name=_method_name)
 
         if string_utils.is_empty(source_path):
-            ex = exception_helper.create_deploy_exception('WLSDPLY-09317', application_name, SOURCE_PATH)
+            ex = exception_helper.create_deploy_exception('WLSDPLY-09317', type_name, application_name, SOURCE_PATH)
             self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
             raise ex
 
@@ -1002,12 +1022,16 @@ class ApplicationsDeployer(Deployer):
             source_path = self.model_context.get_domain_home() + '/' + source_path
 
         if not os.path.exists(source_path):
-            ex = exception_helper.create_deploy_exception('WLSDPLY-09318', application_name, str(source_path))
+            ex = exception_helper.create_deploy_exception('WLSDPLY-09318', type_name, application_name,
+                                                          str(source_path))
             self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
             raise ex
 
-        # if options is not None and 'libraryModule' in options and string_utils.to_boolean(options['libraryModule']):
-        computed_name = self.__get_deployable_application_versioned_name(source_path, application_name)
+        if is_library:
+            computed_name = self.__get_deployable_library_versioned_name(source_path, application_name)
+        else:
+            computed_name = self.__get_deployable_application_versioned_name(source_path, application_name)
+
         application_name = computed_name
 
         # build the dictionary of named arguments to pass to the deploy_application method
@@ -1018,7 +1042,7 @@ class ApplicationsDeployer(Deployer):
                 plan = self.model_context.get_domain_home() + '/' + plan
 
             if not os.path.exists(plan):
-                ex = exception_helper.create_deploy_exception('WLSDPLY-09319', application_name, plan)
+                ex = exception_helper.create_deploy_exception('WLSDPLY-09319', type_name, application_name, plan)
                 self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
                 raise ex
             kwargs['planPath'] = str(plan)
@@ -1033,7 +1057,7 @@ class ApplicationsDeployer(Deployer):
                 kwargs[key] = value
         kwargs['timeout'] = self.model_context.get_model_config().get_deploy_timeout()
 
-        self.logger.fine('WLSDPLY-09320', application_name, kwargs,
+        self.logger.fine('WLSDPLY-09320', type_name, application_name, kwargs,
                          class_name=self._class_name, method_name=_method_name)
         self.wlst_helper.deploy_application(application_name, *args, **kwargs)
         return application_name

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1048,11 +1048,11 @@ WLSDPLY-09312=Stopping application {0} for update
 WLSDPLY-09313=Starting application {0}
 WLSDPLY-09314=Undeploying {0} {1} for update
 WLSDPLY-09315=Redeploying application {0} because a shared library referenced has been updated
-WLSDPLY-09316=Deploying application {0}
-WLSDPLY-09317=The application or library named {0} cannot be deployed because the {1} attribute is not specified
-WLSDPLY-09318={0} Source Path {1} does not exists
-WLSDPLY-09319=The application {0} specified Plan Path {1} that does not exist
-WLSDPLY-09320=Deploying application {0} with arguments {1}
+WLSDPLY-09316=Deploying {0} {1}
+WLSDPLY-09317={0} {1} cannot be deployed because the {2} attribute is not specified
+WLSDPLY-09318={0} {1} Source Path {2} does not exists
+WLSDPLY-09319={0} {1} specified Plan Path {2} that does not exist
+WLSDPLY-09320=Deploying {0} {1} with arguments {2}
 WLSDPLY-09321=Invalid Manifest found in processing shared library {0} at {1}: Extension-Name attribute \
   specified with no value: {2}
 WLSDPLY-09322=Invalid Manifest found in processing shared library {0} at {1}: Implementation-Version attribute \


### PR DESCRIPTION
Solves the original problem in #739 - deriving the versioned name for a library from its manifest for initial online deployment.

The issue of avoiding redeployment of a library (or application) when the versioned name matches an existing deployment is unresolved. There are complex issues with determining the versioned name during the strategy phase that will require additional changes.

