### PR TITLE
fixed issue where deleted application was still thought to exist 

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -152,11 +152,9 @@ class ApplicationsDeployer(Deployer):
         root_path = self.aliases.get_wlst_subfolders_path(self._base_location)
         application_location = LocationContext(self._base_location).append_location(APPLICATION)
         application_token = self.aliases.get_name_token(application_location)
-        existing_applications = deployer_utils.get_existing_object_list(application_location, self.aliases)
 
         for application_name in applications:
-            self.logger.info('WLSDPLY-09301', APPLICATION, application_name, self._parent_type, self._parent_name,
-                             class_name=self._class_name, method_name=_method_name)
+            existing_applications = deployer_utils.get_existing_object_list(application_location, self.aliases)
 
             if model_helper.is_delete_name(application_name):
                 if self.__verify_delete_versioned_app(application_name, existing_applications, type='app'):
@@ -165,6 +163,9 @@ class ApplicationsDeployer(Deployer):
                     existing_names = deployer_utils.get_existing_object_list(location, self.aliases)
                     deployer_utils.delete_named_element(location, application_name, existing_names, self.aliases)
                 continue
+            else:
+                self.logger.info('WLSDPLY-09301', APPLICATION, application_name, self._parent_type, self._parent_name,
+                                 class_name=self._class_name, method_name=_method_name)
 
             application = \
                 copy.deepcopy(dictionary_utils.get_dictionary_element(applications, application_name))

--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -84,11 +84,9 @@ class ApplicationsDeployer(Deployer):
         root_path = self.aliases.get_wlst_subfolders_path(self._base_location)
         shared_library_location = LocationContext(self._base_location).append_location(LIBRARY)
         shared_library_token = self.aliases.get_name_token(shared_library_location)
-        existing_shared_libraries = deployer_utils.get_existing_object_list(shared_library_location, self.aliases)
 
         for shared_library_name in shared_libraries:
-            self.logger.info('WLSDPLY-09608', LIBRARY, shared_library_name, self._parent_type, self._parent_name,
-                             class_name=self._class_name, method_name=_method_name)
+            existing_shared_libraries = deployer_utils.get_existing_object_list(shared_library_location, self.aliases)
 
             if model_helper.is_delete_name(shared_library_name):
                 if self.__verify_delete_versioned_app(shared_library_name, existing_shared_libraries, type='lib'):
@@ -97,6 +95,9 @@ class ApplicationsDeployer(Deployer):
                     existing_names = deployer_utils.get_existing_object_list(location, self.aliases)
                     deployer_utils.delete_named_element(location, shared_library_name, existing_names, self.aliases)
                 continue
+            else:
+                self.logger.info('WLSDPLY-09608', LIBRARY, shared_library_name, self._parent_type, self._parent_name,
+                                 class_name=self._class_name, method_name=_method_name)
 
             #
             # In WLST offline mode, the shared library name must match the fully qualified name, including


### PR DESCRIPTION
Fixes #975.  The application deployer was not updating its existing names list after deleting an application.  If the same application name in the model was being re-added, create_if_not_exists thinks the application is still there.