### PR TITLE
Wdt 575 - compareModel needs to return all original unchanged attributes for app/lib

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
+++ b/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
@@ -444,15 +444,6 @@ class ModelComparer(object):
                     key_value = dictionary_utils.get_element(current_folder, key)
                     if key_value is not None:
                         change_folder[key] = key_value
-            # if change_folder and (SOURCE_PATH not in change_folder):
-            #     print 'i ma here'
-            #     # if SourcePath not present, past and current folder had matching values
-            #     source_path = dictionary_utils.get_element(current_folder, SOURCE_PATH)
-            #     if source_path is not None:
-            #         comment = exception_helper.get_message('WLSDPLY-05714', SOURCE_PATH)
-            #         _add_comment(comment, change_folder)
-            #         change_folder[SOURCE_PATH] = source_path
-
 
 def _add_comment(comment, dictionary):
     """

--- a/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
+++ b/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
@@ -14,8 +14,6 @@ from wlsdeploy.aliases.location_context import LocationContext
 from wlsdeploy.aliases.model_constants import APPLICATION
 from wlsdeploy.aliases.model_constants import KUBERNETES
 from wlsdeploy.aliases.model_constants import LIBRARY
-from wlsdeploy.aliases.model_constants import SOURCE_PATH
-from wlsdeploy.exception import exception_helper
 from wlsdeploy.json.json_translator import COMMENT_MATCH
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.util import dictionary_utils
@@ -428,21 +426,14 @@ class ModelComparer(object):
         if location is not None:
             folder_path = location.get_model_folders()
 
-        app_lib_attributes = [
-            'AltDescriptorDir', 'AltDescriptorPath', 'AltWLSDescriptorPath', 'ApplicationIdentifier',
-            'ApplicationName',  'CacheInAppDirectory',  'CompatibilityName', 'DeploymentOrder',
-            'DeploymentPrincipalName', 'InstallDir', 'ModuleType', 'Notes',
-            'ParallelDeployModules', 'PlanDir', 'PlanStagingMode', 'SecurityDDModel',
-            'SourcePath', 'StagingMode', 'Target', 'ValidateDDSecurityData', 'VersionIdentifier'
-        ]
-
         # Application and Library should include SourcePath if they have any other elements
         if (len(folder_path) == 1) and (folder_path[0] in self.SOURCE_PATH_FOLDERS):
             # Handling Application and Library changes but keep the original that has not been changed
             if change_folder:
-                for key in app_lib_attributes:
+                orig_keys = dictionary_utils.get_dictionary_attributes(past_folder)
+                for key in orig_keys:
                     if key not in change_folder.keys():
-                        key_value = dictionary_utils.get_element(current_folder, key)
+                        key_value = dictionary_utils.get_element(past_folder, key)
                         if key_value is not None:
                             change_folder[key] = key_value
 

--- a/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
+++ b/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
@@ -428,15 +428,30 @@ class ModelComparer(object):
         if location is not None:
             folder_path = location.get_model_folders()
 
+        app_lib_attributes = [
+            'AltDescriptorDir', 'AltDescriptorPath', 'AltWLSDescriptorPath', 'ApplicationIdentifier',
+            'ApplicationName',  'CacheInAppDirectory',  'CompatibilityName', 'DeploymentOrder',
+            'DeploymentPrincipalName', 'InstallDir', 'ModuleType', 'Notes',
+            'ParallelDeployModules', 'PlanDir', 'PlanStagingMode', 'SecurityDDModel',
+            'SourcePath', 'StagingMode', 'Target', 'ValidateDDSecurityData', 'VersionIdentifier'
+        ]
+
         # Application and Library should include SourcePath if they have any other elements
         if (len(folder_path) == 1) and (folder_path[0] in self.SOURCE_PATH_FOLDERS):
-            if change_folder and (SOURCE_PATH not in change_folder):
-                # if SourcePath not present, past and current folder had matching values
-                source_path = dictionary_utils.get_element(current_folder, SOURCE_PATH)
-                if source_path is not None:
-                    comment = exception_helper.get_message('WLSDPLY-05714', SOURCE_PATH)
-                    _add_comment(comment, change_folder)
-                    change_folder[SOURCE_PATH] = source_path
+            # Handling Application and Library changes but keep the original that has not been changed
+            for key in app_lib_attributes:
+                if key not in change_folder.keys():
+                    key_value = dictionary_utils.get_element(current_folder, key)
+                    if key_value is not None:
+                        change_folder[key] = key_value
+            # if change_folder and (SOURCE_PATH not in change_folder):
+            #     print 'i ma here'
+            #     # if SourcePath not present, past and current folder had matching values
+            #     source_path = dictionary_utils.get_element(current_folder, SOURCE_PATH)
+            #     if source_path is not None:
+            #         comment = exception_helper.get_message('WLSDPLY-05714', SOURCE_PATH)
+            #         _add_comment(comment, change_folder)
+            #         change_folder[SOURCE_PATH] = source_path
 
 
 def _add_comment(comment, dictionary):

--- a/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
+++ b/core/src/main/python/wlsdeploy/tool/compare/model_comparer.py
@@ -439,11 +439,12 @@ class ModelComparer(object):
         # Application and Library should include SourcePath if they have any other elements
         if (len(folder_path) == 1) and (folder_path[0] in self.SOURCE_PATH_FOLDERS):
             # Handling Application and Library changes but keep the original that has not been changed
-            for key in app_lib_attributes:
-                if key not in change_folder.keys():
-                    key_value = dictionary_utils.get_element(current_folder, key)
-                    if key_value is not None:
-                        change_folder[key] = key_value
+            if change_folder:
+                for key in app_lib_attributes:
+                    if key not in change_folder.keys():
+                        key_value = dictionary_utils.get_element(current_folder, key)
+                        if key_value is not None:
+                            change_folder[key] = key_value
 
 def _add_comment(comment, dictionary):
     """

--- a/core/src/test/python/compare_model_test.py
+++ b/core/src/test/python/compare_model_test.py
@@ -109,7 +109,7 @@ class CompareModelTestCase(unittest.TestCase):
             self.assertEqual(model_dictionary['resources'].has_key('SingletonService'), True)
             self.assertEqual(model_dictionary['appDeployments']['Library'].has_key('!jax-rs#2.0@2.22.4.0'), True)
             self.assertEqual(model_dictionary['appDeployments']['Library'].has_key('!jsf#1.2@1.2.9.0'), True)
-            self.assertEqual(model_dictionary['appDeployments']['Application']['myear'].has_key('ModuleType'), False)
+            self.assertEqual(model_dictionary['appDeployments']['Application']['myear'].has_key('ModuleType'), True)
 
         except (CompareException, PyWLSTException), te:
             return_code = 2


### PR DESCRIPTION
We need to return all original unchanged attributes for Application and Library also,  the reason is the delta can be used for updating the domain which can triggers undeploy and deploy again,  without the original values, then after the undeploy, the model used will not have enough information for deploy again.