### PR TITLE
Allow Jython bool value in model for deep copy and file write in WLS 14.1.2

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.  All rights reserved.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.util;
@@ -514,6 +514,7 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
 
         String typeName = origType.fastGetName();
         switch(typeName) {
+            case "bool":
             case "float":
             case "int":
             case "long":

--- a/core/src/main/python/wlsdeploy/yaml/yaml_translator.py
+++ b/core/src/main/python/wlsdeploy/yaml/yaml_translator.py
@@ -242,6 +242,10 @@ class PythonToYaml(object):
             result = 'null'
         elif type(value) is int or type(value) is long or type(value) is float:
             result = str(value)
+        elif type(value) is bool:
+            result = 'false'
+            if value:
+                result = 'true'
         elif type(value) is list:
             new_value = '['
             for element in value:


### PR DESCRIPTION
The target filters set ServerTemplate / AutoMigrationEnabled to False.
Any custom filter could do the same.
Tested backward compatibility with 12.2.1.3.

Internal JIRA-WDT-564
