### PR TITLE
Add empty model folders to domain

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/creator.py
@@ -117,7 +117,11 @@ class Creator(object):
 
         self.logger.entering(type_name, str(base_location), log_created,
                              class_name=self.__class_name, method_name=_method_name)
-        if model_nodes is None or len(model_nodes) == 0 or not self._is_type_valid(base_location, type_name):
+
+        if model_nodes is None or len(model_nodes) == 0:
+           self.logger.fine('WLSDPLY-12568', type_name, class_name=self.__class_name, method_name=_method_name)
+
+        if not self._is_type_valid(base_location, type_name):
             return
 
         location = LocationContext(base_location).append_location(type_name)

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1327,6 +1327,7 @@ WLSDPLY-12564=Unable to retrieve database connection string, please make sure it
 WLSDPLY-12565=The archive file was not provided so there are no custom files to extract
 WLSDPLY-12566=Installing {0} user custom files to domain home {1}
 WLSDPLY-12567=The archive file {0} contains no user custom files to install
+WLSDPLY-12568=Creating empty folder {0}. Folder contains no attributes or sub-folders.
 
 # domain_typedef.py
 WLSDPLY-12300={0} got the domain type {1} but the domain type definition file {2} was not valid: {3}


### PR DESCRIPTION
Fixes #990 

If a empty singleton folder (no attributes or subfolders) is presented in the model, add that folder to the domain.