### PR TITLE
fix: typo grammar spell

### DIFF
--- a/alias-test/src/test/python/aliastest/generate/generator_helper.py
+++ b/alias-test/src/test/python/aliastest/generate/generator_helper.py
@@ -413,7 +413,7 @@ class GeneratorHelper:
         """
         Use the mbean info map containment type to pluck out (best able) the subfolders
         :param methods_map: contains the methods from the mbean interface
-        :param mbean_info_map: contans the property descriptors from the MBeanInfo
+        :param mbean_info_map: contains the property descriptors from the MBeanInfo
         """
         self._remove_subfolders(methods_map, mbean_info_map)
         self._remove_unused_methods(methods_map)

--- a/alias-test/src/test/python/aliastest/generate/generator_helper.py
+++ b/alias-test/src/test/python/aliastest/generate/generator_helper.py
@@ -413,7 +413,7 @@ class GeneratorHelper:
         """
         Use the mbean info map containment type to pluck out (best able) the subfolders
         :param methods_map: contains the methods from the mbean interface
-        :param mbean_info_map: contains the property descriptors from the MBeanInfo
+        :param mbean_info_map: contans the property descriptors from the MBeanInfo
         """
         self._remove_subfolders(methods_map, mbean_info_map)
         self._remove_unused_methods(methods_map)

--- a/alias-test/src/test/python/aliastest/util/all_utils.py
+++ b/alias-test/src/test/python/aliastest/util/all_utils.py
@@ -331,7 +331,7 @@ def populate_test_files_location(kwargs):
     """
     Find the test files path from the argument list, for the test file location command. This is
     populated in the global location of the utils file, for use during this instance of the integration test.
-    Any generated json files will be stored and read from this location, and verification reports will be strored
+    Any generated json files will be stored and read from this location, and verification reports will be stored
     at this location.
     :param kwargs: command line argument map
     """
@@ -544,7 +544,7 @@ def _write_dictionary_to_json_file(dictionary, writer, indent=''):
     Write the python dictionary in json syntax using the provided writer stream.
     :param dictionary: python dictionary to convert to json syntax
     :param writer: where to write the dictionary into json syntax
-    :param indent: current string indention of the json syntax. If not provided, indent is an empty string
+    :param indent: current string indentation of the json syntax. If not provided, indent is an empty string
     """
     _method_name = '_write_dictionary_to_json_file'
     _start_dict = '{'

--- a/alias-test/src/test/python/aliastest/util/all_utils.py
+++ b/alias-test/src/test/python/aliastest/util/all_utils.py
@@ -331,7 +331,7 @@ def populate_test_files_location(kwargs):
     """
     Find the test files path from the argument list, for the test file location command. This is
     populated in the global location of the utils file, for use during this instance of the integration test.
-    Any generated json files will be stored and read from this location, and verification reports will be stored
+    Any generated json files will be stored and read from this location, and verification reports will be strored
     at this location.
     :param kwargs: command line argument map
     """
@@ -544,7 +544,7 @@ def _write_dictionary_to_json_file(dictionary, writer, indent=''):
     Write the python dictionary in json syntax using the provided writer stream.
     :param dictionary: python dictionary to convert to json syntax
     :param writer: where to write the dictionary into json syntax
-    :param indent: current string indentation of the json syntax. If not provided, indent is an empty string
+    :param indent: current string indention of the json syntax. If not provided, indent is an empty string
     """
     _method_name = '_write_dictionary_to_json_file'
     _start_dict = '{'

--- a/alias-test/src/test/python/aliastest/verify/verifier_helper.py
+++ b/alias-test/src/test/python/aliastest/verify/verifier_helper.py
@@ -1236,7 +1236,7 @@ def object_type(attribute_info):
     """
     Determine if the attribute is an object or reference type in WLST.
     :param attribute_info: Information gathered about the attribute
-    :return: True if the attribut is an object type in WLST
+    :return: True if the attribute is an object type in WLST
     """
     lsa_type, get_type, cmo_type = _get_attribute_types(attribute_info)
     return lsa_type == alias_constants.OBJECT or \

