### PR TITLE
Avoid discovering attributes that are not set (online mode)

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
+++ b/core/src/main/python/wlsdeploy/tool/discover/discoverer.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os
@@ -112,6 +112,13 @@ class Discoverer(object):
                 else:
                     _logger.finer('WLSDPLY-06131', wlst_lsa_param, class_name=_class_name, method_name=_method_name)
                     wlst_value = wlst_lsa_params[wlst_lsa_param]
+
+                # if attribute was never set (online only), don't add to the model
+                if not self._wlst_helper.is_set(wlst_lsa_param):
+                    _logger.finest('WLSDPLY-06157', wlst_lsa_param, str(location), class_name=_class_name,
+                                   method_name=_method_name)
+                    continue
+
                 self._add_to_dictionary(dictionary, location, wlst_lsa_param, wlst_value, wlst_path)
 
         # These will come after the lsa / get params in the ordered dictionary

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -588,6 +588,7 @@ WLSDPLY-06154=Attribute {0} for model folder at location {1} is not in the lsa m
    to retrieve the attribute value
 WLSDPLY-06155=Attribute {0} value at location {1} replaced by token {2}
 WLSDPLY-06156=MBean not defined in alias definitions at location {0}. Will skip discovery of MBean folder.
+WLSDPLY-06157=Attribute {0} is not set at location {1}, omitting from model
 
 # mbean_getter.py, attribute_getter.py specific to discover
 WLSDPLY-06200=Unable to get the Security Realm Provider location {0} in version {1} with offline WLST. \


### PR DESCRIPTION
Check the WLST isSet() method before adding each attribute to the model.
FYI wlst_helper.is_set() already checks for online, returns True for offline.

Fixes #825

Internal JIRA WDT-288
