### PR TITLE
Create validation mode for WKTUI

### DIFF
--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -40,6 +40,7 @@ from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.compare.model_comparer import ModelComparer
 from wlsdeploy.tool.validate.validator import Validator
 from wlsdeploy.util import cla_helper
+from wlsdeploy.util import validate_configuration
 from wlsdeploy.util import variables
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.model_context import ModelContext
@@ -111,7 +112,7 @@ class ModelFileDiffer:
                 model_file_name = self.past_dict_file
                 FileToPython(model_file_name, True).parse()
 
-            self.model_context.set_validation_method('lax')
+            self.model_context.set_validation_method(validate_configuration.LAX_METHOD)
 
             aliases = Aliases(model_context=self.model_context, wlst_mode=WlstModes.OFFLINE,
                               exception_type=ExceptionType.COMPARE)

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -76,9 +76,7 @@ def __process_args(args):
     cla_util = CommandLineArgUtil(_program_name, __required_arguments, __optional_arguments)
     argument_map = cla_util.process_args(args, trailing_arg_count=2)
 
-    model_context = ModelContext(_program_name, argument_map)
-    model_context.set_ignore_missing_archive_entries(True)
-    return model_context
+    return ModelContext(_program_name, argument_map)
 
 
 class ModelFileDiffer:
@@ -112,6 +110,7 @@ class ModelFileDiffer:
                 model_file_name = self.past_dict_file
                 FileToPython(model_file_name, True).parse()
 
