### PR TITLE
add support for setting topologyProfile in typedef files

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -90,6 +90,7 @@ from wlsdeploy.tool.util.library_helper import LibraryHelper
 from wlsdeploy.tool.util.rcu_helper import RCUHelper
 from wlsdeploy.tool.util.target_helper import TargetHelper
 from wlsdeploy.tool.util.targeting_types import TargetingType
+from wlsdeploy.tool.util.topology_profiles import TopologyProfile
 from wlsdeploy.tool.util.topology_helper import TopologyHelper
 from wlsdeploy.util import dictionary_utils
 from wlsdeploy.util import model
@@ -506,6 +507,12 @@ class DomainCreator(Creator):
         :raises: CreateException: if an error occurs
         """
         _method_name = '__create_base_domain_with_select_template'
+        
+        topology_profile_text = self._domain_typedef.get_topology_profile()
+        if topology_profile_text in TopologyProfile:
+            self.logger.info('WLSDPLY-12569', topology_profile_text,
+                         class_name=self.__class_name, method_name=_method_name)
+            self.wlst_helper.set_topology_profile(topology_profile_text)
 
         self.logger.entering(domain_home, class_name=self.__class_name, method_name=_method_name)
         base_template = self._domain_typedef.get_base_template()

--- a/core/src/main/python/wlsdeploy/tool/util/topology_profiles.py
+++ b/core/src/main/python/wlsdeploy/tool/util/topology_profiles.py
@@ -1,0 +1,10 @@
+"""
+Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+"""
+from wlsdeploy.util.enum import Enum
+
+TopologyProfile = Enum([
+    'Compact',
+    'Expanded'
+])

--- a/core/src/main/python/wlsdeploy/tool/util/wlst_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/wlst_helper.py
@@ -638,6 +638,25 @@ class WlstHelper(object):
             self.__logger.throwing(class_name=self.__class_name, method_name=_method_name, error=pwe)
             raise pwe
         self.__logger.exiting(class_name=self.__class_name, method_name=_method_name)
+        
+    def set_topology_profile(self, profile):
+        """
+        Set the topology profile used by domain templates.  This would be
+        either Compact or Expanded
+        :param profile: Compact or Expanded
+        :raises: Exception for the specified tool type: if a WLST error occurs
+        """
+        _method_name = 'set_topology_profile'
+        self.__logger.entering(profile, class_name=self.__class_name, method_name=_method_name)
+        try:
+            self.__load_global('setTopologyProfile')(profile)
+        except offlineWLSTException, e:
+            pwe = exception_helper.create_exception(self.__exception_type, 'WLSDPLY-00128', profile,
+                                                    e.getLocalizedMessage(), error=e)
+            self.__logger.throwing(class_name=self.__class_name, method_name=_method_name, error=pwe)
+            raise pwe
+        self.__logger.exiting(class_name=self.__class_name, method_name=_method_name)
+
 
     def select_template(self, template):
         """

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -110,6 +110,7 @@ WLSDPLY-00124=Entering is_set({0}) method
 WLSDPLY-00125=is_set({0}) in {1} mode failed: {2}
 WLSDPLY-00126=Exiting is_set({0}) method
 WLSDPLY-00127=Unable to load the DomainRuntimeService from the WLST globals : {0}
+WLSDPLY-00128=setTopologyProfile({0}) failed : {1}
 
 
 ###############################################################################
@@ -1328,6 +1329,7 @@ WLSDPLY-12565=The archive file was not provided so there are no custom files to 
 WLSDPLY-12566=Installing {0} user custom files to domain home {1}
 WLSDPLY-12567=The archive file {0} contains no user custom files to install
 WLSDPLY-12568=Creating empty folder {0}. Folder contains no attributes or sub-folders.
+WLSDPLY-12569=Setting topology profile to {0}
 
 # domain_typedef.py
 WLSDPLY-12300={0} got the domain type {1} but the domain type definition file {2} was not valid: {3}
@@ -1346,6 +1348,8 @@ WLSDPLY-12310=Version {0} returned from the domain home
 WLSDPLY-12311=Targeting type "{0}" in type definition file {1} is not allowed for WebLogic version {2}
 WLSDPLY-12312=Targeting type "{0}" in type definition file {1} is not valid
 WLSDPLY-12313=Domain type {0} is not supported for WebLogic version {1}
+WLSDPLY-12314=Topology Profile "{0}" in type definition file {1} is not allowed for WebLogic version {2}
+WLSDPLY-12315=Topology Profile "{0}" in type definition file {1} is not valid
 
 # create.py
 WLSDPLY-12400={0} got the JAVA_HOME {1} from the environment variable but it was not a valid location: {2}


### PR DESCRIPTION
Issue #1005 
allows topologyProfile to be set in a typedef file.  eg

```
{
    "name": "OSB_COMPACT",
    "description": "OSB compact domain definitions",
    "topologyProfile": "Compact",
    "versions": {
        "12.2.1.4": "OSB_12CR2",
        "14.1":     "NOT_SUPPORTED"
    },
    "definitions": {
        "OSB_12CR2": {
            "baseTemplate": "Basic WebLogic Server Domain",
            "extensionTemplates": [
                "Oracle Service Bus",
                "Oracle Enterprise Scheduler Service Basic",
                "Oracle Enterprise Manager Plugin for ESS"
            ],
            "rcuSchemas": [ "WLS", "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "UCSUMS", "SOAINFRA", "ESS" ]
        }
    }
}

```