### PR TITLE
Don't capitalize true/false values when parsing model

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
+++ b/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
@@ -305,10 +305,8 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
         String booleanValue = "False";
         if (!StringUtils.isEmpty(text)) {
             text = StringUtils.stripQuotes(text.trim());
-            // don't adjust case, these may not be intended as boolean
-            if ("true".equalsIgnoreCase(text)) {
-                booleanValue = text;
-            } else if ("false".equalsIgnoreCase(text)) {
+            // don't adjust value, it may not be intended as boolean
+            if ("true".equalsIgnoreCase(text) || "false".equalsIgnoreCase(text)) {
                 booleanValue = text;
             } else {
                 getLogger().warning("WLSDPLY-18000", name, text);

--- a/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
+++ b/core/src/main/java/oracle/weblogic/deploy/yaml/AbstractYamlTranslator.java
@@ -305,10 +305,11 @@ public abstract class AbstractYamlTranslator extends YamlBaseListener {
         String booleanValue = "False";
         if (!StringUtils.isEmpty(text)) {
             text = StringUtils.stripQuotes(text.trim());
+            // don't adjust case, these may not be intended as boolean
             if ("true".equalsIgnoreCase(text)) {
-                booleanValue = "True";
+                booleanValue = text;
             } else if ("false".equalsIgnoreCase(text)) {
-                booleanValue = "False";
+                booleanValue = text;
             } else {
                 getLogger().warning("WLSDPLY-18000", name, text);
             }

--- a/core/src/test/python/variable_injector_test.py
+++ b/core/src/test/python/variable_injector_test.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2018, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import unittest
@@ -215,8 +215,8 @@ class VariableFileHelperTest(unittest.TestCase):
     def testWithListMBeanName(self):
         expected = dict()
         short_name = self._helper.get_folder_short_name(LocationContext().append_location('Server'))
-        expected[short_name + '.m1.SSL.Enabled'] = 'True'
-        expected[short_name + '.m2.SSL.Enabled'] = 'True'
+        expected[short_name + '.m1.SSL.Enabled'] = 'true'
+        expected[short_name + '.m2.SSL.Enabled'] = 'true'
         replacement_dict = dict()
         replacement_dict['Server[m1,m2].SSL.Enabled'] = dict()
         actual = self._helper.inject_variables(replacement_dict)
@@ -225,8 +225,8 @@ class VariableFileHelperTest(unittest.TestCase):
     def testWithManagedServerKeyword(self):
         short_name = self._helper.get_folder_short_name(LocationContext().append_location('Server'))
         expected = dict()
-        expected[short_name + '.m1.SSL.Enabled'] = 'True'
-        expected[short_name + '.m2.SSL.Enabled'] = 'True'
+        expected[short_name + '.m1.SSL.Enabled'] = 'true'
+        expected[short_name + '.m2.SSL.Enabled'] = 'true'
         replacement_dict = dict()
         replacement_dict['Server[MANAGED_SERVERS].SSL.Enabled'] = dict()
         actual = self._helper.inject_variables(replacement_dict)
@@ -234,9 +234,9 @@ class VariableFileHelperTest(unittest.TestCase):
 
     def testWithMultiKeyword(self):
         expected = dict()
-        expected['Server.AdminServer.SSL.Enabled'] = 'True'
-        expected['Server.m1.SSL.Enabled'] = 'True'
-        expected['Server.m2.SSL.Enabled'] = 'True'
+        expected['Server.AdminServer.SSL.Enabled'] = 'true'
+        expected['Server.m1.SSL.Enabled'] = 'true'
+        expected['Server.m2.SSL.Enabled'] = 'true'
         replacement_dict = dict()
         replacement_dict['Server[MANAGED_SERVERS,ADMIN_SERVER].SSL.Enabled'] = dict()
         actual = self._helper.inject_variables(replacement_dict)


### PR DESCRIPTION
Example: WebAppFilesCaseInsensitive can have values of [false, os, true]

Internal Jira WDT-463