### PR TITLE
Compare tool: keep source path, don't delete non-name folders

### DIFF
--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -281,6 +281,7 @@ def main():
             if len(obj.get_compare_msgs()) > 0:
                 try:
                     file_name = _outputdir + '/compare_model_stdout'
+                    print format_message('WLSDPLY-05715', len(obj.get_compare_msgs()), file_name)
                     fos = JFileOutputStream(file_name, False)
                     writer = JPrintWriter(fos, True)
                     writer.println(BLANK_LINE)

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------
@@ -21,33 +21,25 @@ import java.io.FileOutputStream as JFileOutputStream
 import java.io.IOException as JIOException
 import java.io.PrintWriter as JPrintWriter
 from java.lang import System
-from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.compare import CompareException
 from oracle.weblogic.deploy.exception import ExceptionHelper
 from oracle.weblogic.deploy.util import CLAException
 from oracle.weblogic.deploy.util import FileUtils
-from oracle.weblogic.deploy.util import PyOrderedDict
 from oracle.weblogic.deploy.util import PyWLSTException
 from oracle.weblogic.deploy.util import VariableException
 from oracle.weblogic.deploy.validate import ValidateException
+from oracle.weblogic.deploy.yaml import YamlException
 
 import oracle.weblogic.deploy.util.TranslateException as TranslateException
-from wlsdeploy.aliases import alias_utils
-from wlsdeploy.aliases.alias_constants import ALIAS_LIST_TYPES
-from wlsdeploy.aliases.alias_constants import PROPERTIES
 from wlsdeploy.aliases.aliases import Aliases
-from wlsdeploy.aliases.location_context import LocationContext
-from wlsdeploy.aliases.model_constants import KUBERNETES
 from wlsdeploy.aliases.wlst_modes import WlstModes
 from wlsdeploy.exception import exception_helper
 from wlsdeploy.exception.expection_types import ExceptionType
-from wlsdeploy.json.json_translator import COMMENT_MATCH
 from wlsdeploy.json.json_translator import PythonToJson
 from wlsdeploy.logging.platform_logger import PlatformLogger
+from wlsdeploy.tool.compare.model_comparer import ModelComparer
 from wlsdeploy.tool.validate.validator import Validator
 from wlsdeploy.util import cla_helper
-from wlsdeploy.util import dictionary_utils
-from wlsdeploy.util import model_helper
 from wlsdeploy.util import variables
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.model_context import ModelContext
@@ -71,6 +63,7 @@ __optional_arguments = [
     CommandLineArgUtil.VARIABLE_FILE_SWITCH
 ]
 
