### PR TITLE
Allow WDT 2.0 target configuration with reduced functionality

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/util/filter_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/filter_helper.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import imp
@@ -17,7 +17,8 @@ __logger = PlatformLogger('wlsdeploy.tool.util')
 TARGET_CONFIG_TOKEN = '@@TARGET_CONFIG_DIR@@'
 
 __id_filter_map = {
-    # 'filterId': filter_method
+    # temporary - allow WDT 1.9 to specify no-op WDT 2.0 filter
+    'wko_filter': lambda x: x
 }
 
 

--- a/core/src/main/python/wlsdeploy/util/cla_utils.py
+++ b/core/src/main/python/wlsdeploy/util/cla_utils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2021, Oracle Corporation and/or its affiliates.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 Module that handles command-line argument parsing and common validation.
@@ -841,6 +841,10 @@ class CommandLineArgUtil(object):
 
     def _validate_validate_method_arg(self, value):
         method_name = '_validate_validate_method_arg'
+
+        # temporary for WDT 1.9: allow WDT 2.0 method, just interpret as lax
+        if value == 'wktui':
+            return self.LAX_VALIDATION_METHOD
 
         if value is None or len(value) == 0:
             ex = exception_helper.create_cla_exception('WLSDPLY-20029')

--- a/core/src/main/python/wlsdeploy/util/target_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/target_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 
@@ -76,7 +76,13 @@ class TargetConfiguration(object):
         Return the validation method for this target environment.
         :return: the validation method, or None
         """
-        return dictionary_utils.get_element(self.config_dictionary, 'validation_method')
+        validation_method = dictionary_utils.get_element(self.config_dictionary, 'validation_method')
+
+        # temporary for WDT 1.9: allow WDT 2.0 method, just interpret as lax
+        if validation_method == 'wktui':
+            validation_method = 'lax'
+
+        return validation_method
 
     def get_model_filters(self):
         """


### PR DESCRIPTION
Allow newer WKT UI to work with pre-2.0 WDT.
Allow validateModel with method `wktui` (interpret as `lax`).
Allow target configurations with validate method `wktui` (`lax`) and ID filter `wko_filter` (no-op).