### PR TITLE
JSON formatter - don't convert true / false strings to boolean

### DIFF
--- a/core/src/main/python/wlsdeploy/json/json_translator.py
+++ b/core/src/main/python/wlsdeploy/json/json_translator.py
@@ -235,8 +235,6 @@ def _format_json_value(value):
     builder = StringBuilder()
     if type(value) == bool:
         builder.append(JBoolean.toString(value))
-    elif isinstance(value, types.StringTypes) and (value == 'true' or value == 'false'):
-        builder.append(value)
     elif isinstance(value, types.StringTypes):
         builder.append('"').append(_escape_text(value.strip())).append('"')
     else:


### PR DESCRIPTION
This results in some boolean fields becoming strings in the JSON model, but TypeUtils converts those correctly when the model is applied to the domain.

Internal JIRA WDT-532