+
 def __process_args(args):
     """
     Process the command-line arguments.
@@ -87,393 +80,6 @@ def __process_args(args):
     return model_context
 
 
-class ModelDiffer:
-
-    def __init__(self, current_dict, past_dict, aliases, all_changes, all_added, all_removed, compare_msgs):
-        self.aliases = aliases
-        self.final_changed_model = PyOrderedDict()
-        self.current_dict = current_dict
-        self.past_dict = past_dict
-        self.set_current = sets.Set()
-        self.set_past = sets.Set()
-        if self.current_dict and len(self.current_dict.keys()) > 0:
-            for item in self.current_dict.keys():
-                self.set_current.add(item)
-        if self.past_dict and len(self.past_dict.keys()) > 0:
-            for item in self.past_dict.keys():
-                self.set_past.add(item)
-        self.intersect = self.set_current.intersection(self.set_past)
-        self.all_changes = all_changes
-        self.all_added = all_added
-        self.all_removed = all_removed
-        self.compare_msgs = compare_msgs
-
-
-    def added(self):
-        return self.set_current - self.intersect
-
-    def removed(self):
-        return self.set_past - self.intersect
-
-    def changed(self):
-        result = sets.Set()
-        for o in self.intersect:
-            if self.past_dict[o] != self.current_dict[o]:
-                result.add(o)
-        return result
-
-    def unchanged(self):
-        result = sets.Set()
-        for o in self.intersect:
-            if self.past_dict[o] == self.current_dict[o]:
-                result.add(o)
-        return result
-
-    # def print_diff(self,s, category):
-    #     print category
-    #     if len(s) > 0:
-    #         print s
-
-    def recursive_changed_detail(self, key, token, root):
-        """
-        Recursively handle the changed items
-        :param key: current key to locate the current dictionary for comparison
-        :param token: token is a '|' separated string of the changed item representing the path of the model as it
-            traverses down the path (this will be changed in recursive calls)
-        :param root: root folder of the changes in the model (never change)
-        """
-        debug("DEBUG: Entering recursive_changed_detail key=%s token=%s root=%s", key, token, root)
-
-        a = ModelDiffer(self.current_dict[key], self.past_dict[key], self.aliases, self.all_changes, self.all_added,
-                        self.all_removed, self.compare_msgs)
-        diff = a.changed()
-        added = a.added()
-        removed = a.removed()
-        saved_token = token
-
-        debug('DEBUG: In recursive changed detail %s', diff)
-        debug('DEBUG: In recursive added detail %s', added)
-        if len(diff) > 0:
-            for o in diff:
-                token = saved_token
-                # The token is a | separated string that is used to parse and rebuilt the structure later
-                debug('DEBUG: in recursive changed detail walking down 1 %s', o)
-                token = token + PATH_TOKEN + o
-                if a.is_dict(o):
-                    debug('DEBUG: in recursive changed detail walking down 2 %s', token)
-                    a.recursive_changed_detail(o, token, root)
-                    last = token.rfind(PATH_TOKEN)
-                    token = root
-                else:
-                    self.all_changes.append(token)
-                    last = token.rfind(PATH_TOKEN)
-                    token = root
-
-        # already out of recursive calls, add all entries from current dictionary
-        # resources.JDBCSubsystemResources.* (note it may not have the lower level nodes
-        added_token = token
-        debug('DEBUG: current added token %s', added_token)
-        if len(added) > 0:
-            for item in added:
-                token = saved_token
-                debug('DEBUG: recursive added token %s item %s ', token, item)
-                self.all_added.append(token + PATH_TOKEN + item)
-
-        # We don't really care about this, just put something here is enough
-        if len(removed) > 0:
-            for item in removed:
-                token = saved_token
-                debug('DEBUG: removed %s', item)
-                self.all_removed.append(token + PATH_TOKEN + item)
-        debug('DEBUG: Exiting recursive_changed_detail')
-
-    def is_dict(self, key):
-        """
-        Check to see if the ke in the current dictionary is a dictionary.
-        :param key: key of the dictionary
-        :return: true if it is a dictionary otherwise false
-        """
-        if self.current_dict.has_key(key) and isinstance(self.current_dict[key], PyOrderedDict):
-            return 1
-        else:
-            return 0
-
-    def calculate_changed_model(self):
-        """
-        Calculate the changed model.
-        """
-        _method_name = 'calculate_changed_model'
-
-        # This is the top level of changes only
-        #  e.g. from no appDeployments to have appDeployments
-        #       from no resources to have resources
-        #
-        #  changed, added, removed are keys in the dictionary
-        #   i.e. resources, domainInfo, appDeployments, topology
-        #
-        try:
-            changed = self.changed()
-            added = self.added()
-            removed = self.removed()
-
-            #
-            #  Call recursive for each key (i.e. appDeployments, topology, resources etc..)
-            #
-            for s in changed:
-                self.recursive_changed_detail(s, s, s)
-                self._add_results(self.all_changes)
-                self._add_results(self.all_added)
-                self._add_results(self.all_removed, True)
-
-            for s in added:
-                self.recursive_changed_detail(s, s, s)
-                self._add_results(self.all_changes)
-                self._add_results(self.all_added)
-
-            # Clean up previous delete first
-            for x in self.all_removed:
-                self.all_removed.remove(x)
-
-            # Top level:  e.g. delete all resources, all appDeployments
-
-            for s in removed:
-                self.recursive_changed_detail(s, s, s)
-                self._add_results(self.all_removed, True)
-
-        except (KeyError, IndexError), ke:
-            _logger.severe('WLSDPLY-05709', str(ke)),
-            ex = exception_helper.create_pywlst_exception('WLSDPLY-05709', str(ke))
-            _logger.throwing(ex, class_name=_class_name, method_name=_method_name)
-            raise ex
-        except AliasException, ae:
-            _logger.severe('WLSDPLY-05709', ae.getLocalizedMessage(),
-                           error=ae, class_name=_class_name, method_name=_method_name)
-            ex = exception_helper.create_compare_exception(ae.getLocalizedMessage(), error=ae)
-            _logger.throwing(ex, class_name=_class_name, method_name=_method_name)
-            raise ex
-
-    def _parse_change_path(self, path):
-        """
-        Determine the location and attribute name (if specified) for the specified change path.
-        Include a property key for property attribute paths.
-        :param path: delimited change path, such as "resources|JDBCSystemResource|Generic2|JdbcResource"
-        :return: tuple - (location from path, attribute name from path, property key from path)
-        """
-        _method_name = '_parse_change_path'
-
-        location = LocationContext()
-        attribute_name = None
-        property_key = None
-        name_token_next = False
-        property_key_next = False
-
-        path_tokens = path.split(PATH_TOKEN)
-        folder_names = self.aliases.get_model_section_top_level_folder_names(path_tokens[0])
-
-        attribute_names = []
-        attributes_location = self.aliases.get_model_section_attribute_location(path_tokens[0])
-        if attributes_location is not None:
-            attribute_names = self.aliases.get_model_attribute_names(attributes_location)
-
-        if path_tokens[0] == KUBERNETES:
-            return None, None
-
-        for path_token in path_tokens[1:]:
-            if name_token_next:
-                token_name = self.aliases.get_name_token(location)
-                location.add_name_token(token_name, path_token)
-                name_token_next = False
-            elif property_key_next:
-                property_key = path_token
-            elif path_token in folder_names:
-                location.append_location(path_token)
-                folder_names = self.aliases.get_model_subfolder_names(location)
-                attribute_names = self.aliases.get_model_attribute_names(location)
-                regular_type = not self.aliases.is_artificial_type_folder(location)
-                security_type = regular_type and self.aliases.is_security_provider_type(location)
-                multiple_type = regular_type and self.aliases.supports_multiple_mbean_instances(location)
-                if multiple_type or security_type:
-                    name_token_next = True
-                else:
-                    token_name = self.aliases.get_name_token(location)
-                    if not location.get_name_for_token(token_name):
-                        location.add_name_token(token_name, "TOKEN")
-            elif path_token in attribute_names:
-                attribute_name = path_token
-                attribute_type = self.aliases.get_model_attribute_type(location, attribute_name)
-                if attribute_type == PROPERTIES:
-                    property_key_next = True
-                name_token_next = False
-            else:
-                ex = exception_helper.create_compare_exception('WLSDPLY-05712', path_token, path)
-                _logger.throwing(ex, class_name=_class_name, method_name=_method_name)
-                raise ex
-
-        return location, attribute_name, property_key
-
-    def _add_results(self, change_paths, is_delete=False):
-        """
-        Update the differences in the final model dictionary with the changes
-        :param change_paths: Array of changes in delimited format
-        :param is_delete: flag indicating to delete paths
-        """
-        parent_index = -2
-        for change_path in change_paths:
-            # change_path is the keys of changes in the piped format, such as:
-            # resources|JDBCSystemResource|Generic2|JdbcResource|JDBCConnectionPoolParams|TestConnectionsOnReserve
-            location, attribute_name, property_key = self._parse_change_path(change_path)
-            is_folder_path = attribute_name is None
-
-            if is_delete and not is_folder_path:
-                # Skip adding if it is a delete of an attribute
-                self.compare_msgs.add(('WLSDPLY-05701', change_path))
-                continue
-
-            # splitted is a tuple containing the next token, and a delimited string of remaining tokens
-            splitted = change_path.split(PATH_TOKEN, 1)
-
-            # change_tree will be a nested dictionary containing the change path parent elements.
-            # change_tokens is a list of parent tokens in change_tree.
-            change_tree = PyOrderedDict()
-            change_tokens = []
-
-            while len(splitted) > 1:
-                tmp_folder = PyOrderedDict()
-                tmp_folder[splitted[0]] = PyOrderedDict()
-                if len(change_tree) > 0:
-                    # traverse to the leaf folder
-                    change_folder = change_tree
-                    for token in change_tokens:
-                        change_folder = change_folder[token]
-                    change_folder[splitted[0]] = PyOrderedDict()
-                    change_tokens.append(splitted[0])
-                else:
-                    change_tree = tmp_folder
-                    change_tokens.append(splitted[0])
-                splitted = splitted[1].split(PATH_TOKEN, 1)
-
-            # key is the last name in the change path
-            key = splitted[0]
-
-            # find the specified folder in the change tree and in the current and previous models
-            change_folder = change_tree
-            current_folder = self.current_dict
-            previous_folder = self.past_dict
-            for token in change_tokens:
-                change_folder = change_folder[token]
-                current_folder = current_folder[token]
-                previous_folder = dictionary_utils.get_dictionary_element(previous_folder, token)
-
-            # set the value in the change folder if present.
-            # merge new and previous values if relevant.
-            # add a comment if the previous value was found.
-            if current_folder:
-                current_value = current_folder[key]
-                previous_value = dictionary_utils.get_element(previous_folder, key)
-                change_value, comment = self._get_change_info(current_value, previous_value, location, attribute_name,
-                                                              property_key)
-
-                if comment:
-                    # make comment key unique, key will not appear in output
-                    comment_key = COMMENT_MATCH + comment
-                    change_folder[comment_key] = comment
-                change_folder[key] = change_value
-            else:
-                change_folder[key] = None
-
-            # merge the change tree into the final model
-            self.merge_dictionaries(self.final_changed_model, change_tree)
-
-            # if it is a deletion then go back and update with '!'
-
-            if is_delete:
-                split_delete = change_path.split(PATH_TOKEN)
-                # allowable_delete_length = len(allowable_delete.split(PATH_TOKEN))
-                split_delete_length = len(split_delete)
-                if is_folder_path:
-                    app_key = split_delete[split_delete_length - 1]
-                    parent_key = split_delete[parent_index]
-                    debug("DEBUG: deleting folder %s from the model: key %s ", change_path, app_key)
-                    pointer_dict = self.final_changed_model
-                    for k_item in split_delete:
-                        if k_item == parent_key:
-                            break
-                        pointer_dict = pointer_dict[k_item]
-                    del pointer_dict[parent_key][app_key]
-                    # Special handling for deleting all resources in high level
-                    if split_delete_length == 2 and app_key != 'WebAppContainer':
-                        pointer_dict[parent_key][app_key] = PyOrderedDict()
-                        old_keys = self.past_dict[parent_key][app_key].keys()
-                        for old_key in old_keys:
-                            pointer_dict[parent_key][app_key]['!' + old_key] = PyOrderedDict()
-                    else:
-                        pointer_dict[parent_key]['!' + app_key] = PyOrderedDict()
-
-    def _get_change_info(self, current_value, previous_value, location, attribute_name, property_key):
-        """
-        Determine the value and comment to put in the change model based on the supplied arguments.
-        :param current_value: the current value from the new model
-        :param previous_value: the previous value from the old model
-        :param location: the location of the value in the model
-        :param attribute_name: the name of the attribute, or None if this is a folder path
-        :param property_key: a key in a property value, or None if a different type
-        :return: a tuple with the change value and comment, either can be None
-        """
-        change_value = current_value
-        comment = None
-
-        if attribute_name and (previous_value is not None):
-            attribute_type = self.aliases.get_model_attribute_type(location, attribute_name)
-            if attribute_type in ALIAS_LIST_TYPES:
-                current_list = alias_utils.create_list(current_value, 'WLSDPLY-08001')
-                previous_list = alias_utils.create_list(previous_value, 'WLSDPLY-08000')
-
-                change_list = list(previous_list)
-                for item in current_list:
-                    if item in previous_list:
-                        change_list.remove(item)
-                    else:
-                        change_list.append(item)
-                for item in previous_list:
-                    if item not in current_list:
-                        change_list.remove(item)
-                        change_list.append(model_helper.get_delete_name(item))
-                change_value = ','.join(change_list)
-
-                current_text = ','.join(current_list)
-                previous_text = ','.join(previous_list)
-                comment = attribute_name + ": '" + previous_text + "' -> '" + current_text + "'"
-            elif attribute_type == PROPERTIES:
-                comment = property_key + ": '" + str(previous_value) + "'"
-            elif not isinstance(previous_value, dict):
-                comment = attribute_name + ": '" + str(previous_value) + "'"
-
-        return change_value, comment
-
-    def merge_dictionaries(self, dictionary, new_dictionary):
-        """
-         Merge the values from the new dictionary to the existing one.
-        :param dictionary: the existing dictionary
-        :param new_dictionary: the new dictionary to be merged
-        """
-        for key in new_dictionary:
-            new_value = new_dictionary[key]
-            if key not in dictionary:
-                dictionary[key] = new_value
-            else:
-                value = dictionary[key]
-                if isinstance(value, PyOrderedDict) and isinstance(new_value, PyOrderedDict):
-                    self.merge_dictionaries(value, new_value)
-                else:
-                    dictionary[key] = new_value
-
-    def get_final_changed_model(self):
-        """
-        Return the changed model.
-        """
-        return self.final_changed_model
-
-
 class ModelFileDiffer:
     """
       This is the main driver for the caller.  It compares two model files whether they are json or yaml format.
