### PR TITLE
WIP: Avoid undeploying apps and libraries when targets are deleted

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -232,23 +232,16 @@ class ApplicationsDeployer(Deployer):
         # libraries to be undeployed
         update_library_list = list()
 
-        # app targets to be deleted
-        app_delete_targets = dict()
-
-        # library targets to be deleted
-        lib_delete_targets = dict()
-
         lib_location = LocationContext(base_location).append_location(LIBRARY)
         # Go through the model libraries and find existing libraries that are referenced
         # by applications and compute a processing strategy for each library.
         self.__build_library_deploy_strategy(lib_location, model_shared_libraries, existing_lib_refs,
-                                             stop_app_list, update_library_list, stop_and_undeploy_app_list,
-                                             lib_delete_targets)
+                                             stop_app_list, update_library_list, stop_and_undeploy_app_list)
 
         # Go through the model applications and compute the processing strategy for each application.
         app_location = LocationContext(base_location).append_location(APPLICATION)
         self.__build_app_deploy_strategy(app_location, model_applications, existing_app_refs,
-                                         stop_and_undeploy_app_list, app_delete_targets)
+                                         stop_and_undeploy_app_list)
 
         # deployed_app_list is list of apps that has been deployed and stareted again
         # redeploy_app_list is list of apps that needs to be redeplyed
@@ -267,18 +260,6 @@ class ApplicationsDeployer(Deployer):
         for app in stop_and_undeploy_app_list:
             self.__stop_app(app)
             self.__undeploy_app(app)
-
-        # targets were deleted from an app, so undeploy for those specific targets
-        for app in app_delete_targets:
-            delete_targets = app_delete_targets[app]
-            if delete_targets:
-                self.__undeploy_app(app, targets=delete_targets)
-
-        # targets were deleted from a library, so undeploy for those specific targets
-        for lib in lib_delete_targets:
-            delete_targets = lib_delete_targets[lib]
-            if delete_targets:
-                self.__undeploy_app(lib, library_module='true', targets=delete_targets)
 
         # library is updated, it must be undeployed first
         for lib in update_library_list:
@@ -521,7 +502,7 @@ class ApplicationsDeployer(Deployer):
         return existing_libraries
 
     def __build_library_deploy_strategy(self, location, model_libs, existing_lib_refs, stop_app_list,
-                                        update_library_list, stop_and_undeploy_app_list, lib_delete_targets):
+                                        update_library_list, stop_and_undeploy_app_list):
         """
         Update maps and lists to control re-deployment processing.
         :param location: the location of the libraries
@@ -530,7 +511,6 @@ class ApplicationsDeployer(Deployer):
         :param stop_app_list: a list to update with dependent apps to be stopped and undeployed
         :param update_library_list: a list to update with libraries to be stopped before deploying
         :param stop_and_undeploy_app_list: a list to update with libraries to be stopped and undeployed
-        :param lib_delete_targets: a map to update with delete targets for libraries
         """
         _method_name = '__build_library_deploy_strategy'
 
@@ -563,9 +543,8 @@ class ApplicationsDeployer(Deployer):
 
                 existing_lib_ref = dictionary_utils.get_dictionary_element(existing_lib_refs, versioned_name)
 
-                # collect the delete targets, and remove them from the model and existing targets
-                lib_delete_targets[versioned_name] = \
-                    self.__extract_delete_targets(lib_dict, existing_lib_ref, location, lib)
+                # remove deleted targets from the model and the existing library targets
+                self.__remove_delete_targets(lib_dict, existing_lib_ref)
 
                 if versioned_name in existing_libs:
                     # skipping absolute path libraries if they are the same
@@ -628,15 +607,13 @@ class ApplicationsDeployer(Deployer):
                                 lib_dict['SourcePath'] = existing_src_path
         return
 