+            # allow unresolved tokens and archive entries
             self.model_context.set_validation_method(validate_configuration.LAX_METHOD)
 
             aliases = Aliases(model_context=self.model_context, wlst_mode=WlstModes.OFFLINE,

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -434,11 +434,6 @@ def __check_and_customize_model(model, model_context, aliases, credential_inject
     # target config always present in model context, default config if not declared
     target_configuration = model_context.get_target_configuration()
 
-    # if target config declared, use the validation method it contains (lax, etc.)
-    if model_context.is_targetted_config():
-        validation_method = target_configuration.get_validation_method()
-        model_context.set_validation_method(validation_method)
-
     credential_cache = None
     if credential_injector is not None:
         # filter variables or secrets that are no longer in the model

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 The entry point for the discoverDomain tool.

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -68,10 +68,9 @@ def __process_args(args):
     cla_helper.validate_variable_file_exists(_program_name, argument_map)
     cla_helper.process_encryption_args(argument_map)
 
+    # allow unresolved tokens and archive entries
     argument_map[CommandLineArgUtil.VALIDATION_METHOD] = validate_configuration.LAX_METHOD
-    model_context = model_context_helper.create_context(_program_name, argument_map)
-    model_context.set_ignore_missing_archive_entries(True)
-    return model_context
+    return model_context_helper.create_context(_program_name, argument_map)
 
 
 def __extract_resource(model, model_context):

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -20,6 +20,7 @@ from wlsdeploy.tool.extract.domain_resource_extractor import DomainResourceExtra
 from wlsdeploy.tool.util import model_context_helper
 from wlsdeploy.util import cla_helper
 from wlsdeploy.util import tool_exit
+from wlsdeploy.util import validate_configuration
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.cla_utils import TOOL_TYPE_EXTRACT
 from wlsdeploy.util.model import Model
@@ -67,7 +68,7 @@ def __process_args(args):
     cla_helper.validate_variable_file_exists(_program_name, argument_map)
     cla_helper.process_encryption_args(argument_map)
 
-    argument_map[CommandLineArgUtil.VALIDATION_METHOD] = CommandLineArgUtil.LAX_VALIDATION_METHOD
+    argument_map[CommandLineArgUtil.VALIDATION_METHOD] = validate_configuration.LAX_METHOD
     model_context = model_context_helper.create_context(_program_name, argument_map)
     model_context.set_ignore_missing_archive_entries(True)
     return model_context

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 The entry point for the extractDomainResource tool.

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -55,7 +55,8 @@ def __process_args(args):
     target_configuration_helper.process_target_arguments(argument_map)
 
     model_context = ModelContext(_program_name, argument_map)
-    model_context.set_ignore_missing_archive_entries(True)
+    # override this check, since archive file is not supplied here
+    model_context.get_validate_configuration().set_allow_unresolved_archive_references(True)
     return model_context
 
 

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 The WLS Deploy tooling entry point for the validateModel tool.

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -28,6 +28,7 @@ from wlsdeploy.tool.validate.validator import Validator
 from wlsdeploy.util import cla_helper
 from wlsdeploy.util import dictionary_utils
 from wlsdeploy.util import tool_exit
+from wlsdeploy.util import validate_configuration
 from wlsdeploy.util import variables
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
@@ -84,7 +85,7 @@ def __process_model_args(argument_map):
     except CLAException, ce:
         # in lax validation mode, if no model is found, log at INFO and exit
         method = dictionary_utils.get_element(argument_map, CommandLineArgUtil.VALIDATION_METHOD)
-        if method == CommandLineArgUtil.LAX_VALIDATION_METHOD:
+        if method == validate_configuration.LAX_METHOD:
             __logger.info('WLSDPLY-20032', _program_name, class_name=_class_name, method_name=_method_name)
             model_context = model_context_helper.create_exit_context(_program_name)
             tool_exit.end(model_context, CommandLineArgUtil.PROG_OK_EXIT_CODE)

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -132,8 +132,6 @@ def __perform_model_file_validation(model_file_name, model_context):
                                                         model_context.get_archive_file_name())
 
     except (TranslateException, VariableException), te:
-        __logger.severe('WLSDPLY-20009', _program_name, model_file_name, te.getLocalizedMessage(),
-                        error=te, class_name=_class_name, method_name=_method_name)
         ex = exception_helper.create_validate_exception(te.getLocalizedMessage(), error=te)
         __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
         raise ex
@@ -168,9 +166,9 @@ def main(args):
         model_context = model_context_helper.create_exit_context(_program_name)
         tool_exit.end(model_context, exit_code)
 
-    try:
-        model_file_name = model_context.get_model_file()
+    model_file_name = model_context.get_model_file()
 
+    try:
         if model_file_name is not None:
             __perform_model_file_validation(model_file_name, model_context)
 
@@ -183,10 +181,9 @@ def main(args):
                     exit_code = CommandLineArgUtil.PROG_WARNING_EXIT_CODE
 
     except ValidateException, ve:
+        exit_code = CommandLineArgUtil.PROG_ERROR_EXIT_CODE
         __logger.severe('WLSDPLY-20000', _program_name, ve.getLocalizedMessage(), error=ve,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        sys.exit(CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
 
     cla_helper.clean_up_temp_files()
 

--- a/core/src/main/python/wlsdeploy/tool/prepare/model_preparer.py
+++ b/core/src/main/python/wlsdeploy/tool/prepare/model_preparer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 import os

--- a/core/src/main/python/wlsdeploy/tool/prepare/model_preparer.py
+++ b/core/src/main/python/wlsdeploy/tool/prepare/model_preparer.py
@@ -199,8 +199,8 @@ class ModelPreparer:
         credential_caches = self.credential_injector.get_variable_cache()
         for key in credential_caches:
             if variables.is_variable_string(credential_caches[key]):
-                credential_caches[key] = variables._substitute(credential_caches[key],
-                                                               original_variables, self.model_context)
+                credential_caches[key] = variables.substitute_value(credential_caches[key],
+                                                                    original_variables, self.model_context)
 
     def _apply_filter_and_inject_variable(self, model_dict, model_context):
         """

--- a/core/src/main/python/wlsdeploy/tool/validate/kubernetes_validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/kubernetes_validator.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 

--- a/core/src/main/python/wlsdeploy/tool/validate/kubernetes_validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/kubernetes_validator.py
@@ -5,8 +5,8 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 from wlsdeploy.aliases.model_constants import KUBERNETES
 from wlsdeploy.exception.expection_types import ExceptionType
+from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.extract import wko_schema_helper
-from wlsdeploy.tool.validate.validator_logger import ValidatorLogger
 from wlsdeploy.util import dictionary_utils
 
 
@@ -15,7 +15,7 @@ class KubernetesValidator(object):
     Class for validating the kubernetes section of a model file
     """
     _class_name = 'KubernetesValidator'
-    _logger = ValidatorLogger('wlsdeploy.validate')
+    _logger = PlatformLogger('wlsdeploy.validate')
 
     def __init__(self, model_context):
         self._model_context = model_context

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -822,21 +822,21 @@ class Validator(object):
         #     token to make that explicit in the model.
         #
         if WLSDeployArchive.isPathIntoArchive(path):
+            # If the validate configuration allows unresolved archive references,
+            # log INFO messages identifying missing entries, and allow validation to succeed.
+            # Otherwise, log SEVERE messages that will cause validation to fail.
+            log_method = self._logger.severe
+            if self._validate_configuration.allow_unresolved_archive_references():
+                log_method = _info_logger.info
+
             if self._archive_helper is not None:
                 archive_has_file = self._archive_helper.contains_file_or_path(path)
                 if not archive_has_file:
-                    self._logger.severe('WLSDPLY-05024', attribute_name, model_folder_path, path,
-                                        self._archive_file_name, class_name=_class_name, method_name=_method_name)
+                    log_method('WLSDPLY-05024', attribute_name, model_folder_path, path,
+                               self._archive_file_name, class_name=_class_name, method_name=_method_name)
             else:
-                # If the validate configuration allows unresolved archive references,
-                # log an INFO message identifying missing entries, and allow validation to succeed.
-                # Otherwise, log a SEVERE message that will cause validation to fail.
-                if self._validate_configuration.allow_unresolved_archive_references():
-                    _info_logger.info('WLSDPLY-05025', attribute_name, model_folder_path, path,
-                                      class_name=_class_name, method_name=_method_name)
-                else:
-                    self._logger.severe('WLSDPLY-05025', attribute_name, model_folder_path, path,
-                                        class_name=_class_name, method_name=_method_name)
+                log_method('WLSDPLY-05025', attribute_name, model_folder_path, path,
+                           class_name=_class_name, method_name=_method_name)
         else:
             tokens = validation_utils.extract_path_tokens(path)
             self._logger.finest('tokens={0}', str(tokens), class_name=_class_name, method_name=_method_name)

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -762,7 +762,7 @@ class Validator(object):
                     # assuming that the value is not None
 
                     logger_method = self._logger.warning
-                    if self._model_context.get_validate_configuration().allow_missing_variables():
+                    if self._model_context.get_validate_configuration().allow_unresolved_variable_tokens():
                         logger_method = self._logger.info
 
                     variables_file_name = self._model_context.get_variable_file()

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os
@@ -761,9 +761,9 @@ class Validator(object):
                     # FIXME(mwooten) - the cla_utils should be fixing all windows paths to use forward slashes already
                     # assuming that the value is not None
 
-                    logger_method = self._logger.info
-                    if self._model_context.get_validation_method() == 'strict':
-                        logger_method = self._logger.warning
+                    logger_method = self._logger.warning
+                    if self._model_context.get_validate_configuration().allow_missing_variables():
+                        logger_method = self._logger.info
 
                     variables_file_name = self._model_context.get_variable_file()
                     if variables_file_name is None:
@@ -937,14 +937,9 @@ class Validator(object):
     def _log_version_invalid(self, message, method_name):
         """
         Log a message indicating that an attribute is not valid for the current WLS version and WLST mode.
-        Log INFO if validation method is "lax", otherwise log WARNING.
+        Log INFO or WARNING, depending on validation mode.
         """
-        if self._model_context.is_targetted_config():
-            validation_method = self._model_context.get_target_configuration().get_validation_method()
-        else:
-            validation_method = self._model_context.get_validation_method()
-
         log_method = self._logger.warning
-        if validation_method == 'lax':
+        if self._model_context.get_validate_configuration().allow_version_invalid_attributes():
             log_method = _info_logger.info
         log_method('WLSDPLY-05027', message, class_name=_class_name, method_name=method_name)

--- a/core/src/main/python/wlsdeploy/util/cla_utils.py
+++ b/core/src/main/python/wlsdeploy/util/cla_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 Module that handles command-line argument parsing and common validation.

--- a/core/src/main/python/wlsdeploy/util/cla_utils.py
+++ b/core/src/main/python/wlsdeploy/util/cla_utils.py
@@ -20,15 +20,17 @@ import oracle.weblogic.deploy.util.FileUtils as JFileUtils
 from wlsdeploy.exception import exception_helper
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.util import path_utils
+from wlsdeploy.util import validate_configuration
 from wlsdeploy.util.target_configuration import CREDENTIALS_METHOD
 from wlsdeploy.util.target_configuration import CREDENTIALS_METHODS
 from wlsdeploy.util.target_configuration import TargetConfiguration
+from wlsdeploy.util.target_configuration import VALIDATION_METHOD
+from wlsdeploy.util.validate_configuration import VALIDATION_METHODS
 
 # tool type may indicate variations in argument processing
 TOOL_TYPE_CREATE = "create"
 TOOL_TYPE_DEFAULT = "default"
 TOOL_TYPE_EXTRACT = "extract"
-
 
 
 class CommandLineArgUtil(object):
@@ -119,10 +121,6 @@ class CommandLineArgUtil(object):
 
     ARCHIVE_FILES_SEPARATOR = ','
     MODEL_FILES_SEPARATOR = ','
-
-    LAX_VALIDATION_METHOD = 'lax'
-    STRICT_VALIDATION_METHOD = 'strict'
-    VALIDATION_METHODS = [LAX_VALIDATION_METHOD, STRICT_VALIDATION_METHOD]
 
     HELP_EXIT_CODE                 = 100
     USAGE_ERROR_EXIT_CODE          = 99
@@ -844,8 +842,8 @@ class CommandLineArgUtil(object):
             ex.setExitCode(self.ARG_VALIDATION_ERROR_EXIT_CODE)
             self._logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
-        elif value not in self.VALIDATION_METHODS:
-            ex = exception_helper.create_cla_exception('WLSDPLY-20030', value, self.VALIDATION_METHODS)
+        elif value not in VALIDATION_METHODS:
+            ex = exception_helper.create_cla_exception('WLSDPLY-20030', value, VALIDATION_METHODS)
             ex.setExitCode(self.ARG_VALIDATION_ERROR_EXIT_CODE)
             self._logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
@@ -1163,8 +1161,11 @@ class CommandLineArgUtil(object):
                 config_dictionary = eval(file_handle.read())
                 target_configuration = TargetConfiguration(config_dictionary)
                 validation_method = target_configuration.get_validation_method()
-                if (validation_method is not None) and (validation_method not in self.VALIDATION_METHODS):
-                    ex = exception_helper.create_cla_exception('WLSDPLY-01645', target_configuration_file)
+                if (validation_method is not None) and \
+                        (validation_method not in validate_configuration.VALIDATION_METHODS):
+                    ex = exception_helper.create_cla_exception('WLSDPLY-01648', target_configuration_file,
+                                                               validation_method, VALIDATION_METHOD,
+                                                               ', '.join(validate_configuration.VALIDATION_METHODS))
                     ex.setExitCode(self.ARG_VALIDATION_ERROR_EXIT_CODE)
                     self._logger.throwing(ex, class_name=self._class_name, method_name=method_name)
                     raise ex

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -95,7 +95,6 @@ class ModelContext(object):
         self._rcu_db_user = self.DB_USER_DEFAULT
         self._discard_current_edit = False
         self._model_config = None
-        self._ignore_missing_archive_entries = False
 
         self._trailing_args = []
 
@@ -332,9 +331,7 @@ class ModelContext(object):
         if self._variable_properties_file is not None:
             arg_map[CommandLineArgUtil.VARIABLE_PROPERTIES_FILE_SWITCH] = self._variable_properties_file
 
-        model_context = ModelContext(self._program_name, arg_map)
-        model_context._ignore_missing_archive_entries = self._ignore_missing_archive_entries
-        return model_context
+        return ModelContext(self._program_name, arg_map)
 
     def get_model_config(self):
         """
@@ -723,20 +720,6 @@ class ModelContext(object):
         :return: the trailing argument
         """
         return self._trailing_args[index]
-
-    def get_ignore_missing_archive_entries(self):
-        """
-        Determine if the tool should ignore missing archive entries during validation.
-        :return: True if the tool should ignore missing entries
-        """
-        return self._ignore_missing_archive_entries
-
-    def set_ignore_missing_archive_entries(self, ignore):
-        """
-        Configure the tool to ignore missing archive entries during validation.
-        :param ignore: True if the tool should ignore missing entries, False otherwise
-        """
-        self._ignore_missing_archive_entries = ignore
 
     def is_wlst_online(self):
         """

--- a/core/src/main/python/wlsdeploy/util/target_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/target_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 

--- a/core/src/main/python/wlsdeploy/util/target_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/target_configuration.py
@@ -9,6 +9,9 @@ from wlsdeploy.util import dictionary_utils
 CREDENTIALS_METHOD = "credentials_method"
 CREDENTIALS_OUTPUT_METHOD = "credentials_output_method"
 
+# type for validation method
+VALIDATION_METHOD = "validation_method"
+
 # Overrides the Kubernetes secret name for the WebLogic admin user credential
 WLS_CREDENTIALS_NAME = "wls_credentials_name"
 
@@ -76,7 +79,7 @@ class TargetConfiguration(object):
         Return the validation method for this target environment.
         :return: the validation method, or None
         """
-        return dictionary_utils.get_element(self.config_dictionary, 'validation_method')
+        return dictionary_utils.get_element(self.config_dictionary, VALIDATION_METHOD)
 
     def get_model_filters(self):
         """

--- a/core/src/main/python/wlsdeploy/util/validate_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/validate_configuration.py
@@ -6,8 +6,9 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 # validation method keys
 STRICT_METHOD = "strict"
 LAX_METHOD = "lax"
+WKTUI_METHOD = "wktui"
 
-VALIDATION_METHODS = [STRICT_METHOD, LAX_METHOD]
+VALIDATION_METHODS = [STRICT_METHOD, LAX_METHOD, WKTUI_METHOD]
 
 
 class ValidateConfiguration(object):
@@ -24,52 +25,60 @@ class ValidateConfiguration(object):
         self._key = key
 
         # defaults are values for STRICT mode
-        self._allow_missing_environment_variables = False
-        self._allow_missing_file_variables = False
-        self._allow_missing_secrets = False
-        self._allow_missing_variables = False
+        self._allow_unresolved_environment_tokens = False
+        self._allow_unresolved_file_tokens = False
+        self._allow_unresolved_secret_tokens = False
+        self._allow_unresolved_variable_tokens = False
         self._allow_version_invalid_attributes = False
 
         if key == LAX_METHOD:
-            self._allow_missing_environment_variables = True
-            self._allow_missing_file_variables = True
-            self._allow_missing_secrets = True
-            self._allow_missing_variables = True
+            self._allow_unresolved_environment_tokens = True
+            self._allow_unresolved_file_tokens = True
+            self._allow_unresolved_secret_tokens = True
+            self._allow_unresolved_variable_tokens = True
             self._allow_version_invalid_attributes = True
 
-    def allow_missing_environment_variables(self):
-        """
-        Returns True if missing environment variables should be overlooked during validation.
-        Callers may reduce some WARNING or SEVERE messages to INFO.
-        """
-        return self._allow_missing_environment_variables
+        elif key == WKTUI_METHOD:
+            # similar to LAX_METHOD, but validate variable tokens.
+            # secrets, files and environment variables may not be present in the UI environment.
+            self._allow_unresolved_environment_tokens = True
+            self._allow_unresolved_file_tokens = True
+            self._allow_unresolved_secret_tokens = True
+            self._allow_version_invalid_attributes = True
 
-    def allow_missing_file_variables(self):
+    def allow_unresolved_environment_tokens(self):
         """
-        Returns True if missing file variables should be overlooked during validation.
-        This includes empty variable files.
-        Callers may reduce some WARNING or SEVERE messages to INFO.
+        Returns True if unresolved environment tokens should be allowed during validation.
+        Callers may reduce some message levels to INFO, or avoid throwing some exceptions.
         """
-        return self._allow_missing_file_variables
+        return self._allow_unresolved_environment_tokens
 
-    def allow_missing_variables(self):
+    def allow_unresolved_file_tokens(self):
         """
-        Returns True if missing variables should be overlooked during validation.
-        Callers may reduce some WARNING or SEVERE messages to INFO.
+        Returns True if unresolved file tokens should be allowed during validation.
+        This includes references to missing or empty token files.
+        Callers may reduce some message levels to INFO, or avoid throwing some exceptions.
         """
-        return self._allow_missing_variables
+        return self._allow_unresolved_file_tokens
 
-    def allow_missing_secrets(self):
+    def allow_unresolved_variable_tokens(self):
         """
-        Returns True if missing secrets should be overlooked during validation.
-        This includes declaring secrets directories that don't exist, or empty secrets files.
-        Callers may reduce some WARNING or SEVERE messages to INFO.
+        Returns True if unresolved variable tokens should be allowed during validation.
+        Callers may reduce some message levels to INFO, or avoid throwing some exceptions.
         """
-        return self._allow_missing_secrets
+        return self._allow_unresolved_variable_tokens
+
+    def allow_unresolved_secret_tokens(self):
+        """
+        Returns True if unresolved secret tokens should be allowed during validation.
+        This includes configured secrets directories that don't exist, or missing or empty secrets files.
+        Callers may reduce some message levels to INFO, or avoid throwing some exceptions.
+        """
+        return self._allow_unresolved_secret_tokens
 
     def allow_version_invalid_attributes(self):
         """
         Returns True if version-invalid attributes should be overlooked during validation.
-        Callers may reduce some WARNING or SEVERE messages to INFO.
+        Callers may reduce some message levels to INFO, or avoid throwing some exceptions.
         """
         return self._allow_version_invalid_attributes

--- a/core/src/main/python/wlsdeploy/util/validate_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/validate_configuration.py
@@ -25,6 +25,7 @@ class ValidateConfiguration(object):
         self._key = key
 
         # defaults are values for STRICT mode
+        self._allow_unresolved_archive_references = False
         self._allow_unresolved_environment_tokens = False
         self._allow_unresolved_file_tokens = False
         self._allow_unresolved_secret_tokens = False
@@ -32,6 +33,8 @@ class ValidateConfiguration(object):
         self._allow_version_invalid_attributes = False
 
         if key == LAX_METHOD:
+            # almost no checks on archive, tokens, etc.
+            self._allow_unresolved_archive_references = False
             self._allow_unresolved_environment_tokens = True
             self._allow_unresolved_file_tokens = True
             self._allow_unresolved_secret_tokens = True
@@ -39,12 +42,20 @@ class ValidateConfiguration(object):
             self._allow_version_invalid_attributes = True
 
         elif key == WKTUI_METHOD:
-            # similar to LAX_METHOD, but validate variable tokens.
-            # secrets, files and environment variables may not be present in the UI environment.
+            # allow unresolved secret, file and environment tokens,
+            # since they may not be present in the UI environment.
+            # allow version-invalid attributes, since they are not applied.
             self._allow_unresolved_environment_tokens = True
             self._allow_unresolved_file_tokens = True
             self._allow_unresolved_secret_tokens = True
             self._allow_version_invalid_attributes = True
+
+    def allow_unresolved_archive_references(self):
+        """
+        Returns True if unresolved archive references should be allowed during validation.
+        Callers may reduce some message levels to INFO, or avoid throwing some exceptions.
+        """
+        return self._allow_unresolved_archive_references
 
     def allow_unresolved_environment_tokens(self):
         """
@@ -82,3 +93,12 @@ class ValidateConfiguration(object):
         Callers may reduce some message levels to INFO, or avoid throwing some exceptions.
         """
         return self._allow_version_invalid_attributes
+
+    # set methods - use with caution
+
+    def set_allow_unresolved_archive_references(self, allow):
+        """
+        Override the pre-defined setting to allow unresolved archive references.
+        For use by tools that use non-lax validation mode, but don't consider archive files.
+        """
+        self._allow_unresolved_archive_references = allow

--- a/core/src/main/python/wlsdeploy/util/validate_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/validate_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 

--- a/core/src/main/python/wlsdeploy/util/validate_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/validate_configuration.py
@@ -34,7 +34,7 @@ class ValidateConfiguration(object):
 
         if key == LAX_METHOD:
             # almost no checks on archive, tokens, etc.
-            self._allow_unresolved_archive_references = False
+            self._allow_unresolved_archive_references = True
             self._allow_unresolved_environment_tokens = True
             self._allow_unresolved_file_tokens = True
             self._allow_unresolved_secret_tokens = True

--- a/core/src/main/python/wlsdeploy/util/validate_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/validate_configuration.py
@@ -1,0 +1,75 @@
+"""
+Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+"""
+
+# validation method keys
+STRICT_METHOD = "strict"
+LAX_METHOD = "lax"
+
+VALIDATION_METHODS = [STRICT_METHOD, LAX_METHOD]
+
+
+class ValidateConfiguration(object):
+    """
+    Provide validation configuration based on a validation method key.
+    """
+    _class_name = 'ValidateConfiguration'
+
+    def __init__(self, key):
+        """
+        Initialize the validate configuration based on the key.
+        :param key: a validation method key
+        """
+        self._key = key
+
+        # defaults are values for STRICT mode
+        self._allow_missing_environment_variables = False
+        self._allow_missing_file_variables = False
+        self._allow_missing_secrets = False
+        self._allow_missing_variables = False
+        self._allow_version_invalid_attributes = False
+
+        if key == LAX_METHOD:
+            self._allow_missing_environment_variables = True
+            self._allow_missing_file_variables = True
+            self._allow_missing_secrets = True
+            self._allow_missing_variables = True
+            self._allow_version_invalid_attributes = True
+
+    def allow_missing_environment_variables(self):
+        """
+        Returns True if missing environment variables should be overlooked during validation.
+        Callers may reduce some WARNING or SEVERE messages to INFO.
+        """
+        return self._allow_missing_environment_variables
+
+    def allow_missing_file_variables(self):
+        """
+        Returns True if missing file variables should be overlooked during validation.
+        This includes empty variable files.
+        Callers may reduce some WARNING or SEVERE messages to INFO.
+        """
+        return self._allow_missing_file_variables
+
+    def allow_missing_variables(self):
+        """
+        Returns True if missing variables should be overlooked during validation.
+        Callers may reduce some WARNING or SEVERE messages to INFO.
+        """
+        return self._allow_missing_variables
+
+    def allow_missing_secrets(self):
+        """
+        Returns True if missing secrets should be overlooked during validation.
+        This includes declaring secrets directories that don't exist, or empty secrets files.
+        Callers may reduce some WARNING or SEVERE messages to INFO.
+        """
+        return self._allow_missing_secrets
+
+    def allow_version_invalid_attributes(self):
+        """
+        Returns True if version-invalid attributes should be overlooked during validation.
+        Callers may reduce some WARNING or SEVERE messages to INFO.
+        """
+        return self._allow_version_invalid_attributes

--- a/core/src/main/python/wlsdeploy/util/variables.py
+++ b/core/src/main/python/wlsdeploy/util/variables.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os

--- a/core/src/main/python/wlsdeploy/util/weblogic_helper.py
+++ b/core/src/main/python/wlsdeploy/util/weblogic_helper.py
@@ -217,7 +217,7 @@ class WebLogicHelper(object):
                     wl_home = oracle_home + '/' + dirs[0]
                 else:
                     wl_home = None
-                
+
         return wl_home
 
     def is_weblogic_version_or_above(self, str_version, use_actual_version=False):
@@ -298,13 +298,13 @@ class WebLogicHelper(object):
 
         system_ini = SerializedSystemIni.getEncryptionService(domain_home)
         if system_ini is None:
-            ex = exception_helper.create_encryption_exception('WLSDPLY-01740')
+            ex = exception_helper.create_encryption_exception('WLSDPLY-01840')
             self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
             raise ex
 
         encryption_service = ClearOrEncryptedService(system_ini)
         if encryption_service is None:
-            ex = exception_helper.create_encryption_exception('WLSDPLY-01741')
+            ex = exception_helper.create_encryption_exception('WLSDPLY-01841')
             self.logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
             raise ex
         return encryption_service

--- a/core/src/main/python/wlsdeploy/util/weblogic_helper.py
+++ b/core/src/main/python/wlsdeploy/util/weblogic_helper.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import java.lang.Exception as JException

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates.
 # The Universal Permissive License (UPL), Version 1.0
 #
 #

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -341,13 +341,7 @@ WLSDPLY-01738=Path in {0} is not a directory: {1}
 WLSDPLY-01739=Could not resolve secret token "{0}". Known secrets include: {1}.  Secrets can only be resolved in \
   Kubernetes environment. The secret token's name and keys must have a matching Kubernetes secret name and literals \
   in the same namespace. For WebLogic Kubernetes Operator deployment, you must specify the secret name in \
-  "domain.spec.configuration.secrets"  
-
-# wlsdeploy/util/weblogic_helper.py
-WLSDPLY-01740=Encryption failed: Unable to locate SerializedSystemIni
-WLSDPLY-01741=Encryption failed: Unable to initialize encryption service
-
-# wlsdeploy/util/variables.py (cont'd)
+  "domain.spec.configuration.secrets"
 WLSDPLY-01745=Invalid token syntax for name "{0}", should match "{1}"
 WLSDPLY-01746=Invalid token syntax for {0} value "{1}", should match "{2}"
 
@@ -377,6 +371,10 @@ WLSDPLY-01786=MBean {0} getter {1} is not an attribute on the MBean instance
 WLSDPLY-01787=The list of attributes to discover that are not in the LSA map {0}
 WLSDPLY-01788=Attribute {0} from {1} not found in {2}
 
+# wlsdeploy/tool/util/credential_map_helper.py
+WLSDPLY-01790=Creating default credential mapper initialization file {0}
+WLSDPLY-01791=Attribute "{0}" is required for {1} credential mapping {2}
+
 # wlsdeploy/util/weblogic_roles_helper.py
 WLSDPLY-01800=Updating role mapper file: {0}
 WLSDPLY-01801=Creating backup file: {0}
@@ -385,9 +383,9 @@ WLSDPLY-01803=Adding roles: {0}
 WLSDPLY-01804=Failed to convert role {0} with expression {1} because {2}
 WLSDPLY-01805=Unexpected {0} during role mapper processing: {1}
 
-# wlsdeploy/tool/util/credential_map_helper.py
-WLSDPLY-01790=Creating default credential mapper initialization file {0}
-WLSDPLY-01791=Attribute "{0}" is required for {1} credential mapping {2}
+# wlsdeploy/util/weblogic_helper.py
+WLSDPLY-01840=Encryption failed: Unable to locate SerializedSystemIni
+WLSDPLY-01841=Encryption failed: Unable to initialize encryption service
 
 # wlsdeploy/tool/util/default_authenticator_helper.py
 WLSDPLY-01900=Append to default authenticator initialization file {0}

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -286,7 +286,6 @@ WLSDPLY-01641=Value {0} specified for -target argument does not resolve to a dir
 WLSDPLY-01642={0} is required and must be a directory for {1} {2}
 WLSDPLY-01643=-target {0} specified does not have the configuration file {1} in the file system
 WLSDPLY-01644=Target configuration file {0} is not formatted properly {1}
-WLSDPLY-01645=Target configuration file {0} validation_method must be either strict or lax
 WLSDPLY-01646=Supplied OPSS wallet directory {0} was not valid: {1}
 WLSDPLY-01647=Supplied output directory {0} was not valid: {1}
 WLSDPLY-01648=Target configuration file {0} has invalid value {1} for {2}. Valid values are: {3}

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -331,7 +331,7 @@ WLSDPLY-01725=Using configuration file {0}
 # wlsdeploy/util/variables.py
 WLSDPLY-01730=Failed to load variables file {0}: {1}
 WLSDPLY-01731=Variables updated by {0}
-WLSDPLY-01732=Variable {0} is not found in properties file
+WLSDPLY-01732=Variable "{0}" is not found in properties file
 WLSDPLY-01733=Variable file {0} cannot be read: {1}
 WLSDPLY-01734=No value in variable file {0}
 WLSDPLY-01735=Assignment in {0} is not formatted as X=Y: {1}
@@ -342,7 +342,7 @@ WLSDPLY-01739=Could not resolve secret token "{0}". Known secrets include: {1}. 
   Kubernetes environment. The secret token's name and keys must have a matching Kubernetes secret name and literals \
   in the same namespace. For WebLogic Kubernetes Operator deployment, you must specify the secret name in \
   "domain.spec.configuration.secrets"
-WLSDPLY-01740=Variable substitution errors ({0})
+WLSDPLY-01740=Found {0} token substitution errors
 WLSDPLY-01745=Invalid token syntax for name "{0}", should match "{1}"
 WLSDPLY-01746=Invalid token syntax for {0} value "{1}", should match "{2}"
 

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -342,6 +342,7 @@ WLSDPLY-01739=Could not resolve secret token "{0}". Known secrets include: {1}. 
   Kubernetes environment. The secret token's name and keys must have a matching Kubernetes secret name and literals \
   in the same namespace. For WebLogic Kubernetes Operator deployment, you must specify the secret name in \
   "domain.spec.configuration.secrets"
+WLSDPLY-01740=Variable substitution errors ({0})
 WLSDPLY-01745=Invalid token syntax for name "{0}", should match "{1}"
 WLSDPLY-01746=Invalid token syntax for {0} value "{1}", should match "{2}"
 

--- a/system-test/src/test/java/oracle/weblogic/deploy/integration/ITWdt.java
+++ b/system-test/src/test/java/oracle/weblogic/deploy/integration/ITWdt.java
@@ -1,4 +1,4 @@
-// Copyright 2019, 2021, Oracle Corporation and/or its affiliates.
+// Copyright 2019, 2022, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at
 // http://oss.oracle.com/licenses/upl.
 

--- a/system-test/src/test/java/oracle/weblogic/deploy/integration/ITWdt.java
+++ b/system-test/src/test/java/oracle/weblogic/deploy/integration/ITWdt.java
@@ -727,7 +727,7 @@ public class ITWdt extends BaseTest {
             String cmd = validateModelScript + " -oracle_home " + mwhome_12213 + " -model_file " +
                 getSampleModelFile("-constant");
             CommandResult result = Runner.run(cmd, getTestMethodEnvironment(testInfo), out);
-            verifyResult(result, "the archive file was not provided");
+            verifyErrorMsg(result, "the archive file was not provided");
         }
     }
 


### PR DESCRIPTION
New mode `wktui` will match `strict`, but allow unresolved secret, environment, and file tokens.
In standalone `validateModel`, list warning and severe messages in summary, without stopping validation.
Standalone `validateModel` in `strict` mode will now flag missing archive entries as errors, and return exit code 2.
See internal Jira WKTUI-215

Use `ValidateConfiguration` to check validation mode.
Some message keys were renumbered.