@@ -483,23 +89,7 @@ class ModelFileDiffer:
         self.past_dict_file = past_dict
         self.output_dir = output_dir
         self.model_context = model_context
-        # For recursive calls
-        self.all_changes = []
-        self.all_added = []
-        self.all_removed = []
         self.compare_msgs = sets.Set()
-
-    def get_dictionary(self, file):
-        """
-        Retrieve the python dictionary from file
-        :param file:  disk file containing the python dictionary
-        :return:  python dictionary
-        """
-        true = True
-        false = False
-        fh = open(file, 'r')
-        content = fh.read()
-        return eval(content)
 
     def compare(self):
         """
@@ -583,51 +173,43 @@ class ModelFileDiffer:
             _logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             return VALIDATION_FAIL
 
-        obj = ModelDiffer(current_dict, past_dict, aliases, self.all_changes, self.all_added,
-              self.all_removed, self.compare_msgs)
-        obj.calculate_changed_model()
-        net_diff = obj.get_final_changed_model()
+        comparer = ModelComparer(current_dict, past_dict, aliases, self.compare_msgs)
+        change_model = comparer.compare_models()
 
         print BLANK_LINE
         print format_message('WLSDPLY-05706', self.current_dict_file, self.past_dict_file)
         print BLANK_LINE
-        if len(net_diff.keys()) == 0:
+        if len(change_model.keys()) == 0:
             print format_message('WLSDPLY-05710')
             print BLANK_LINE
             return 0
 
         if self.output_dir:
-            fos = None
-            writer = None
             file_name = None
             try:
                 print format_message('WLSDPLY-05711', self.output_dir)
                 print BLANK_LINE
+
+                # write the change model as a JSON file
                 file_name = self.output_dir + '/diffed_model.json'
-                fos = JFileOutputStream(file_name, False)
-                writer = JPrintWriter(fos, True)
-                json_object = PythonToJson(net_diff)
-                json_object._write_dictionary_to_json_file(net_diff, writer)
-                writer.close()
+                json_object = PythonToJson(change_model)
+                json_object.write_to_json_file(file_name)
+
+                # write the change model as a YAML file
                 file_name = self.output_dir + '/diffed_model.yaml'
-                fos = JFileOutputStream(file_name, False)
-                writer = JPrintWriter(fos, True)
-                pty = PythonToYaml(net_diff)
-                pty._write_dictionary_to_yaml_file(net_diff, writer)
-                writer.close()
-            except JIOException, ioe:
-                if fos:
-                    fos.close()
-                if writer:
-                    writer.close()
-                _logger.severe('WLSDPLY-05708', file_name, ioe.getLocalizedMessage(),
-                               error=ioe, class_name=_class_name, method_name=_method_name)
+                pty = PythonToYaml(change_model)
+                pty.write_to_yaml_file(file_name)
+
+            except YamlException, ye:
+                _logger.severe('WLSDPLY-05708', file_name, ye.getLocalizedMessage(),
+                               error=ye, class_name=_class_name, method_name=_method_name)
                 return 2
         else:
+            # write the change model to standard output in YAML format
             print format_message('WLSDPLY-05707')
             print BLANK_LINE
-            pty = PythonToYaml(net_diff)
-            pty._write_dictionary_to_yaml_file(net_diff, System.out)
+            pty = PythonToYaml(change_model)
+            pty._write_dictionary_to_yaml_file(change_model, System.out)
 
         return 0
 

--- a/core/src/main/python/wlsdeploy/aliases/alias_utils.py
+++ b/core/src/main/python/wlsdeploy/aliases/alias_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import copy
@@ -144,7 +144,7 @@ def merge_model_and_existing_properties(model_props, existing_props, string_prop
         for entry_set in model_properties.entrySet():
             key = entry_set.getKey()
             value = entry_set.getValue()
-            existing_properties.setProperty(key, value)
+            existing_properties.setProperty(key, str(value))
         if model_props_is_string:
             result = _properties_to_string(existing_properties, string_props_separator_char)
         else:

--- a/core/src/main/python/wlsdeploy/tool/compare/__init__.py
+++ b/core/src/main/python/wlsdeploy/tool/compare/__init__.py
@@ -1,0 +1,4 @@
+"""
+Copyright (c) 2021, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+"""

--- a/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
+++ b/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
@@ -1,0 +1,283 @@
+"""
+Copyright (c) 2021, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+"""
+
+from oracle.weblogic.deploy.util import PyOrderedDict
+
+from wlsdeploy.aliases import alias_utils
+from wlsdeploy.aliases.alias_constants import ALIAS_LIST_TYPES
+from wlsdeploy.aliases.alias_constants import PROPERTIES
+from wlsdeploy.aliases.location_context import LocationContext
+from wlsdeploy.aliases.model_constants import KUBERNETES
+from wlsdeploy.json.json_translator import COMMENT_MATCH
+from wlsdeploy.logging.platform_logger import PlatformLogger
+from wlsdeploy.util import model_helper
+
+
+class ModelComparer(object):
+    """
+    Class for comparing two WDT models.
+    """
+    _class_name = "ModelComparer"
+    _logger = PlatformLogger('wlsdeploy.compare_model')
+
+    def __init__(self, current_model_dict, past_model_dict, aliases, messages):
+        """
+        :param current_model_dict: the new dictionary being compared
+        :param past_model_dict: the old dictionary being compared
+        :param aliases: a reference to an Aliases class instance
+        :param messages: a Set to be updated with messages
+        """
+        self._current_model_dict = current_model_dict
+        self._past_model_dict = past_model_dict
+        self._aliases = aliases
+        self._messages = messages
+
+    def compare_models(self):
+        """
+        Compare the current an past models from the top level.
+        :return: a dictionary of differences between these models
+        """
+        self._messages.clear()
+        location = None
+        change_model_dict = self._compare_folders(self._current_model_dict, self._past_model_dict, location, location)
+        return change_model_dict
+
+    def _compare_folders(self, current_folder, past_folder, location, attributes_location):
+        """
+        Compare folders after determining if the folder has named sub-folders.
+        :param current_folder: a folder in the current model
+        :param past_folder: a folder in the past model
+        :param location: the location for the specified folders
+        :param attributes_location: the attribute location for the specified folders
+        :return: a dictionary of differences between these folders
+        """
+        _method_name = '_compare_folders'
+
+        # determine if the specified location has named folders, such as topology/Server
+        has_named_folders = False
+        if (location is not None) and not self._aliases.is_artificial_type_folder(location):
+            has_named_folders = self._aliases.supports_multiple_mbean_instances(location) or \
+                                self._aliases.requires_artificial_type_subfolder_handling(location)
+
+        if has_named_folders:
+            return self._compare_named_folders(current_folder, past_folder, location, attributes_location)
+        else:
+            return self._compare_folder_contents(current_folder, past_folder, location, attributes_location)
+
+    def _compare_named_folders(self, current_folder, past_folder, location, attributes_location):
+        """
+        Compare current and past named folders using the specified locations.
+        A named folder is a subfolder of a multiple-MBean folder, such as topology/Server/my-server
+        :param current_folder: a folder in the current model
+        :param past_folder: a folder in the past model
+        :param location: the location for the specified folders
+        :param attributes_location: the attribute location for the specified folders
+        :return: a dictionary of differences between these folders
+        """
+        change_folder = PyOrderedDict()
+
+        for name in current_folder:
+            # check if name is present in both folders.
+            # if found, compare the two folders recursively.
+            if name in past_folder:
+                next_current = current_folder[name]
+                next_past = past_folder[name]
+                location.add_name_token(self._aliases.get_name_token(location), name)
+                attributes_location.add_name_token(self._aliases.get_name_token(attributes_location), name)
+                changes = self._compare_folder_contents(next_current, next_past, location, attributes_location)
+                if changes:
+                    change_folder[name] = changes
+
+            # check for added names.
+            # if found, add the entire folder contents.
+            else:
+                change_folder[name] = current_folder[name]
+                pass
+
+        # check for deleted names.
+        # if name is not in the current folder, add its delete name.
+        for name in past_folder:
+            if name not in current_folder:
+                delete_name = model_helper.get_delete_name(name)
+                change_folder[delete_name] = PyOrderedDict()
+
+        return change_folder
+
+    def _compare_folder_contents(self, current_folder, past_folder, location, attributes_location):
+        """
+        Compare the contents of current and past folders using the specified locations.
+        :param current_folder: a folder in the current model
+        :param past_folder: a folder in the past model
+        :param location: the location for the specified folders
+        :param attributes_location: the attribute location for the specified folders
+        :return: a dictionary of differences between these folders
+        """
+        change_folder = PyOrderedDict()
+
+        attribute_names = []
+        if attributes_location is not None:
+            attribute_names = self._aliases.get_model_attribute_names(attributes_location)
+
+        # check if keys in the current folder are present in the past folder
+        for key in current_folder:
+            if not self._check_key(key, location):
+                continue
+
+            if key in past_folder:
+                current_value = current_folder[key]
+                past_value = past_folder[key]
+
+                if key in attribute_names:
+                    self._compare_attribute(current_value, past_value, attributes_location, key, change_folder)
+
+                else:
+                    next_location, next_attributes_location = self._get_next_location(location, key)
+                    next_change = self._compare_folders(current_value, past_value, next_location,
+                                                        next_attributes_location)
+
+                    if next_change:
+                        change_folder[key] = next_change
+
+            else:
+                # key is present the current folder, not in the past folder.
+                # just add to the change folder, no further recursion needed.
+                change_folder[key] = current_folder[key]
+
+        # check if keys in the past folder are not in the current folder
+        for key in past_folder:
+            if not self._check_key(key, location):
+                continue
+
+            if key not in current_folder:
+                if key in attribute_names:
+                    # if an attribute was deleted, just add a message
+                    change_path = self._aliases.get_model_folder_path(location) + "/" + key
+                    self._messages.add(('WLSDPLY-05701', change_path))
+
+                else:
+                    # if a folder was deleted, keep recursing through the past model.
+                    # there may be named elements underneath that need to be deleted.
+                    current_value = PyOrderedDict()
+                    past_value = past_folder[key]
+                    next_location, next_attributes_location = self._get_next_location(location, key)
+                    next_change = self._compare_folders(current_value, past_value, next_location,
+                                                        next_attributes_location)
+
+                    if next_change:
+                        change_folder[key] = next_change
+
+        return change_folder
+
+    def _get_next_location(self, location, key):
+        """
+        Get the next locations for the specified key and location.
+        :param location: the current location (None indicates model root)
+        :param key: the key of the next location
+        :return: a tuple with the next location and the next attributes location
+        """
+        if location is None:
+            next_location = LocationContext()
+            next_attributes_location = self._aliases.get_model_section_attribute_location(key)
+        else:
+            next_location = LocationContext(location)
+            next_location.append_location(key)
+            next_location.add_name_token(self._aliases.get_name_token(next_location), 'FOLDER')
+            next_attributes_location = next_location
+
+        return next_location, next_attributes_location
+
+    def _compare_attribute(self, current_value, past_value, location, key, change_folder):
+        """
+        Compare values of an attribute from the current and past folders.
+        The change value and any comments will be added to the change folder.
+        :param current_value: the value from the current model
+        :param past_value: the value from the past model
+        :param key: the key of the attribute
+        :param change_folder: the folder in the change model to be updated
+        :param location: the location for attributes in the specified folders
+        """
+        if current_value != past_value:
+            attribute_type = self._aliases.get_model_attribute_type(location, key)
+            if attribute_type in ALIAS_LIST_TYPES:
+                current_list = alias_utils.create_list(current_value, 'WLSDPLY-08001')
+                previous_list = alias_utils.create_list(past_value, 'WLSDPLY-08000')
+
+                change_list = list(previous_list)
+                for item in current_list:
+                    if item in previous_list:
+                        change_list.remove(item)
+                    else:
+                        change_list.append(item)
+                for item in previous_list:
+                    if item not in current_list:
+                        change_list.remove(item)
+                        change_list.append(model_helper.get_delete_name(item))
+
+                current_text = ','.join(current_list)
+                previous_text = ','.join(previous_list)
+                comment = key + ": '" + previous_text + "' -> '" + current_text + "'"
+                _add_comment(comment, change_folder)
+                change_folder[key] = ','.join(change_list)
+
+            elif attribute_type == PROPERTIES:
+                self._compare_properties(current_value, past_value, key, change_folder)
+
+            else:
+                if not isinstance(past_value, dict):
+                    comment = key + ": '" + str(past_value) + "'"
+                    _add_comment(comment, change_folder)
+                change_folder[key] = current_value
+
+    def _compare_properties(self, current_value, past_value, key, change_folder):
+        """
+        Compare values of a properties attribute from the current and past folders.
+        The change value and any comments will be added to the change folder.
+        :param current_value: the value from the current model
+        :param past_value: the value from the past model
+        :param key: the key of the attribute
+        :param change_folder: the folder in the change model to be updated
+        """
+        property_dict = PyOrderedDict()
+        for property_key in current_value:
+            current_property_value = current_value[property_key]
+            if property_key in past_value:
+                past_property_value = past_value[property_key]
+                if past_property_value != current_property_value:
+                    comment = property_key + ": '" + str(past_property_value) + "'"
+                    _add_comment(comment, property_dict)
+                    property_dict[property_key] = current_property_value
+            else:
+                property_dict[property_key] = current_property_value
+
+        # property values don't support delete notation,
+        # so any deleted keys in the current value will be ignored.
+
+        if property_dict:
+            change_folder[key] = property_dict
+
+    def _check_key(self, key, location):
+        """
+        Determine if the specified key and location will be compared.
+        :param key: the key to be checked
+        :param location: the location to be checked
+        :return: True if the key and location will be compared, False otherwise
+        """
+        _method_name = '_check_key'
+
+        if (location is None) and (key == KUBERNETES):
+            self._logger.info('WLSDPLY-05713', KUBERNETES, class_name=self._class_name, method_name=_method_name)
+            return False
+        return True
+
+
+def _add_comment(comment, dictionary):
+    """
+    Add a comment to the specified dictionary
+    :param comment: the comment text
+    :param dictionary: the dictionary to be appended
+    """
+    # make comment key unique, key will not appear in output
+    comment_key = COMMENT_MATCH + comment
+    dictionary[comment_key] = comment

--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import copy
@@ -109,7 +109,8 @@ class ApplicationsDeployer(Deployer):
                 copy.deepcopy(dictionary_utils.get_dictionary_element(shared_libraries, shared_library_name))
             shlib_source_path = dictionary_utils.get_element(shared_library, SOURCE_PATH)
             if string_utils.is_empty(shlib_source_path):
-                ex = exception_helper.create_deploy_exception('WLSDPLY-09302', shared_library_name, SOURCE_PATH)
+                ex = exception_helper.create_deploy_exception('WLSDPLY-09302', LIBRARY, shared_library_name,
+                                                              SOURCE_PATH)
                 self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
                 raise ex
 
@@ -117,7 +118,7 @@ class ApplicationsDeployer(Deployer):
                 if self.archive_helper is not None:
                     self.__extract_source_path_from_archive(shlib_source_path, LIBRARY, shared_library_name)
                 else:
-                    ex = exception_helper.create_deploy_exception('WLSDPLY-09303', shared_library_name)
+                    ex = exception_helper.create_deploy_exception('WLSDPLY-09303', LIBRARY, shared_library_name)
                     self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
                     raise ex
 
@@ -170,7 +171,8 @@ class ApplicationsDeployer(Deployer):
 
             app_source_path = dictionary_utils.get_element(application, SOURCE_PATH)
             if string_utils.is_empty(app_source_path):
-                ex = exception_helper.create_deploy_exception('WLSDPLY-09302', application_name, SOURCE_PATH)
+                ex = exception_helper.create_deploy_exception('WLSDPLY-09302', APPLICATION, application_name,
+                                                              SOURCE_PATH)
                 self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
                 raise ex
 
@@ -178,7 +180,7 @@ class ApplicationsDeployer(Deployer):
                 if self.archive_helper is not None:
                     self.__extract_source_path_from_archive(app_source_path, APPLICATION, application_name)
                 else:
-                    ex = exception_helper.create_deploy_exception('WLSDPLY-09303', application_name)
+                    ex = exception_helper.create_deploy_exception('WLSDPLY-09303', APPLICATION, application_name)
                     self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
                     raise ex
 

--- a/core/src/main/python/wlsdeploy/tool/validate/validation_utils.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validation_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import re
@@ -126,7 +126,8 @@ def is_compatible_data_type(expected_data_type, actual_data_type):
     elif expected_data_type in ['float', 'double']:
         retval = (actual_data_type in ["<type 'float'>", "<type 'str'>", "<type 'unicode'>"])
     elif expected_data_type == 'properties' or expected_data_type == 'dict':
-        retval = (actual_data_type in ["<type 'PyOrderedDict'>", "<type 'dict'>", "<type 'str'>"])
+        retval = (actual_data_type in ["<type 'PyOrderedDict'>", "<type 'oracle.weblogic.deploy.util.PyOrderedDict'>",
+                                       "<type 'dict'>", "<type 'str'>"])
     elif 'list' in expected_data_type:
         retval = (actual_data_type in ["<type 'list'>", "<type 'str'>", "<type 'unicode'>"])
     elif expected_data_type in ['password', 'credential', 'jarray']:

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -494,6 +494,7 @@ WLSDPLY-05710=The models are identical
 WLSDPLY-05711=The model differences and output is written to the directory {0}
 WLSDPLY-05712=Unrecognized token {0} in path {1}
 WLSDPLY-05713=Model section {0} will not be compared
+WLSDPLY-05714={0} is unchanged, but required if other changes are present
 
 # prepare_model.py
 WLSDPLY-05801=Error in prepare model {0}

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 # The Universal Permissive License (UPL), Version 1.0
 #
 #
@@ -1053,8 +1053,8 @@ WLSDPLY-09208=Formatted restart line : {0}
 # wlsdeploy/tool/deploy/application_deployer.py
 WLSDPLY-09300=No shared libraries found in {0} with name {1}
 WLSDPLY-09301=Adding {0} {1} to {2} {3}
-WLSDPLY-09302=The model definition for shared library {0} is invalid because the {1} attribute is missing or empty
-WLSDPLY-09303=Unable to deploy shared library {0} because the archive file was not provided
+WLSDPLY-09302=The model definition for {0} {1} is invalid because the {2} attribute is missing or empty
+WLSDPLY-09303=Unable to deploy {0} {1} because the archive file was not provided
 WLSDPLY-09304=No applications found in {0} with name {1}
 WLSDPLY-09305=Failed to compute parent from the specified location because the folder {0} was not found in \
   the model location {1}

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -490,11 +490,12 @@ WLSDPLY-05706=Comparing Models: new={0} vs old={1}
 WLSDPLY-05707=Differences between new model and old model:
 WLSDPLY-05708=An error occurred while trying to write file {0}: {1}
 WLSDPLY-05709=Fatal compare model error {0}
-WLSDPLY-05710=The models are identical
+WLSDPLY-05710=There are no changes to apply between the old and new models
 WLSDPLY-05711=The model differences and output is written to the directory {0}
 WLSDPLY-05712=Unrecognized token {0} in path {1}
 WLSDPLY-05713=Model section {0} will not be compared
 WLSDPLY-05714={0} is unchanged, but required if other changes are present
+WLSDPLY-05715=There are {0} attributes that only exist in the previous model, see {1}
 
 # prepare_model.py
 WLSDPLY-05801=Error in prepare model {0}

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 # The Universal Permissive License (UPL), Version 1.0
 #
 #
@@ -493,6 +493,7 @@ WLSDPLY-05709=Fatal compare model error {0}
 WLSDPLY-05710=The models are identical
 WLSDPLY-05711=The model differences and output is written to the directory {0}
 WLSDPLY-05712=Unrecognized token {0} in path {1}
+WLSDPLY-05713=Model section {0} will not be compared
 
 # prepare_model.py
 WLSDPLY-05801=Error in prepare model {0}

--- a/core/src/test/python/compare_model_test.py
+++ b/core/src/test/python/compare_model_test.py
@@ -72,7 +72,7 @@ class CompareModelTestCase(unittest.TestCase):
 
             self.assertEqual(yaml_exists, True)
             self.assertEqual(json_exists, True)
-            self.assertEqual(len(stdout_result), 1)
+            self.assertEqual(len(stdout_result), 14)
 
             self.assertEqual(model_dictionary.has_key('resources'), True)
             self.assertEqual(model_dictionary.has_key('topology'), True)
@@ -85,12 +85,8 @@ class CompareModelTestCase(unittest.TestCase):
             self.assertEqual(model_dictionary['appDeployments'].has_key('Application'), True)
             self.assertEqual(model_dictionary['appDeployments']['Application'].has_key('myear'), True)
             self.assertEqual(model_dictionary['resources'].has_key('JMSSystemResource'), True)
-            self.assertEqual(model_dictionary['resources'].has_key('!WebAppContainer'), True)
             self.assertEqual(model_dictionary['resources']['JMSSystemResource'].has_key('MyJmsModule'), True)
-            self.assertEqual(model_dictionary['resources'].has_key('!WebAppContainer'), True)
             self.assertEqual(model_dictionary['resources'].has_key('SingletonService'), True)
-            self.assertEqual(model_dictionary['topology']['ServerTemplate']['cluster-1-template']
-                             .has_key('!ServerStart'), True)
             self.assertEqual(model_dictionary['appDeployments']['Library'].has_key('!jax-rs#2.0@2.22.4.0'), True)
             self.assertEqual(model_dictionary['appDeployments']['Library'].has_key('!jsf#1.2@1.2.9.0'), True)
             self.assertEqual(model_dictionary['appDeployments']['Application']['myear'].has_key('ModuleType'), False)

--- a/core/src/test/python/compare_model_test.py
+++ b/core/src/test/python/compare_model_test.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import unittest
@@ -13,19 +13,39 @@ from oracle.weblogic.deploy.logging import SummaryHandler
 from oracle.weblogic.deploy.util import PyWLSTException
 
 from compare_model import ModelFileDiffer
+from wlsdeploy.aliases.model_constants import APPLICATION
+from wlsdeploy.aliases.model_constants import APP_DEPLOYMENTS
+from wlsdeploy.aliases.model_constants import LIBRARY
+from wlsdeploy.aliases.model_constants import MAX_THREADS_CONSTRAINT
+from wlsdeploy.aliases.model_constants import MIN_THREADS_CONSTRAINT
+from wlsdeploy.aliases.model_constants import RESOURCES
+from wlsdeploy.aliases.model_constants import SELF_TUNING
+from wlsdeploy.aliases.model_constants import SOURCE_PATH
+from wlsdeploy.aliases.model_constants import TOPOLOGY
+from wlsdeploy.aliases.model_constants import WORK_MANAGER
 from wlsdeploy.logging.platform_logger import PlatformLogger
+from wlsdeploy.util import dictionary_utils
+from wlsdeploy.util import model_helper
 from wlsdeploy.util.model_context import ModelContext
 from wlsdeploy.util.model_translator import FileToPython
 
 
 class CompareModelTestCase(unittest.TestCase):
     _resources_dir = '../../test-classes'
+    _tests_dir = '../../unit-tests'
+    _results_dir = _tests_dir + '/compare'
     _use_ordering = True
 
     def setUp(self):
         self.name = 'CompareModelTestCase'
         self._logger = PlatformLogger('wlsdeploy.compare_model')
         self._program_name = 'CompareModelTestCase'
+
+        if not os.path.isdir(self._tests_dir):
+            os.mkdir(self._tests_dir)
+
+        if not os.path.isdir(self._results_dir):
+            os.mkdir(self._results_dir)
 
         # add summary handler to validate logger to check results
         self._summary_handler = SummaryHandler()
@@ -419,6 +439,87 @@ class CompareModelTestCase(unittest.TestCase):
 
         if os.path.exists(_temp_dir):
             shutil.rmtree(_temp_dir)
+
+        self.assertEqual(return_code, 0)
+
+    def testCompareModel4(self):
+        _method_name = 'testCompareModel4'
+
+        _models_dir = self._resources_dir + '/compare'
+        _new_model_file = _models_dir + '/model-4-new.yaml'
+        _old_model_file = _models_dir + '/model-4-old.yaml'
+
+        _output_dir = os.path.join(self._results_dir, 'model-4')
+        if not os.path.isdir(_output_dir):
+            os.mkdir(_output_dir)
+
+        args_map = {
+            '-oracle_home': '/oracle',
+            '-output_dir': _output_dir,
+            '-trailing_arguments': [_new_model_file, _old_model_file]
+        }
+
+        try:
+            model_context = ModelContext('CompareModelTestCase', args_map)
+            differ = ModelFileDiffer(_new_model_file, _old_model_file, model_context, _output_dir)
+            return_code = differ.compare()
+            self.assertEqual(return_code, 0)
+
+            yaml_result = _output_dir + os.sep + 'diffed_model.yaml'
+            self.assertEqual(os.path.exists(yaml_result), True, "YAML result should exist: " + yaml_result)
+
+            json_result = _output_dir + os.sep + 'diffed_model.json'
+            self.assertEqual(os.path.exists(json_result), True, "JSON result should exist: " + json_result)
+
+            # see comments in the model for erased attributes
+            messages = differ.get_compare_msgs()
+            self.assertEqual(len(messages), 2)
+
+            model_root = FileToPython(yaml_result).parse()
+
+            # topology section not present, since no Server differences
+            topology = dictionary_utils.get_element(model_root, TOPOLOGY)
+            self.assertEqual(topology, None, "topology should not be present")
+
+            resources = dictionary_utils.get_dictionary_element(model_root, RESOURCES)
+
+            # the SelfTuning should contain delete keys for nested, named folders
+            self_tuning = dictionary_utils.get_dictionary_element(resources, SELF_TUNING)
+
+            work_manager = dictionary_utils.get_dictionary_element(self_tuning, WORK_MANAGER)
+            delete_name = model_helper.get_delete_name('newWM')
+            self.assertEqual(delete_name in work_manager, True, WORK_MANAGER + ' should contain ' + delete_name)
+
+            min_constraint = dictionary_utils.get_dictionary_element(self_tuning, MIN_THREADS_CONSTRAINT)
+            delete_name = model_helper.get_delete_name('SampleMinThreads')
+            self.assertEqual(delete_name in min_constraint, True,
+                             MIN_THREADS_CONSTRAINT + ' should contain ' + delete_name)
+
+            max_constraint = dictionary_utils.get_dictionary_element(self_tuning, MAX_THREADS_CONSTRAINT)
+            delete_name = model_helper.get_delete_name('SampleMaxThreads')
+            self.assertEqual(delete_name in max_constraint, True,
+                             MAX_THREADS_CONSTRAINT + ' should contain ' + delete_name)
+
+            deployments = dictionary_utils.get_dictionary_element(model_root, APP_DEPLOYMENTS)
+
+            libraries = dictionary_utils.get_dictionary_element(deployments, LIBRARY)
+            # mylib should not appear in change model, it had no changes
+            self.assertEqual(len(libraries), 1, "only one entry should be present in " + LIBRARY)
+            # retarget should have a source path in change model, even though only targeting changed
+            retarget = dictionary_utils.get_dictionary_element(libraries, 'retarget')
+            self.assertEqual(SOURCE_PATH in retarget, True, LIBRARY + ' retarget should  contain ' + SOURCE_PATH)
+
+            applications = dictionary_utils.get_dictionary_element(deployments, APPLICATION)
+            # myapp should not appear in change model, it had no changes
+            self.assertEqual(len(applications), 1, "only one entry should be present in " + APPLICATION)
+            # retarget should have a source path in change model, even though only targeting changed
+            retarget = dictionary_utils.get_dictionary_element(applications, 'retarget')
+            self.assertEqual(SOURCE_PATH in retarget, True, APPLICATION + ' retarget should  contain ' + SOURCE_PATH)
+
+        except (CompareException, PyWLSTException), te:
+            return_code = 2
+            self._logger.severe('WLSDPLY-05709', te.getLocalizedMessage(), error=te,
+                                class_name=self._program_name, method_name=_method_name)
 
         self.assertEqual(return_code, 0)
 

--- a/core/src/test/resources/compare/model-4-new.yaml
+++ b/core/src/test/resources/compare/model-4-new.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# see comments in model-4-old.yaml
+topology:
+    Server:
+        s1:
+
+appDeployments:
+    Library:
+        'mylib':
+            SourcePath: '/libs/mylib.jar'
+            Target: 'cluster-1'
+
+        'retarget':
+            SourcePath: '/libs/retarget.jar'
+            Target: 'cluster-1,cluster-2'
+
+    Application:
+        myapp:
+            SourcePath: /apps/myapp.ear
+            Target: ['cluster-1']
+
+        retarget:
+            SourcePath: /apps/retarget.ear
+            Target: ['cluster-1','cluster-2']

--- a/core/src/test/resources/compare/model-4-old.yaml
+++ b/core/src/test/resources/compare/model-4-old.yaml
@@ -1,0 +1,58 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+# test that Application and Library SourcePath are included when needed.
+# test that only named folders are deleted when a subtree is removed.
+# 2 attributes are erased in the change model, and will be flagged in the output.
+topology:
+    Server:
+        s1:
+            # SSL not in new model, should not appear in change model.
+            # it's the only diff, so Server will not appear at all.
+            SSL:
+                Notes: yes  # erased
+
+resources:
+    # SelfTuning is absent in the new model.
+    # the change model should have deleted elements newWM, SampleMinThreads, SampleMaxThreads.
+    SelfTuning:
+        WorkManager:
+            newWM:
+                Target: 'cluster-1'
+                MinThreadsConstraint: 'SampleMinThreads'
+                MaxThreadsConstraint: 'SampleMaxThreads'
+        MinThreadsConstraint:
+            SampleMinThreads:
+                Count: 2
+        MaxThreadsConstraint:
+            SampleMaxThreads:
+                Count: 20
+
+    # WebAppContainer is absent in the new model.
+    # it should not appear at all in the change model.
+    WebAppContainer:
+        GzipCompression:
+            Notes: WTH  # erased
+
+appDeployments:
+    Library:
+        # completely unchanged, should not appear in the change model.
+        'mylib':
+            SourcePath: '/libs/mylib.jar'
+            Target: 'cluster-1'
+
+        # unchanged except for targets, SourcePath should still appear in change model.
+        'retarget':
+            SourcePath: '/libs/retarget.jar'
+            Target: 'cluster-1'
+
+    Application:
+        # completely unchanged, should not appear in the change model.
+        myapp:
+            SourcePath: '/apps/myapp.ear'
+            Target: ['cluster-1']
+
+        # unchanged except for targets, SourcePath should still appear in change model.
+        retarget:
+            SourcePath: '/apps/retarget.ear'
+            Target: ['cluster-1']


### PR DESCRIPTION
Keep the source path for applications and libraries in the change model, even if unchanged.
Internal Jira WDT-535

Avoid flagging non-named model folders for deletion in the change model.
Internal Jira WDT-527

ModelDiffer has been moved out of compare_model.py (see model_comparer.py).
Refactored as ModelComparer to use a single pass through the models, and provide additional checks.

Some messages in applications_deployer.py were corrected to indicate Application or Library as needed.
Fix in alias_utils.py for merging properties.
