### PR TITLE
Add separate target filters for k8s and vz

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/util/filter_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/filter_helper.py
@@ -18,6 +18,8 @@ __logger = PlatformLogger('wlsdeploy.tool.util')
 TARGET_CONFIG_TOKEN = '@@TARGET_CONFIG_DIR@@'
 
 __id_filter_map = {
+    'k8s_filter': wko_filter.filter_model,
+    'vz_filter': wko_filter.filter_model,
     'wko_filter': wko_filter.filter_model
 }
 

--- a/core/src/main/python/wlsdeploy/tool/util/filters/model_traverse.py
+++ b/core/src/main/python/wlsdeploy/tool/util/filters/model_traverse.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, Oracle and/or its affiliates.
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 from wlsdeploy.aliases.aliases import Aliases
@@ -7,6 +7,7 @@ from wlsdeploy.aliases.model_constants import APP_DEPLOYMENTS
 from wlsdeploy.aliases.model_constants import DOMAIN_INFO
 from wlsdeploy.aliases.model_constants import RESOURCES
 from wlsdeploy.aliases.model_constants import TOPOLOGY
+from wlsdeploy.aliases.validation_codes import ValidationCodes
 from wlsdeploy.logging.platform_logger import PlatformLogger
 
 _class_name = 'ModelTraverse'
@@ -71,6 +72,9 @@ class ModelTraverse:
             self.traverse_node(model_node, model_location)
 
     def traverse_node(self, model_node, model_location):
+        result, message = self._aliases.is_version_valid_location(model_location)
+        if result == ValidationCodes.VERSION_INVALID:
+            return
         valid_folder_names = self._aliases.get_model_subfolder_names(model_location)
         valid_attribute_names = self._aliases.get_model_attribute_names(model_location)
         self.traverse_node_elements(model_node, model_location, valid_folder_names, valid_attribute_names)

--- a/core/src/main/targetconfigs/k8s/k8s_operator_filter.py
+++ b/core/src/main/targetconfigs/k8s/k8s_operator_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+# Copyright (c) 2020, 2022, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # ------------
@@ -56,15 +56,3 @@ def __cleanup_topology(model):
                 for delthis in ['ServerStart']:
                     if server_templates[server_template].has_key(delthis):
                         del server_templates[server_template][delthis]
-        else:
-            topology['ServerTemplate'] = {}
-            server_templates = topology['ServerTemplate']
-            if topology.has_key('Cluster'):
-                clusters = topology['Cluster']
-                for cluster in clusters:
-                    server_templates[cluster] = {}
-                    server_template = server_templates[cluster]
-                    server_template['Cluster'] = cluster
-                    server_template['AutoMigrationEnabled'] = False
-
-

--- a/core/src/main/targetconfigs/k8s/target.json
+++ b/core/src/main/targetconfigs/k8s/target.json
@@ -2,7 +2,7 @@
   "model_filters" : {
         "discover": [
           { "name": "k8s_prep", "path": "@@TARGET_CONFIG_DIR@@/k8s_operator_filter.py" },
-          { "id": "wko_filter" }
+          { "id": "k8s_filter" }
         ]
       },
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},

--- a/core/src/main/targetconfigs/vz/target.json
+++ b/core/src/main/targetconfigs/vz/target.json
@@ -2,7 +2,7 @@
     "model_filters" : {
         "discover": [
             { "name": "vz_prep", "path": "@@TARGET_CONFIG_DIR@@/vz_filter.py" },
-            { "id": "wko_filter" }
+            { "id": "vz_filter" }
         ]
     },
     "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},


### PR DESCRIPTION
Also fixed bugs with k8s filter:
- Remove server template creation from k8s filter (see PR #844).
- Skip version-invalid folders when running online attribute filter.
