### PR TITLE
if defined, use top-level replicas as default for clusters

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/extract/domain_resource_extractor.py
+++ b/core/src/main/python/wlsdeploy/tool/extract/domain_resource_extractor.py
@@ -251,11 +251,11 @@ class DomainResourceExtractor:
                 cluster_list = list()
                 spec_section[CLUSTERS] = cluster_list
                 for cluster_name, cluster_values in model_clusters.items():
-                    if REPLICAS not in spec_section:
+                    if REPLICAS in spec_section:
+                        server_count = spec_section[REPLICAS]
+                    else:
                         server_count = k8s_helper.get_server_count(cluster_name, cluster_values,
                                                                    self._model.get_model(), self._aliases)
-                    else:
-                        server_count = spec_section[REPLICAS]
                     cluster_dict = PyOrderedDict()
                     cluster_dict[CLUSTER_NAME] = cluster_name
                     cluster_dict[REPLICAS] = server_count

--- a/core/src/main/python/wlsdeploy/tool/extract/domain_resource_extractor.py
+++ b/core/src/main/python/wlsdeploy/tool/extract/domain_resource_extractor.py
@@ -251,8 +251,11 @@ class DomainResourceExtractor:
                 cluster_list = list()
                 spec_section[CLUSTERS] = cluster_list
                 for cluster_name, cluster_values in model_clusters.items():
-                    server_count = k8s_helper.get_server_count(cluster_name, cluster_values, self._model.get_model(),
-                                                               self._aliases)
+                    if REPLICAS not in spec_section:
+                        server_count = k8s_helper.get_server_count(cluster_name, cluster_values,
+                                                                   self._model.get_model(), self._aliases)
+                    else:
+                        server_count = spec_section[REPLICAS]
                     cluster_dict = PyOrderedDict()
                     cluster_dict[CLUSTER_NAME] = cluster_name
                     cluster_dict[REPLICAS] = server_count


### PR DESCRIPTION
extractDomainResource should use the replica count when specified in the kubernetes section as the default cluster replicas count instead of the cluster size