-    def __build_app_deploy_strategy(self, location, model_apps, existing_app_refs, stop_and_undeploy_app_list,
-                                    app_delete_targets):
+    def __build_app_deploy_strategy(self, location, model_apps, existing_app_refs, stop_and_undeploy_app_list):
         """
         Update maps and lists to control re-deployment processing.
         :param location: the location of the applications
         :param model_apps: a copy of applications from the model, attributes may be revised
         :param existing_app_refs: map of information about each existing app
         :param stop_and_undeploy_app_list: a list to update with apps to be stopped and undeployed
-        :param app_delete_targets: a map to update with delete targets for applications
         """
         _method_name = '__build_app_deploy_strategy'
 
@@ -665,9 +642,8 @@ class ApplicationsDeployer(Deployer):
 
                 existing_app_ref = dictionary_utils.get_dictionary_element(existing_app_refs, versioned_name)
 
-                # collect the delete targets, and remove them from the model and existing targets
-                app_delete_targets[versioned_name] = \
-                    self.__extract_delete_targets(app_dict, existing_app_ref, location, app)
+                # remove deleted targets from the model and the existing app targets
+                self.__remove_delete_targets(app_dict, existing_app_ref)
 
                 if versioned_name in existing_apps:
                     # Compare the hashes of the domain's existing apps to the model's apps.
@@ -719,17 +695,13 @@ class ApplicationsDeployer(Deployer):
                         stop_and_undeploy_app_list.append(versioned_name)
         return
 
-    def __extract_delete_targets(self, model_dict, existing_ref, location, name):
+    def __remove_delete_targets(self, model_dict, existing_ref):
         """
-        Create a comma-separated list of targets to be deleted for an app or library.
-        Remove those targets from the model and existing target dictionaries.
+        Remove deleted targets from the model and existing target dictionaries.
         :param model_dict: the model dictionary for the app or library, may be modified
         :param existing_ref: the existing dictionary for the app or library, may be modified
-        :param location: the location of the app or library, for logging
-        :param name: the name of the app or library, for logging
-        :return: a comma-separated list of targets to be removed, empty string for no targets
         """
-        _method_name = '__extract_delete_targets'
+        _method_name = '__remove_delete_targets'
 
         model_targets = dictionary_utils.get_element(model_dict, TARGET)
         model_targets = alias_utils.create_list(model_targets, 'WLSDPLY-08000')
@@ -738,7 +710,6 @@ class ApplicationsDeployer(Deployer):
         if not existing_targets:
             existing_targets = list()
 
-        delete_targets = []
         model_targets_iterator = list(model_targets)
         for model_target in model_targets_iterator:
             if model_helper.is_delete_name(model_target):
@@ -746,15 +717,8 @@ class ApplicationsDeployer(Deployer):
                 target_name = model_helper.get_delete_item_name(model_target)
                 if target_name in existing_targets:
                     existing_targets.remove(target_name)
-                    delete_targets.append(target_name)
-                else:
-                    location.add_name_token(self.aliases.get_name_token(location), name)
-                    location_path = self.aliases.get_model_folder_path(location)
-                    self.logger.warning('WLSDPLY-08022', model_target, TARGET, location_path,
-                                        class_name=self._class_name, method_name=_method_name)
 
         model_dict[TARGET] = ",".join(model_targets)
