### PR TITLE
Allow build with JDK11

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <!-- Need to resolve Jython classes at compile time.  At runtime, WLST will provide the classes. -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,10 @@
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
         <!-- Need to resolve Jython classes at compile time.  At runtime, WLST will provide the classes. -->
         <dependency>
             <groupId>org.python</groupId>
@@ -49,13 +53,13 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-easymock</artifactId>
-            <version>1.6.6</version>
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.6.6</version>
+            <version>2.0.9</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
                 <artifactId>guava</artifactId>
                 <version>29.0-jre</version>
             </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -116,7 +121,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.22.2</version>
                     <configuration>
                         <!-- Created by jacoco plugin (inherited configuration) -->
                         <argLine>${surefireArgLine}</argLine>
@@ -145,7 +150,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.9</version>
+                    <version>0.8.6</version>
                     <executions>
                         <execution>
                             <id>pre-unit-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,22 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>enforce-wlst</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <rules>
+                                <requireProperty>
+                                    <property>unit-test-wlst-dir</property>
+                                    <message>Unable to find WLST in order to run unit tests. Please set the unit-test-wlst-dir System property to point to the directory where wlst.sh lives in the Oracle Home. Or, set WLST_DIR environment variable. An example can be found in .mvn/maven.config-template. Optionally, you may -DskipTests.
+                                    </message>
+                                </requireProperty>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
I was able to build with JDK 8, 11, and 16.  The generated classes are still compatible with JDK 1.7 based on the target and requirement to run with WLS 10.3.6.