### PR TITLE
Move clear JDBC placeholder targets after set server groups to contro…

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/topology_updater.py
@@ -150,6 +150,9 @@ class TopologyUpdater(Deployer):
         self._process_section(self._topology, folder_list, MIGRATABLE_TARGET, location, delete_now)
 
         # targets may have been inadvertently assigned when clusters were added
+        return jdbc_names
+
+    def clear_placeholder_targeting(self, jdbc_names):
         self.topology_helper.clear_jdbc_placeholder_targeting(jdbc_names)
 
     def warn_set_server_groups(self):


### PR DESCRIPTION
…l target to admin server

Fixes WDT-555

I moved the clear jdbc placholder targets to after set server groups, which targets to Admin for RAC. This change reflects the order which create domain clears the placeholder targets.