### PR TITLE
Fix conversion problem in JSON translator

### DIFF
--- a/core/src/main/python/wlsdeploy/json/json_translator.py
+++ b/core/src/main/python/wlsdeploy/json/json_translator.py
@@ -233,8 +233,10 @@ def _format_json_value(value):
     """
     import java.lang.StringBuilder as StringBuilder
     builder = StringBuilder()
-    if type(value) == bool or (isinstance(value, types.StringTypes) and (value == 'true' or value == 'false')):
+    if type(value) == bool:
         builder.append(JBoolean.toString(value))
+    elif isinstance(value, types.StringTypes) and (value == 'true' or value == 'false'):
+        builder.append(value)
     elif isinstance(value, types.StringTypes):
         builder.append('"').append(_escape_text(value.strip())).append('"')
     else:


### PR DESCRIPTION
Resolves 14.1.1 compareModel unit test problems.
Make separate case for boolean text, no longer auto-converted with newer Jython.

Internal Jira WDT-486
