### PR TITLE
System test: generate the sample archive in the target/resources directory

### DIFF
--- a/system-test/src/test/java/oracle/weblogic/deploy/integration/BaseTest.java
+++ b/system-test/src/test/java/oracle/weblogic/deploy/integration/BaseTest.java
@@ -197,6 +197,10 @@ public class BaseTest {
         return getProjectRoot() + FS + "src" + FS + "test" + FS + "resources";
     }
 
+    protected static String getGeneratedResourcePath() {
+        return getTargetDir() + FS + "resources";
+    }
+
     protected static ExecResult buildSampleArchive() throws Exception {
         logger.info("Building WDT archive ...");
         String command = "sh " + getResourcePath() + FS + "build-archive.sh";
@@ -204,7 +208,7 @@ public class BaseTest {
     }
 
     protected static String getSampleArchiveFile() throws Exception {
-        return getResourcePath() + FS + SAMPLE_ARCHIVE_FILE;
+        return getGeneratedResourcePath() + FS + SAMPLE_ARCHIVE_FILE;
     }
 
     protected static String getSampleModelFile(String suffix) throws Exception {

--- a/system-test/src/test/resources/build-archive.sh
+++ b/system-test/src/test/resources/build-archive.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 #
-#Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates.
 #
-#Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+# Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 #
-rm -Rf src/test/resources/archive
-mkdir -p src/test/resources/archive/wlsdeploy/applications
+projectDir=$(pwd)
+archiveDir=${projectDir}/target/resources/archive
+rm -Rf $archiveDir
+mkdir -p $archiveDir/wlsdeploy/applications
 cd ../samples/docker-domain/simple-app
-jar cvf ../../../system-test/src/test/resources/archive/wlsdeploy/applications/simple-app.war  *
-cd ../../../system-test/src/test/resources/archive
+jar cvf $archiveDir/wlsdeploy/applications/simple-app.war  *
+cd $archiveDir
 jar cvf ../archive.zip *


### PR DESCRIPTION
Avoid generating under src directory, accidentally committing.
System test ran clean, archive is being referenced under target dir.