### PR TITLE
decrypt encyrpted security user password before encrypting for security

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -702,7 +702,7 @@ class DomainCreator(Creator):
         self.logger.entering(class_name=self.__class_name, method_name=_method_name)
         security_folder = dictionary_utils.get_dictionary_element(self._topology, SECURITY)
         if security_folder is not None:
-            helper = DefaultAuthenticatorHelper(self.model_context, ExceptionType.CREATE)
+            helper = DefaultAuthenticatorHelper(self.model_context, self.aliases, ExceptionType.CREATE)
             helper.create_default_init_file(security_folder)
         self.logger.exiting(class_name=self.__class_name, method_name=_method_name)
 

--- a/core/src/main/python/wlsdeploy/tool/util/default_authenticator_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/default_authenticator_helper.py
@@ -43,8 +43,9 @@ class DefaultAuthenticatorHelper(object):
     """
     _class_name = 'DefaultAuthenticatorHelper'
 
-    def __init__(self, model_context, exception_type):
+    def __init__(self, model_context, aliases, exception_type):
         self._model_context = model_context
+        self._aliases = aliases
         self._exception_type = exception_type
         self._logger = PlatformLogger('wlsdeploy.tool.util')
         self._weblogic_helper = WebLogicHelper(self._logger)
@@ -135,6 +136,7 @@ class DefaultAuthenticatorHelper(object):
         hash_entry[HASH_DESCRIPTION] = description
         groups = dictionary_utils.get_element(group_attributes, GROUP_MEMBER_OF)
         password = self._get_required_attribute(user_mapping_section, PASSWORD, USER, name)
+        password = self._aliases.decrypt_password(password)
         password_encoded = self._encode_password(name, password)
         hash_entry[HASH_USER_PASSWORD] = password_encoded
         group_list = []
@@ -177,6 +179,7 @@ class DefaultAuthenticatorHelper(object):
         _method_name = '_get_required_attribute'
 
         result = dictionary_utils.get_element(dictionary, name)
+
         if result is None:
             pwe = exception_helper.create_exception(self._exception_type, '-01791', name, mapping_type,
                                                     mapping_name)


### PR DESCRIPTION
Fixes Issue #1010 

Security user password that was encrypted using the encryption tool was not decrypted before being decrypted for the security files.