-        return ",".join(delete_targets)
 
     def __verify_delete_versioned_app(self, app, existing_apps, type='app'):
         """

--- a/core/src/main/python/wlsdeploy/tool/deploy/deployer_utils.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/deployer_utils.py
@@ -7,6 +7,8 @@ import os
 from sets import Set
 
 from java.io import IOException
+from java.io import PrintStream
+from java.lang import System
 from java.net import URI
 from java.net import URISyntaxException
 from java.security import NoSuchAlgorithmException
@@ -17,7 +19,12 @@ from oracle.weblogic.deploy.util import StringUtils
 from oracle.weblogic.deploy.util import PyWLSTException
 from oracle.weblogic.deploy.util import WLSDeployArchive
 
+from oracle.weblogic.deploy.exception import BundleAwareException
+
+from wlsdeploy.aliases import alias_utils
 from wlsdeploy.aliases.location_context import LocationContext
+from wlsdeploy.aliases.model_constants import APPLICATION
+from wlsdeploy.aliases.model_constants import APP_DEPLOYMENTS
 from wlsdeploy.aliases.model_constants import CLUSTER
 from wlsdeploy.aliases.model_constants import DYNAMIC_CLUSTER_SIZE
 from wlsdeploy.aliases.model_constants import DYNAMIC_SERVERS
@@ -25,17 +32,22 @@ from wlsdeploy.aliases.model_constants import FILE_URI
 from wlsdeploy.aliases.model_constants import JDBC_DRIVER_PARAMS
 from wlsdeploy.aliases.model_constants import JDBC_RESOURCE
 from wlsdeploy.aliases.model_constants import JDBC_SYSTEM_RESOURCE
+from wlsdeploy.aliases.model_constants import LIBRARY
 from wlsdeploy.aliases.model_constants import MAX_DYNAMIC_SERVER_COUNT
 from wlsdeploy.aliases.model_constants import SERVER
 from wlsdeploy.aliases.model_constants import SERVER_NAME_PREFIX
 from wlsdeploy.aliases.model_constants import SERVER_NAME_START_IDX
+from wlsdeploy.aliases.model_constants import TARGET
 from wlsdeploy.aliases.validation_codes import ValidationCodes
 from wlsdeploy.aliases.wlst_modes import WlstModes
 from wlsdeploy.exception import exception_helper
 from wlsdeploy.exception.expection_types import ExceptionType
 from wlsdeploy.logging import platform_logger
-from wlsdeploy.util import model_helper
+from wlsdeploy.tool.util.string_output_stream import StringOutputStream
 from wlsdeploy.tool.util.wlst_helper import WlstHelper
+from wlsdeploy.util import dictionary_utils
+from wlsdeploy.util import model_helper
+from wlsdeploy.util.cla_utils import CommandLineArgUtil
 
 from wlsdeploy.aliases.model_constants import RESOURCE_GROUP
 from wlsdeploy.aliases.model_constants import RESOURCE_GROUP_TEMPLATE
@@ -556,6 +568,63 @@ def get_list_of_restarts():
     return restart_list
 
 
+def online_check_save_activate(model_context):
+    """
+    For online update and deploy, check if restart is required, then cancel or save and activate.
+    :param model_context: used to perform checks
+    :return: the exit code for the tool
+    :raises BundleAwareException: if an error occurs during the process
+    """
+    _method_name = 'online_check_save_activate'
+    exit_code = 0
+
+    try:
+        # First we enable the stdout again and then redirect the stdoout to a string output stream
+        # call isRestartRequired to get the output, capture the string and then silence wlst output again
+
+        _wlst_helper.enable_stdout()
+        sostream = StringOutputStream()
+        System.setOut(PrintStream(sostream))
+        restart_required = _wlst_helper.is_restart_required()
+        is_restartreq_output = sostream.get_string()
+        _wlst_helper.silence()
+        if model_context.is_cancel_changes_if_restart_required() and restart_required:
+            _wlst_helper.cancel_edit()
+            _logger.warning('WLSDPLY_09015', is_restartreq_output)
+            exit_code = CommandLineArgUtil.PROG_CANCEL_CHANGES_IF_RESTART_EXIT_CODE
+            list_non_dynamic_changes(model_context, is_restartreq_output)
+        else:
+            _wlst_helper.save()
+            _wlst_helper.activate(model_context.get_model_config().get_activate_timeout())
+            if restart_required:
+                exit_code = CommandLineArgUtil.PROG_RESTART_REQUIRED
+                list_non_dynamic_changes(model_context, is_restartreq_output)
+                exit_code = list_restarts(model_context, exit_code)
+
+    except BundleAwareException, ex:
+        release_edit_session_and_disconnect()
+        raise ex
+
+    return exit_code
+
+
+def release_edit_session_and_disconnect():
+    """
+    An online error recovery method.
+    """
+    _method_name = 'release_edit_session_and_disconnect'
+    try:
+        _wlst_helper.undo()
+        _wlst_helper.stop_edit()
+        _wlst_helper.disconnect()
+    except BundleAwareException, ex:
+        # This method is only used for cleanup after an error so don't mask
+        # the original problem by throwing yet another exception...
+        _logger.warning('WLSDPLY-09012', ex.getLocalizedMessage(), error=ex,
+                        class_name=_class_name, method_name=_method_name)
+    return
+
+
 def check_if_dynamic_cluster(server_name, cluster_name, aliases):
     """
     Determine if the server is part of a dynamic cluster.
