### PR TITLE
Release plugin args

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,9 +112,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.0.0-M1</version>
-                    <configuration>
-                        <arguments>-Dunit-test-wlst-dir=${unit-test-wlst-dir}</arguments>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -269,6 +266,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
+                    <arguments>-Dunit-test-wlst-dir=${unit-test-wlst-dir}</arguments>
                     <tagNameFormat>release-@{project.version}</tagNameFormat>
                     <!-- Tell release:perform to stop before trying to push to a remote repository -->
                     <goals>install</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.0.0-M1</version>
+                    <configuration>
+                        <arguments>-Dunit-test-wlst-dir=${unit-test-wlst-dir}</arguments>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Adding configuration to the Maven release plugin so that it can pass the unit-test-wlst-dir system property from the command-line to the release builds without requiring the WLST_DIR environment variable (which will also still work).