### PR TITLE
Discover large classpath attribute values

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/aliases.py
+++ b/core/src/main/python/wlsdeploy/aliases/aliases.py
@@ -476,10 +476,8 @@ class Aliases(object):
 
             if attribute_info and not self.__is_wlst_attribute_read_only(location, attribute_info):
                 wlst_attribute_name = attribute_info[WLST_NAME]
-
-                if self._model_context and USES_PATH_TOKENS in attribute_info and \
-                        string_utils.to_boolean(attribute_info[USES_PATH_TOKENS]):
-                    model_attribute_value = self._model_context.replace_token_string(model_attribute_value)
+                uses_path_tokens = USES_PATH_TOKENS in attribute_info and \
+                    string_utils.to_boolean(attribute_info[USES_PATH_TOKENS])
 
                 data_type = attribute_info[WLST_TYPE]
                 if data_type == 'password':
@@ -514,6 +512,11 @@ class Aliases(object):
                             model_val = alias_utils.convert_to_type(LIST, model_attribute_value,
                                                                     delimiter=MODEL_LIST_DELIMITER)
 
+                            if uses_path_tokens:
+                                for index, item in enumerate(model_val):
+                                    item_value = self._model_context.replace_token_string(str(item))
+                                    model_val[index] = item_value
+
                             _read_type, read_delimiter = \
                                 alias_utils.compute_read_data_type_and_delimiter_from_attribute_info(
                                     attribute_info, existing_wlst_value)
@@ -539,6 +542,9 @@ class Aliases(object):
                             wlst_attribute_value = alias_utils.convert_to_type(data_type, merged_value,
                                                                                delimiter=MODEL_LIST_DELIMITER)
                     else:
+                        if uses_path_tokens:
+                            model_attribute_value = self._model_context.replace_token_string(model_attribute_value)
+
                         wlst_attribute_value = alias_utils.convert_to_type(data_type, model_attribute_value,
                                                                            delimiter=MODEL_LIST_DELIMITER)
 

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -5,11 +5,13 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 import copy
 import os
+import re
 import tempfile
 
 import java.net.URI as URI
 
 from oracle.weblogic.deploy.util import XPathUtil
+from wlsdeploy.aliases.model_constants import MODEL_LIST_DELIMITER
 from wlsdeploy.aliases.wlst_modes import WlstModes
 from wlsdeploy.logging import platform_logger
 from wlsdeploy.util import validate_configuration
@@ -898,14 +900,17 @@ class ModelContext(object):
         """
         Replace known types of directories with a tokens that represent the directory.
 
-        :param classpath: containing a string of directories separated by environment specific classpath separator
+        :param classpath: containing a string of directories separated by commas
         :return: tokenized classpath string
         """
-        cp_elements, separator = path_utils.split_classpath(classpath)
+        cp_elements = classpath.split(MODEL_LIST_DELIMITER)
         for index, value in enumerate(cp_elements):
+            path_is_windows = '\\' in value or re.match('^[a-zA-Z][:]', value)
+            if path_is_windows:
+                value = path_utils.fixup_path(value)
             cp_elements[index] = self.tokenize_path(value)
 
-        return separator.join(cp_elements)
+        return MODEL_LIST_DELIMITER.join(cp_elements)
 
     def copy(self, arg_map):
         model_context_copy = copy.copy(self)

--- a/core/src/main/python/wlsdeploy/util/path_utils.py
+++ b/core/src/main/python/wlsdeploy/util/path_utils.py
@@ -1,9 +1,8 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.  All rights reserved.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 import os
-import re
 
 import java.io.File as JFile
 
@@ -15,28 +14,6 @@ CUSTOM_CONFIG_VARIABLE = 'WDT_CUSTOM_CONFIG'
 
 __logger = PlatformLogger('wlsdeploy.util')
 _class_name = 'path_utils'
-
-
-def split_classpath(classpath):
-    """
-    Split the classpath string into a list of classpath directories. The classpath string will be split around
-        the environment specific file separator token.
-    :param classpath: string of token separated directories and files representing the classpath
-    :return: list of classpath nodes
-    """
-    classpath_is_windows = False
-    # This is not a definitive test but it tests the cases we care about...
-    if '\\' in classpath or ';' in classpath or re.match('^[a-zA-Z][:]', classpath):
-        classpath_is_windows = True
-
-    if classpath_is_windows:
-        my_classpath = fixup_path(classpath)
-        separator = ';'
-    else:
-        my_classpath = classpath
-        separator = ':'
-
-    return my_classpath.split(separator), separator
 
 
 def fixup_path(path):


### PR DESCRIPTION
Split discovered classpath attributes correctly to tokenize path elements.
Substitute classpath attributes correctly before setting in WLST.
Fixes #1025


