### PR TITLE
Check for long secret names in generated script

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,7 @@
                     <include>oracle/**/*.json</include>
                     <include>oracle/**/*.ldift</include>
                     <include>oracle/**/*.properties</include>
+                    <include>oracle/**/*.sh</include>
                     <include>oracle/**/*.yaml</include>
                 </includes>
                 <filtering>false</filtering>

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -424,7 +424,8 @@ def __check_and_customize_model(model, model_context, aliases, credential_inject
 
         # Generate k8s create secret script
         if target_configuration.uses_credential_secrets():
-            target_configuration_helper.generate_k8s_script(model_context, credential_cache, model.get_model())
+            target_configuration_helper.generate_k8s_script(model_context, credential_cache, model.get_model(),
+                                                            ExceptionType.DISCOVER)
 
         # create additional output after filtering, but before variables have been inserted
         if model_context.is_targetted_config():

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -302,7 +302,7 @@ class PrepareModel:
             if target_config.uses_credential_secrets():
                 target_configuration_helper.generate_k8s_script(self.model_context,
                                                                 self.credential_injector.get_variable_cache(),
-                                                                full_model_dictionary)
+                                                                full_model_dictionary, ExceptionType.VALIDATE)
 
             # create any additional outputs from full model dictionary
             target_configuration_helper.create_additional_output(Model(full_model_dictionary), self.model_context,

--- a/core/src/main/python/wlsdeploy/tool/util/targets/file_template_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/targets/file_template_helper.py
@@ -19,7 +19,7 @@ from wlsdeploy.util import dictionary_utils
 __class_name = 'file_template_helper'
 __logger = PlatformLogger('wlsdeploy.tool.util')
 
-_substitution_pattern = re.compile("({{{(.*)}}})")
+_substitution_pattern = re.compile("({{{([.-}]*)}}})")
 _block_start_pattern = re.compile("({{#(.*)}})")
 _block_end_pattern = re.compile("({{/(.*)}})")
 

--- a/core/src/main/resources/oracle/weblogic/deploy/k8s/create_k8s_secrets.sh
+++ b/core/src/main/resources/oracle/weblogic/deploy/k8s/create_k8s_secrets.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -eu
+
+# {{{topComment}}}
+NAMESPACE=default
+DOMAIN_UID={{{domainUid}}}
+
+LONG_SECRETS=()
+
+function check_secret_name {
+  if [ ${#1} -gt 63 ]; then
+    LONG_SECRETS+=($1)
+  fi
+}
+
+function create_k8s_secret {
+  SECRET_NAME=${DOMAIN_UID}-$1
+  check_secret_name ${SECRET_NAME}
+  kubectl -n $NAMESPACE delete secret ${SECRET_NAME} --ignore-not-found
+  kubectl -n $NAMESPACE create secret generic ${SECRET_NAME} --from-literal=password=$2
+  kubectl -n $NAMESPACE label secret ${SECRET_NAME} weblogic.domainUID=${DOMAIN_UID}
+}
+
+function create_paired_k8s_secret {
+  SECRET_NAME=${DOMAIN_UID}-$1
+  check_secret_name ${SECRET_NAME}
+  kubectl -n $NAMESPACE delete secret ${SECRET_NAME} --ignore-not-found
+  kubectl -n $NAMESPACE create secret generic ${SECRET_NAME} --from-literal=username=$2 --from-literal=password=$3
+  kubectl -n $NAMESPACE label secret ${SECRET_NAME} weblogic.domainUID=${DOMAIN_UID}
+}
+{{#pairedSecrets}}
+
+# {{{comment}}}
+create_paired_k8s_secret {{{secretName}}} {{{user}}} {{{password}}}
+{{/pairedSecrets}}
+{{#secrets}}
+
+# {{{comment}}}
+create_k8s_secret {{{secretName}}} {{{password}}}
+{{/secrets}}
+
+LONG_SECRETS_COUNT=${#LONG_SECRETS[@]}
+if [ ${LONG_SECRETS_COUNT} -gt 0 ]; then
+  echo ""
+  echo "{{{longMessage}}}"
+  for NAME in "${LONG_SECRETS[@]}"; do
+    echo "  ${NAME}"
+  done
+  echo ""
+{{#longMessageDetails}}
+  echo "{{{text}}}"
+{{/longMessageDetails}}
+fi

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -303,6 +303,10 @@ WLSDPLY-01663=Update {0} for {1}
 WLSDPLY-01664=Update {0} and {1} for {2}
 WLSDPLY-01665=Edit these values to change the namespace or domain UID
 WLSDPLY-01666=Unable to open file template {0}: {1}
+WLSDPLY-01667=WARNING: These {0} secret names are too long to be mounted in a Kubernetes pod:
+WLSDPLY-01668=Secret names to be mounted in a Kubernetes pod should be limited to 63 characters.
+WLSDPLY-01669=To correct this, shorten the DOMAIN_UID or the secret key(s) in this generated script and re-execute.
+WLSDPLY-01670=Update the corresponding secret references in the WDT model(s) to match these values before deployment.
 
 # wlsdeploy/util/enum.py
 WLSDPLY-01700=The value {0} is not a valid value of the Enum type {1}


### PR DESCRIPTION
Use a template for generated script.

Internal Jira WDT-470

Sample output:
```
secret "very-very-long-domain-uid-weblogic-credentials" deleted
secret/very-very-long-domain-uid-weblogic-credentials created
secret/very-very-long-domain-uid-weblogic-credentials labeled
secret "very-very-long-domain-uid-jdbc-very-very-long-datasource-name-too-long-really" deleted
secret/very-very-long-domain-uid-jdbc-very-very-long-datasource-name-too-long-really created
secret/very-very-long-domain-uid-jdbc-very-very-long-datasource-name-too-long-really labeled
secret/very-very-long-domain-uid-jdbc-another-very-very-long-datasource-name created
secret/very-very-long-domain-uid-jdbc-another-very-very-long-datasource-name labeled

WARNING: These 2 secret names are too long to be mounted in a Kubernetes pod:
  very-very-long-domain-uid-jdbc-very-very-long-datasource-name-too-long-really
  very-very-long-domain-uid-jdbc-another-very-very-long-datasource-name

Secret names to be mounted in a Kubernetes pod should be limited to 63 characters.
To correct this, shorten the DOMAIN_UID or the secret key(s) in this generated script and re-execute.
Update the corresponding secret references in the WDT model(s) to match these values before deployment.
```
