### PR TITLE
For -target vz and wko, omit cluster section if list is empty

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/util/targets/file_template_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/targets/file_template_helper.py
@@ -103,7 +103,8 @@ def _create_file_from_stream(template_stream, template_hash, output_file):
 def _process_block(block_key, template_lines, template_hash, file_writer):
     value = dictionary_utils.get_element(template_hash, block_key)
 
-    if value is None:
+    # skip block for value of False, None, or empty collection
+    if not value:
         return
 
     if not isinstance(value, list):

--- a/core/src/main/targetconfigs/vz/application.yaml
+++ b/core/src/main/targetconfigs/vz/application.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-​
+
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:


### PR DESCRIPTION
Problems discussed in verrazzano-dev Slack:
- Section `clusters` should be omitted if list is empty.
- A control character was removed from application.yaml .

For template processing, skip template block if false value in hash.
Internal Jira WDT-522