### PR TITLE
Update update.md

### DIFF
--- a/site/model.md
+++ b/site/model.md
@@ -36,7 +36,7 @@ All assignment statements must have one or more spaces between the colon and the
 - [Using Multiple Models](#using-multiple-models)
 
 ### Top-Level Model Sections
-The tooling has four top-level model sections:
+The tooling has five top-level model sections:
 
 - `domainInfo`     - The location where special information not represented in WLST is specified (for example, the libraries that go in `$DOMAIN_HOME/lib`).
 - `topology`       - The location where servers, clusters, machines, server templates, and other domain-level configuration is specified.

--- a/site/update.md
+++ b/site/update.md
@@ -18,7 +18,7 @@ Unlike the Create Domain Tool, the full domain home directory is specified, rath
 
 The Update Domain Tool will not attempt to recreate or add schemas for the RCU database, for domain types that use RCU.
 
-When running the tool in WLST online mode, the update operation may require server restarts or a domain restart to pick up the changes.  The update operation can also encounter situations where it cannot complete its operation until the domain is restarted.  To communicate these conditions to scripts that may be calling the Update Domain Tool, the shell scripts have three special, non-zero exit codes to communicate these states:
+When running the tool in WLST online mode, the update operation may require server restarts or a domain restart to pick up the changes.  The update operation can also encounter situations where it cannot complete its operation until the domain is restarted.  To communicate these conditions to scripts that may be calling the Update Domain Tool, the shell scripts have two special, non-zero exit codes to communicate these states:
 
 - `103` - The entire domain needs to be restarted.
 - `104` - The domain changes have been canceled because the changes in the model requires a domain restart and -cancel_changes_if_restart_required is specified.


### PR DESCRIPTION
Documentation references two exit codes but specifies that there are three. Change the three to two.
Fixes #854