### PR TITLE
Restore cluster dynamic size after setServerGroups reset value

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/util/target_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/target_helper.py
@@ -591,7 +591,7 @@ class TargetHelper(object):
         for cluster in cluster_map.iterkeys():
             wlst_attribute = self.__locate_dynamic_attribute(cluster)
             bug_map[cluster] = self.wlst_helper.get(wlst_attribute)
-            self.logger.finer('WLSDPLY-12559', cluster, bug_map[cluster],
+            self.logger.finer('WLSDPLY-12560', cluster, bug_map[cluster],
                               class_name=self.__class_name, method_name=_method_name)
         return bug_map
 
@@ -605,7 +605,7 @@ class TargetHelper(object):
             if attribute_value is not None:
                 wlst_attribute = self.__locate_dynamic_attribute(cluster)
                 self.wlst_helper.set(wlst_attribute, attribute_value)
-                self.logger.finer('WLSDPLY-12560', cluster, wlst_attribute,
+                self.logger.finer('WLSDPLY-12561', cluster, wlst_attribute,
                                   class_name=self.__class_name, method_name=_method_name)
 
     def __locate_dynamic_attribute(self, cluster):

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1281,6 +1281,8 @@ WLSDPLY-12257=No server group found for dynamic cluster {0}. Versions of WebLogi
   do not support targeting more than one server group to a dynamic cluster. Server group not defined in domain typedef
 WLSDPLY-12258=RCU {0} file {1} is invalid : {2}
 WLSDPLY-12259=Error creating directory {0} to extract RCU {1} file {2}
+WLSDPLY-12560=Dynamic cluster {0} has size of {1}
+WLSDPLY-12561=Dynamic cluster {0} set to size of {1}
 
 # domain_typedef.py
 WLSDPLY-12300={0} got the domain type {1} but the domain type definition file {2} was not valid: {3}


### PR DESCRIPTION
One off code to save off the original dynamic cluster size and restore after setservergroups resets the value \.

Would appreciate someone testing this.