--- a/alias-test/src/test/python/aliastest/verify/verifier_helper.py
+++ b/alias-test/src/test/python/aliastest/verify/verifier_helper.py
@@ -1236,7 +1236,7 @@ def object_type(attribute_info):
     """
     Determine if the attribute is an object or reference type in WLST.
     :param attribute_info: Information gathered about the attribute
-    :return: True if the attribute is an object type in WLST
+    :return: True if the attribut is an object type in WLST
     """
     lsa_type, get_type, cmo_type = _get_attribute_types(attribute_info)
     return lsa_type == alias_constants.OBJECT or \

--- a/core/src/main/java/oracle/weblogic/deploy/create/RCURunner.java
+++ b/core/src/main/java/oracle/weblogic/deploy/create/RCURunner.java
@@ -24,7 +24,7 @@ import org.python.core.PyString;
 
 
 /**
- * This class does all the work to drop and recreate the RCU schemas besed on the domain type definition.
+ * This class does all the work to drop and recreate the RCU schemas based on the domain type definition.
  */
 public class RCURunner {
     private static final String CLASS = RCURunner.class.getName();

--- a/core/src/main/java/oracle/weblogic/deploy/create/RCURunner.java
+++ b/core/src/main/java/oracle/weblogic/deploy/create/RCURunner.java
@@ -24,7 +24,7 @@ import org.python.core.PyString;
 
 
 /**
- * This class does all the work to drop and recreate the RCU schemas based on the domain type definition.
+ * This class does all the work to drop and recreate the RCU schemas besed on the domain type definition.
  */
 public class RCURunner {
     private static final String CLASS = RCURunner.class.getName();

--- a/core/src/main/java/oracle/weblogic/deploy/util/FileUtils.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/FileUtils.java
@@ -808,7 +808,7 @@ public final class FileUtils {
 
 
     /**
-     * Convert an octal number into Posix File Permisions.
+     * Convert an octal number into Posix File Permissions.
      * @param octals 3 octal digits representing posix file permissions rwxrwxrwx
      * @return a set of Posix file permissions
      */

--- a/core/src/main/java/oracle/weblogic/deploy/util/FileUtils.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/FileUtils.java
@@ -808,7 +808,7 @@ public final class FileUtils {
 
 
     /**
-     * Convert an octal number into Posix File Permissions.
+     * Convert an octal number into Posix File Permisions.
      * @param octals 3 octal digits representing posix file permissions rwxrwxrwx
      * @return a set of Posix file permissions
      */

--- a/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
@@ -156,7 +156,7 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
 
     /**
      * The internal method that the copy.deepcopy() implementation looks for
-     * to preform a deepcopy on non-built-in types.  Note that this implementation
+     * to perform a deepcopy on non-built-in types.  Note that this implementation
      * has limitations in that it only knows how to deepcopy a limited set of types
      * (NoneType, int, long, float, str, list, dict, and PyOrderedDict).  Any other
      * types encountered will log an error and return the original object without

--- a/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/PyOrderedDict.java
@@ -156,7 +156,7 @@ public final class PyOrderedDict extends PyDictionary implements Iterable<PyObje
 
     /**
      * The internal method that the copy.deepcopy() implementation looks for
-     * to perform a deepcopy on non-built-in types.  Note that this implementation
+     * to preform a deepcopy on non-built-in types.  Note that this implementation
      * has limitations in that it only knows how to deepcopy a limited set of types
      * (NoneType, int, long, float, str, list, dict, and PyOrderedDict).  Any other
      * types encountered will log an error and return the original object without

--- a/core/src/main/java/oracle/weblogic/deploy/util/WLSDeployZipFile.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/WLSDeployZipFile.java
@@ -220,7 +220,7 @@ public class WLSDeployZipFile {
      *
      * @param key the beginning part of the entry names to match
      * @return a map of InputStreams keyed by the entry name
-     * @throws WLSDeployArchiveIOException if an IOException occured while rading or writing changes
+     * @throws WLSDeployArchiveIOException if an IOException occurred while rading or writing changes
      */
     public Map<String, InputStream> getZipEntries(String key) throws WLSDeployArchiveIOException {
         final String METHOD = "getZipEntries";

--- a/core/src/main/java/oracle/weblogic/deploy/util/WLSDeployZipFile.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/WLSDeployZipFile.java
@@ -220,7 +220,7 @@ public class WLSDeployZipFile {
      *
      * @param key the beginning part of the entry names to match
      * @return a map of InputStreams keyed by the entry name
-     * @throws WLSDeployArchiveIOException if an IOException occurred while rading or writing changes
+     * @throws WLSDeployArchiveIOException if an IOException occured while rading or writing changes
      */
     public Map<String, InputStream> getZipEntries(String key) throws WLSDeployArchiveIOException {
         final String METHOD = "getZipEntries";

--- a/core/src/main/python/wlsdeploy/aliases/location_context.py
+++ b/core/src/main/python/wlsdeploy/aliases/location_context.py
@@ -42,7 +42,7 @@ class LocationContext(object):
 
     def pop_location(self, index=None):
         """
-        Pops (or removes) a location from the exising location context
+        Pops (or removes) a location from the existing location context
         :param index: integer Index of list item to pop
         :return: The ``model_folder`` of list item at ``index``
         """

--- a/core/src/main/python/wlsdeploy/aliases/location_context.py
+++ b/core/src/main/python/wlsdeploy/aliases/location_context.py
@@ -42,7 +42,7 @@ class LocationContext(object):
 
     def pop_location(self, index=None):
         """
-        Pops (or removes) a location from the existing location context
+        Pops (or removes) a location from the exising location context
         :param index: integer Index of list item to pop
         :return: The ``model_folder`` of list item at ``index``
         """

--- a/core/src/main/python/wlsdeploy/aliases/password_utils.py
+++ b/core/src/main/python/wlsdeploy/aliases/password_utils.py
@@ -57,7 +57,7 @@ def get_wlst_attribute_name(attribute_info, attribute_value, wlst_mode):
     Returns the corrected WLST attribute name for the specified parameters.
     The "Encrypted" suffix is removed from online dual-password attributes for use with unencrypted values.
     :param attribute_info: the attribute information to be checked
-    :param attribute_value: the vaue to be checked for encryption
+    :param attribute_value: the value to be checked for encryption
     :param wlst_mode: the offline or online type to be checked
     :return: the corrected value, or None if no correction was required
     """

--- a/core/src/main/python/wlsdeploy/aliases/password_utils.py
+++ b/core/src/main/python/wlsdeploy/aliases/password_utils.py
@@ -57,7 +57,7 @@ def get_wlst_attribute_name(attribute_info, attribute_value, wlst_mode):
     Returns the corrected WLST attribute name for the specified parameters.
     The "Encrypted" suffix is removed from online dual-password attributes for use with unencrypted values.
     :param attribute_info: the attribute information to be checked
-    :param attribute_value: the value to be checked for encryption
+    :param attribute_value: the vaue to be checked for encryption
     :param wlst_mode: the offline or online type to be checked
     :return: the corrected value, or None if no correction was required
     """

--- a/core/src/main/python/wlsdeploy/json/json_translator.py
+++ b/core/src/main/python/wlsdeploy/json/json_translator.py
@@ -155,7 +155,7 @@ class PythonToJson(object):
         Write the python dictionary in json syntax using the provided writer stream.
         :param dictionary: python dictionary to convert to json syntax
         :param writer: where to write the dictionary into json syntax
-        :param indent: current string indention of the json syntax. If not provided, indent is an empty string
+        :param indent: current string indentation of the json syntax. If not provided, indent is an empty string
         """
         _method_name = '_write_dictionary_to_json_file'
         _start_dict = '{'
@@ -192,7 +192,7 @@ class PythonToJson(object):
         Write the python list in json syntax using the provided writer stream.
         :param alist: python list to convert to json syntax
         :param writer: where to write the list into json syntax
-        :param indent: current string indention of the json syntax. If not provided, indent is an empty string
+        :param indent: current string indentation of the json syntax. If not provided, indent is an empty string
         """
         writer.write('[')
         end_line = ''

--- a/core/src/main/python/wlsdeploy/json/json_translator.py
+++ b/core/src/main/python/wlsdeploy/json/json_translator.py
@@ -155,7 +155,7 @@ class PythonToJson(object):
         Write the python dictionary in json syntax using the provided writer stream.
         :param dictionary: python dictionary to convert to json syntax
         :param writer: where to write the dictionary into json syntax
-        :param indent: current string indentation of the json syntax. If not provided, indent is an empty string
+        :param indent: current string indention of the json syntax. If not provided, indent is an empty string
         """
         _method_name = '_write_dictionary_to_json_file'
         _start_dict = '{'
@@ -192,7 +192,7 @@ class PythonToJson(object):
         Write the python list in json syntax using the provided writer stream.
         :param alist: python list to convert to json syntax
         :param writer: where to write the list into json syntax
-        :param indent: current string indentation of the json syntax. If not provided, indent is an empty string
+        :param indent: current string indention of the json syntax. If not provided, indent is an empty string
         """
         writer.write('[')
         end_line = ''

--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -694,7 +694,7 @@ class DomainCreator(Creator):
     def __create_security_folder(self):
         """
         Create the the security objects if any. The security information
-        from the model will be writting to the DefaultAuthenticatorInit.ldift file
+        from the model will be writing to the DefaultAuthenticatorInit.ldift file
         :raises: CreateException: if an error occurs
         """
         _method_name = '__create_security_folder'
@@ -791,7 +791,7 @@ class DomainCreator(Creator):
     def __create_machines_clusters_and_servers(self, delete_now=True):
         """
         Create the /Cluster, /ServerTemplate, and /Server folder objects.
-        :param delete_now: Flag determing whether the delete of the elements will be delayed
+        :param delete_now: Flag determining whether the delete of the elements will be delayed
         :raises: CreateException: if an error occurs
         """
         _method_name = '__create_machines_clusters_and_servers'

--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -694,7 +694,7 @@ class DomainCreator(Creator):
     def __create_security_folder(self):
         """
         Create the the security objects if any. The security information
-        from the model will be writing to the DefaultAuthenticatorInit.ldift file
+        from the model will be writting to the DefaultAuthenticatorInit.ldift file
         :raises: CreateException: if an error occurs
         """
         _method_name = '__create_security_folder'
@@ -791,7 +791,7 @@ class DomainCreator(Creator):
     def __create_machines_clusters_and_servers(self, delete_now=True):
         """
         Create the /Cluster, /ServerTemplate, and /Server folder objects.
-        :param delete_now: Flag determining whether the delete of the elements will be delayed
+        :param delete_now: Flag determing whether the delete of the elements will be delayed
         :raises: CreateException: if an error occurs
         """
         _method_name = '__create_machines_clusters_and_servers'

--- a/core/src/main/python/wlsdeploy/tool/create/security_provider_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/security_provider_creator.py
@@ -192,7 +192,7 @@ class SecurityProviderCreator(Creator):
         """
         Process the model nodes at the specified location.
         Override default behavior to process security configuration and realm sub-folders before attributes.
-        Security configration attribute DefaultRealm needs to get the MBean of the referenced realm.
+        Security configuration attribute DefaultRealm needs to get the MBean of the referenced realm.
         Realm attribute CertPathBuilder needs to get the MBean of the referenced certificate registry.
         :param location: the location where the nodes should be processed
         :param model_nodes: the model dictionary of the nodes to be processed

--- a/core/src/main/python/wlsdeploy/tool/create/security_provider_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/security_provider_creator.py
@@ -192,7 +192,7 @@ class SecurityProviderCreator(Creator):
         """
         Process the model nodes at the specified location.
         Override default behavior to process security configuration and realm sub-folders before attributes.
-        Security configuration attribute DefaultRealm needs to get the MBean of the referenced realm.
+        Security configration attribute DefaultRealm needs to get the MBean of the referenced realm.
         Realm attribute CertPathBuilder needs to get the MBean of the referenced certificate registry.
         :param location: the location where the nodes should be processed
         :param model_nodes: the model dictionary of the nodes to be processed

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_kubernetes_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_kubernetes_printer.py
@@ -155,7 +155,7 @@ class ModelKubernetesPrinter(object):
         """
         Prints a model sample for the attributes in a model location
         :param schema_folder: the schema folder to be printed
-        :param indent_level: the level of indention for this folder
+        :param indent_level: the level of indentation for this folder
         """
         _method_name = '_print_attributes_sample'
 

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_kubernetes_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_kubernetes_printer.py
@@ -155,7 +155,7 @@ class ModelKubernetesPrinter(object):
         """
         Prints a model sample for the attributes in a model location
         :param schema_folder: the schema folder to be printed
-        :param indent_level: the level of indentation for this folder
+        :param indent_level: the level of indention for this folder
         """
         _method_name = '_print_attributes_sample'
 

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
@@ -95,7 +95,7 @@ class ModelSamplePrinter(object):
 
         print("")
 
-        # write the parent folders, with indention and any name folders included
+        # write the parent folders, with indentation and any name folders included
 
         indent = 0
         model_location = LocationContext()

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
@@ -95,7 +95,7 @@ class ModelSamplePrinter(object):
 
         print("")
 
-        # write the parent folders, with indentation and any name folders included
+        # write the parent folders, with indention and any name folders included
 
         indent = 0
         model_location = LocationContext()

--- a/core/src/main/python/wlsdeploy/tool/util/target_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/target_helper.py
@@ -527,7 +527,7 @@ class TargetHelper(object):
     def get_dc_to_server_groups_map(self, dynamic_cluster_names, server_groups, dc_sg_targeting_limits):
         """
         Remake the map for each dynamic cluster name and its server groups. If the dynamic cluster is not
-        specifically targeted by the dynamic cluster server group targeting limits, targt any remaining
+        specifically targeted by the dynamic cluster server group targeting limits, target any remaining
         server groups not in the targeting limits, to any remaining typedef dynamic cluster server group targets.
         :param dynamic_cluster_names: list of dynamic clusters in the domain
         :param server_groups: list of dynamic server groups in the typedef

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -733,7 +733,7 @@ class ModelContext(object):
     def replace_tokens_in_path(self, attribute_name, resource_dict):
         """
         Replace any tokens in a path with the current values.
-        :param attribute_name: the attrribute name
+        :param attribute_name: the attribute name
         :param resource_dict: the dictionary to use to lookup and replace the attribute value
         """
         separator = ':'

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -733,7 +733,7 @@ class ModelContext(object):
     def replace_tokens_in_path(self, attribute_name, resource_dict):
         """
         Replace any tokens in a path with the current values.
-        :param attribute_name: the attribute name
+        :param attribute_name: the attrribute name
         :param resource_dict: the dictionary to use to lookup and replace the attribute value
         """
         separator = ':'

--- a/core/src/test/python/validation_test.py
+++ b/core/src/test/python/validation_test.py
@@ -207,7 +207,7 @@ class ValidationTestCase(unittest.TestCase):
           self._logger.severe('WLSDPLY-20000', self._program_name, ve.getLocalizedMessage(), error=ve,
                         class_name=self._class_name, method_name=_method_name)
 
-        # assert the validate filter made modications and was persisted
+        # assert the validate filter made modifications and was persisted
         self.assertEquals('gumby1234', model_dictionary['domainInfo']['AdminPassword'], "Expected validate filter to have changed AdminPassword to 'gumby1234'")
 
     def deleteFile(self, path):

--- a/core/src/test/python/validation_test.py
+++ b/core/src/test/python/validation_test.py
@@ -207,7 +207,7 @@ class ValidationTestCase(unittest.TestCase):
           self._logger.severe('WLSDPLY-20000', self._program_name, ve.getLocalizedMessage(), error=ve,
                         class_name=self._class_name, method_name=_method_name)
 
-        # assert the validate filter made modications and was persisted
+        # assert the validate filter made modification and was persisted
         self.assertEquals('gumby1234', model_dictionary['domainInfo']['AdminPassword'], "Expected validate filter to have changed AdminPassword to 'gumby1234'")
 
     def deleteFile(self, path):

--- a/core/src/test/python/validation_test.py
+++ b/core/src/test/python/validation_test.py
@@ -207,7 +207,7 @@ class ValidationTestCase(unittest.TestCase):
           self._logger.severe('WLSDPLY-20000', self._program_name, ve.getLocalizedMessage(), error=ve,
                         class_name=self._class_name, method_name=_method_name)
 
-        # assert the validate filter made modification and was persisted
+        # assert the validate filter made modications and was persisted
         self.assertEquals('gumby1234', model_dictionary['domainInfo']['AdminPassword'], "Expected validate filter to have changed AdminPassword to 'gumby1234'")
 
     def deleteFile(self, path):

--- a/core/src/test/python/wlsdeploy/util/cla_helper_test.py
+++ b/core/src/test/python/wlsdeploy/util/cla_helper_test.py
@@ -183,7 +183,7 @@ class ClaHelperTest(unittest.TestCase):
         # Load model and invoke filter
         model_dictionary = cla_helper.load_model('validateModel', model_context, aliases, "validate", WlstModes.OFFLINE)
 
-        # assert the validate filter made modications and was persisted
+        # assert the validate filter made modifications and was persisted
         self.assertEquals('gumby1234', model_dictionary['domainInfo']['AdminPassword'], "Expected validate filter to have changed AdminPassword to 'gumby1234'")
 
         # check that a single server exists in the result, and its attributes were merged correctly

--- a/core/src/test/python/wlsdeploy/util/cla_helper_test.py
+++ b/core/src/test/python/wlsdeploy/util/cla_helper_test.py
@@ -183,7 +183,7 @@ class ClaHelperTest(unittest.TestCase):
         # Load model and invoke filter
         model_dictionary = cla_helper.load_model('validateModel', model_context, aliases, "validate", WlstModes.OFFLINE)
 
-        # assert the validate filter made modifications and was persisted
+        # assert the validate filter made modications and was persisted
         self.assertEquals('gumby1234', model_dictionary['domainInfo']['AdminPassword'], "Expected validate filter to have changed AdminPassword to 'gumby1234'")
 
         # check that a single server exists in the result, and its attributes were merged correctly

--- a/documentation/1.9/content/concepts/model.md
+++ b/documentation/1.9/content/concepts/model.md
@@ -22,7 +22,7 @@ The metadata model (or model, for short) is a version-independent description of
 
 The model structure, and its folder and attribute names, are based on the WLST 12.2.1.3 offline structure and names with redundant folders removed to keep the model simple.  For example, the WLST path to the URL for a JDBC data source is `/JDBCSystemResource/<data-source-name>/JdbcResource/<data-source-name>/JDBCDriverParams/NO_NAME_0/URL`.  In the model, it is `resources:/JDBCSystemResource/<data-source-name>/JdbcResource/JDBCDriverParams/URL` (where `resources` is the top-level model section where all WebLogic Server resources/services are described).
 
-The model is written in YAML (or optionally, JSON).  The YAML parser, built into the underlying framework, is both strict with regard to the specification and supports only the subset of YAML needed to describe WebLogic Server artifacts.  For example, YAML does not support tabs as indent characters so the parser will generate parse errors if the model file contains leading tabs used for indention purposes.  In general, names and values can be specified without quotes except when the content contains one of the restricted characters; in which case, the content must be enclosed in either single or double quotes.  The restricted characters are:
+The model is written in YAML (or optionally, JSON).  The YAML parser, built into the underlying framework, is both strict with regard to the specification and supports only the subset of YAML needed to describe WebLogic Server artifacts.  For example, YAML does not support tabs as indent characters so the parser will generate parse errors if the model file contains leading tabs used for indentation purposes.  In general, names and values can be specified without quotes except when the content contains one of the restricted characters; in which case, the content must be enclosed in either single or double quotes.  The restricted characters are:
 
 - comma
 - colon
@@ -41,7 +41,7 @@ The model is written in YAML (or optionally, JSON).  The YAML parser, built into
 - curly braces
 - back quote
 
-All assignment statements must have one or more spaces between the colon and the value.  All comments must have a space after the pound sign (also known as hash) to be considered a comment.  YAML doesn't allow comments in all locations.  While the YAML parser used by the framework does not try to enforce these restrictions, it is likely that putting comments in some locations may cause parse errors since YAML is a difficult language to parse due to its complex indention rules.
+All assignment statements must have one or more spaces between the colon and the value.  All comments must have a space after the pound sign (also known as hash) to be considered a comment.  YAML doesn't allow comments in all locations.  While the YAML parser used by the framework does not try to enforce these restrictions, it is likely that putting comments in some locations may cause parse errors since YAML is a difficult language to parse due to its complex indentation rules.
 
 
 ### Top-level model sections

--- a/documentation/1.9/content/concepts/model.md
+++ b/documentation/1.9/content/concepts/model.md
@@ -22,7 +22,7 @@ The metadata model (or model, for short) is a version-independent description of
 
 The model structure, and its folder and attribute names, are based on the WLST 12.2.1.3 offline structure and names with redundant folders removed to keep the model simple.  For example, the WLST path to the URL for a JDBC data source is `/JDBCSystemResource/<data-source-name>/JdbcResource/<data-source-name>/JDBCDriverParams/NO_NAME_0/URL`.  In the model, it is `resources:/JDBCSystemResource/<data-source-name>/JdbcResource/JDBCDriverParams/URL` (where `resources` is the top-level model section where all WebLogic Server resources/services are described).
 
-The model is written in YAML (or optionally, JSON).  The YAML parser, built into the underlying framework, is both strict with regard to the specification and supports only the subset of YAML needed to describe WebLogic Server artifacts.  For example, YAML does not support tabs as indent characters so the parser will generate parse errors if the model file contains leading tabs used for indentation purposes.  In general, names and values can be specified without quotes except when the content contains one of the restricted characters; in which case, the content must be enclosed in either single or double quotes.  The restricted characters are:
+The model is written in YAML (or optionally, JSON).  The YAML parser, built into the underlying framework, is both strict with regard to the specification and supports only the subset of YAML needed to describe WebLogic Server artifacts.  For example, YAML does not support tabs as indent characters so the parser will generate parse errors if the model file contains leading tabs used for indention purposes.  In general, names and values can be specified without quotes except when the content contains one of the restricted characters; in which case, the content must be enclosed in either single or double quotes.  The restricted characters are:
 
 - comma
 - colon
@@ -41,7 +41,7 @@ The model is written in YAML (or optionally, JSON).  The YAML parser, built into
 - curly braces
 - back quote
 
-All assignment statements must have one or more spaces between the colon and the value.  All comments must have a space after the pound sign (also known as hash) to be considered a comment.  YAML doesn't allow comments in all locations.  While the YAML parser used by the framework does not try to enforce these restrictions, it is likely that putting comments in some locations may cause parse errors since YAML is a difficult language to parse due to its complex indentation rules.
+All assignment statements must have one or more spaces between the colon and the value.  All comments must have a space after the pound sign (also known as hash) to be considered a comment.  YAML doesn't allow comments in all locations.  While the YAML parser used by the framework does not try to enforce these restrictions, it is likely that putting comments in some locations may cause parse errors since YAML is a difficult language to parse due to its complex indention rules.
 
 
 ### Top-level model sections

--- a/documentation/1.9/themes/hugo-theme-learn/static/js/learn.js
+++ b/documentation/1.9/themes/hugo-theme-learn/static/js/learn.js
@@ -52,7 +52,7 @@ function switchTab(tabGroup, tabId) {
     targetTabItems = jQuery("[data-tab-group='"+tabGroup+"'][data-tab-item='"+tabId+"']");
 
     // if event is undefined then switchTab was called from restoreTabSelection
-    // so it's not a button event and we don't need to safe the selction or
+    // so it's not a button event and we don't need to safe the selection or
     // prevent page jump
     var isButtonEvent = event != undefined;
 

--- a/documentation/1.9/themes/hugo-theme-learn/static/js/learn.js
+++ b/documentation/1.9/themes/hugo-theme-learn/static/js/learn.js
@@ -52,7 +52,7 @@ function switchTab(tabGroup, tabId) {
     targetTabItems = jQuery("[data-tab-group='"+tabGroup+"'][data-tab-item='"+tabId+"']");
 
     // if event is undefined then switchTab was called from restoreTabSelection
-    // so it's not a button event and we don't need to safe the selection or
+    // so it's not a button event and we don't need to safe the selction or
     // prevent page jump
     var isButtonEvent = event != undefined;
 


### PR DESCRIPTION
fix typo grammar spelling, and replace with to correct word with reference from [Merriam webster](https://www.merriam-webster.com/)