### PR TITLE
remove WeblogicHelper dependencies from aliases for aliastest

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/aliases.py
+++ b/core/src/main/python/wlsdeploy/aliases/aliases.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 from java.lang import String
@@ -50,7 +50,6 @@ from wlsdeploy.exception import exception_helper
 from wlsdeploy.exception.expection_types import ExceptionType
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.util import string_utils
-from wlsdeploy.util.weblogic_helper import WebLogicHelper
 
 
 class Aliases(object):
@@ -74,8 +73,9 @@ class Aliases(object):
         self._exception_type = exception_type
         self._logger = PlatformLogger('wlsdeploy.aliases')
 
-        self._wls_helper = WebLogicHelper(self._logger)
         if wls_version is None:
+            from wlsdeploy.util.weblogic_helper import WebLogicHelper
+            self._wls_helper = WebLogicHelper(self._logger)
             self._wls_version = self._wls_helper.wl_version_actual
         else:
             self._wls_version = wls_version

--- a/core/src/main/python/wlsdeploy/util/cla_utils.py
+++ b/core/src/main/python/wlsdeploy/util/cla_utils.py
@@ -19,12 +19,12 @@ from wlsdeploy.util import path_utils
 from wlsdeploy.util.target_configuration import CREDENTIALS_METHOD
 from wlsdeploy.util.target_configuration import CREDENTIALS_METHODS
 from wlsdeploy.util.target_configuration import TargetConfiguration
-from wlsdeploy.util.weblogic_helper import WebLogicHelper
 
 # tool type may indicate variations in argument processing
 TOOL_TYPE_CREATE = "create"
 TOOL_TYPE_DEFAULT = "default"
 TOOL_TYPE_EXTRACT = "extract"
+
 
 
 class CommandLineArgUtil(object):
@@ -422,6 +422,7 @@ class CommandLineArgUtil(object):
         return self.ORACLE_HOME_SWITCH == key
 
     def _validate_oracle_home_arg(self, value):
+        from wlsdeploy.util.weblogic_helper import WebLogicHelper
         method_name = '_validate_oracle_home_arg'
 
         try:
@@ -923,6 +924,7 @@ class CommandLineArgUtil(object):
         return self.TARGET_VERSION_SWITCH == key
 
     def _validate_target_version_arg(self, value):
+        from wlsdeploy.util.weblogic_helper import WebLogicHelper
         method_name = '_validate_target_version_arg'
 
         # Try our best to determine if this is a legitimate WLS version number.

--- a/core/src/main/python/wlsdeploy/util/string_utils.py
+++ b/core/src/main/python/wlsdeploy/util/string_utils.py
@@ -112,9 +112,9 @@ def load_properties(property_file, exception_type=None):
 def is_weblogic_version_or_above(wls_version, str_version):
     """
     Is the provided version number equal to or greater than the version encapsualted by this version instance
-    :param wls_version: the array representation of the current weblogic version to be compared
-    :param str_version: the string representation of the version to be compared
-    :return: True if the provided version is equal or greater than the version represented by this helper instance
+    :param wls_version: the string representation of the current weblogic version
+    :param str_version: the string representation of the version to be compared to the weblogic version
+    :return: True if the provided version is equal or greater than the version represented by the wls_version argument
     """
     result = False
     array_version = str_version.split('.')
@@ -148,7 +148,7 @@ def is_weblogic_version_or_above(wls_version, str_version):
 def _get_wl_version_array(wl_version):
     """
     Get the WebLogic version number padded to the standard number of digits.
-    :param wl_version: Weblogic version number
+    :param wl_version: WebLogic version number
     :return: the padded WebLogic version number
     """
     result = wl_version.split('.')

--- a/core/src/main/python/wlsdeploy/util/weblogic_helper.py
+++ b/core/src/main/python/wlsdeploy/util/weblogic_helper.py
@@ -1,9 +1,8 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import java.lang.Exception as JException
-import java.lang.String as JString
 
 import weblogic.management.provider.ManagementServiceClient as ManagementServiceClient
 import weblogic.security.internal.SerializedSystemIni as SerializedSystemIni
@@ -16,11 +15,12 @@ from wlsdeploy.util import string_utils
 import os
 import re
 
+
 class WebLogicHelper(object):
     """
     Helper functions for version-specific WebLogic operations.
     """
-    STANDARD_VERSION_NUMBER_PLACES = 5
+
     MINIMUM_WEBLOGIC_VERSION = '10.3.6'
     _class_name = 'WebLogicHelper'
 
@@ -228,27 +228,11 @@ class WebLogicHelper(object):
                 False (default), use version places up to the number represented by STANDARD_VERSION_NUMBER_PLACES
         :return: True if the provided version is equal or greater than the version represented by this helper instance
         """
-        result = False
-        array_version = str_version.split('.')
-        array_wl_version = self._get_wl_version_array(use_actual_version=use_actual_version)
-
-        len_compare = len(array_wl_version)
-        if len(array_version) < len_compare:
-            len_compare = len(array_version)
-
-        idx = 0
-        while idx < len_compare:
-            compare_value = JString(array_version[idx]).compareTo(JString(array_wl_version[idx]))
-            if compare_value < 0:
-                result = True
-                break
-            elif compare_value > 0:
-                result = False
-                break
-            elif idx + 1 == len_compare:
-                result = True
-
-            idx += 1
+        if use_actual_version:
+            wl_version = self.wl_version_actual
+        else:
+            wl_version = self.wl_version
+        result = string_utils.is_weblogic_version_or_above(wl_version, str_version)
 
         return result
 
@@ -260,29 +244,6 @@ class WebLogicHelper(object):
         """
         bean_access = ManagementServiceClient.getBeanInfoAccess()
         return bean_access.getBeanInfoForInterface(interface_name, False, '9.0.0.0')
-
-    # We need to pad the actual version number for comparison purposes so
-    # that is is never shorter than the specified version.  Otherwise,
-    # actual version 12.2.1 will be considered to be equal to 12.2.1.1
-    #
-    def _get_wl_version_array(self, use_actual_version=False):
-        """
-        Get the WebLogic version number padded to the standard number of digits.
-        :param use_actual_version: whether to use the actual or supplied version of WebLogic
-        :return: the padded WebLogic version number
-        """
-        if use_actual_version:
-            result = self.wl_version_actual.split('.')
-        else:
-            result = self.wl_version.split('.')
-
-        if len(result) < self.STANDARD_VERSION_NUMBER_PLACES:
-            index = len(result)
-            while index < self.STANDARD_VERSION_NUMBER_PLACES:
-                result.append('0')
-                index += 1
-
-        return result
 
     def get_next_higher_order_version_number(self, version_number):
         """


### PR DESCRIPTION
Remove hard dependencies on Weblogic classes from WeblogicHelper in the aliases and alias_entries python files. This will allow the alias test to run without having a dependency on an oracle home.