@@ -605,3 +674,55 @@ def check_if_dynamic_cluster(server_name, cluster_name, aliases):
                 return True
     return False
 
+
+def delete_online_deployment_targets(model, aliases, wlst_mode):
+    """
+    For online deploy and update, remove any deleted targets from existing apps and libraries.
+    This step needs to occur during the WLST edit session, before regular app/library deployment.
+    :param model: the model to be examined
+    :param aliases: to resolve WLST paths
+    :param wlst_mode: to check for online mode
+    """
+    if wlst_mode == WlstModes.ONLINE:
+        app_deployments = dictionary_utils.get_dictionary_element(model.get_model(), APP_DEPLOYMENTS)
+        __delete_online_targets(app_deployments, APPLICATION, aliases)
+        __delete_online_targets(app_deployments, LIBRARY, aliases)
+
+
+def __delete_online_targets(app_deployments, model_type, aliases):
+    """
+    For online deploy and update, remove any deleted targets from existing objects of the specified type.
+    Objects may be applications or libraries.
+    :param app_deployments: the APP_DEPLOYMENTS dictionary from the model
+    :param model_type: map of library targets to be deleted
+    :param aliases: the parent location of the apps and libraries
+    """
+    _method_name = '__delete_online_targets'
+
+    location = LocationContext().append_location(model_type)
+    wlst_path = aliases.get_wlst_list_path(location)
+    wlst_names = _wlst_helper.get_existing_object_list(wlst_path)
+    name_token = aliases.get_name_token(location)
+
+    deploy_dict = dictionary_utils.get_dictionary_element(app_deployments, model_type)
+    for deploy_name in deploy_dict.keys():
+        if deploy_name in wlst_names:
+            value_dict = deploy_dict[deploy_name]
+
+            delete_names = []
+            model_targets = dictionary_utils.get_element(value_dict, TARGET)
+            targets = alias_utils.create_list(model_targets, 'WLSDPLY-08000')
+            for target in targets:
+                if model_helper.is_delete_name(target):
+                    delete_names.append(model_helper.get_delete_item_name(target))
+
+            location.add_name_token(name_token, deploy_name)
+            mbean_path = aliases.get_wlst_attributes_path(location)
+            mbean = _wlst_helper.get_mbean_for_wlst_path(mbean_path)
+            mbean_targets = mbean.getTargets()
+            for mbean_target in mbean_targets:
+                mbean_name = mbean_target.getName()
+                if mbean_name in delete_names:
+                    _logger.info('WLSDPLY-09114', mbean_name, model_type, deploy_name, class_name=_class_name,
+                                 method_name=_method_name)
+                    mbean.removeTarget(mbean_target)

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1018,6 +1018,7 @@ WLSDPLY_09015=Online update has been canceled because the flag cancel_changes_if
 WLSDPLY-09016=There are outstanding changes but -discard_current_edit has been specified, all changes have been \
   discarded before processing update.
 WLSDPLY-09017=Server {0} in 
+
 # wlsdeploy/tool/deploy/deployer_utils.py
 WLSDPLY-09100=Existing object names are {0}
 WLSDPLY-09101=Creating MBean type {1} with name {0}
@@ -1034,6 +1035,7 @@ WLSDPLY-09110=Deleting {0} {1}
 WLSDPLY-09111=Unable to get delete item name for {0}
 WLSDPLY-09112=Failed to discard current edit session: {0}
 WLSDPLY-09113=Filenames contains unparseable characters {0} : {1}
+WLSDPLY-09114=Removing target {0} from {1} {2}
 
 # wlsdeploy/tool/deploy/deployer.py
 WLSDPLY-09200=Error setting attribute {0} for {1} {2}: {3}


### PR DESCRIPTION
Delete app/library targets during edit session for online.
Remove target deletion functionality from online app/library deployment.
Refactored restart checking into a shared method online_check_save_activate().
Tested with update and deploy tools.

Internal Jira WDT-534
