### PR TITLE
Avoid re-deploying clusters and servers a second time

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2021, Oracle and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os

--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os
@@ -50,12 +50,8 @@ from wlsdeploy.aliases.model_constants import PARTITION
 from wlsdeploy.aliases.model_constants import PASSWORD
 from wlsdeploy.aliases.model_constants import PASSWORD_ENCRYPTED
 from wlsdeploy.aliases.model_constants import PRODUCTION_MODE_ENABLED
-from wlsdeploy.aliases.model_constants import RCU_ADMIN_PASSWORD
 from wlsdeploy.aliases.model_constants import RCU_COMP_INFO
-from wlsdeploy.aliases.model_constants import RCU_DB_CONN
 from wlsdeploy.aliases.model_constants import RCU_DB_INFO
-from wlsdeploy.aliases.model_constants import RCU_PREFIX
-from wlsdeploy.aliases.model_constants import RCU_SCHEMA_PASSWORD
 from wlsdeploy.aliases.model_constants import RCU_STG_INFO
 from wlsdeploy.aliases.model_constants import RESOURCE_GROUP
 from wlsdeploy.aliases.model_constants import RESOURCE_GROUP_TEMPLATE
@@ -626,7 +622,8 @@ class DomainCreator(Creator):
 
         self.__create_mbeans_used_by_topology_mbeans(location, topology_folder_list)
 
-        self.__create_machines_clusters_and_servers()
+        # these deletions were intentionally skipped when these elements are first created.
+        self.topology_helper.remove_deleted_clusters_and_servers(location, self._topology)
         topology_folder_list.remove(MACHINE)
         topology_folder_list.remove(UNIX_MACHINE)
         topology_folder_list.remove(CLUSTER)

--- a/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 from wlsdeploy.aliases.location_context import LocationContext
@@ -97,7 +97,8 @@ class TopologyUpdater(Deployer):
         self._process_section(self._topology, folder_list, ADMIN_CONSOLE, location)
         self._process_section(self._topology, folder_list, CDI_CONTAINER, location)
 
-        self.update_machines_clusters_and_servers()
+        # these deletions were intentionally skipped when these elements are first created.
+        self._topology_helper.remove_deleted_clusters_and_servers(location, self._topology)
         folder_list.remove(CLUSTER)
         folder_list.remove(SERVER)
         folder_list.remove(SERVER_TEMPLATE)

--- a/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2021, Oracle and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 from wlsdeploy.aliases.location_context import LocationContext

--- a/core/src/main/python/wlsdeploy/tool/util/topology_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/topology_helper.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2021, Oracle and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 

--- a/core/src/main/python/wlsdeploy/tool/validate/validation_utils.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validation_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2021, Oracle and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import re

--- a/core/src/main/python/wlsdeploy/tool/validate/validation_utils.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validation_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import re
@@ -126,7 +126,8 @@ def is_compatible_data_type(expected_data_type, actual_data_type):
     elif expected_data_type in ['float', 'double']:
         retval = (actual_data_type in ["<type 'float'>", "<type 'str'>", "<type 'unicode'>"])
     elif expected_data_type == 'properties' or expected_data_type == 'dict':
-        retval = (actual_data_type in ["<type 'PyOrderedDict'>", "<type 'dict'>", "<type 'str'>"])
+        retval = (actual_data_type in ["<type 'PyOrderedDict'>", "<type 'oracle.weblogic.deploy.util.PyOrderedDict'>",
+                                       "<type 'dict'>", "<type 'str'>"])
     elif 'list' in expected_data_type:
         retval = (actual_data_type in ["<type 'list'>", "<type 'str'>", "<type 'unicode'>"])
     elif expected_data_type in ['password', 'credential', 'jarray']:


### PR DESCRIPTION
After setting server groups, just remove the deleted items.
WLST does not allow SSL/ListenPort to be set a second time.

Also fixed PyDictionary type match for new Jython version.

Fixes #819
