### PR TITLE
Removed deprecated Integer constructor usage

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/logging/SummaryHandler.java
+++ b/core/src/main/java/oracle/weblogic/deploy/logging/SummaryHandler.java
@@ -266,7 +266,7 @@ public class SummaryHandler extends Handler implements WLSDeployLogEndHandler {
     private int getSize(String propSize) {
         Integer handlerSize;
         try {
-            handlerSize = new Integer(propSize);
+            handlerSize = Integer.valueOf(propSize);
         } catch (NumberFormatException nfe) {
             handlerSize = DEFAULT_SIZE;
         }


### PR DESCRIPTION
Java is going to be removing support for `new <WrapperType>(<primitiveType>)`