### PR TITLE
Do not look for path tokens if path is None

### DIFF
--- a/alias-test/src/test/python/aliastest/verify/verifier_helper.py
+++ b/alias-test/src/test/python/aliastest/verify/verifier_helper.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020, 2021, Oracle Corporation and/or its affiliates.
+Copyright (c) 2020, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 

--- a/core/src/main/python/wlsdeploy/aliases/aliases.py
+++ b/core/src/main/python/wlsdeploy/aliases/aliases.py
@@ -512,7 +512,7 @@ class Aliases(object):
                             model_val = alias_utils.convert_to_type(LIST, model_attribute_value,
                                                                     delimiter=MODEL_LIST_DELIMITER)
 
-                            if uses_path_tokens:
+                            if uses_path_tokens and model_val is not None:
                                 for index, item in enumerate(model_val):
                                     item_value = self._model_context.replace_token_string(str(item))
                                     model_val[index] = item_value


### PR DESCRIPTION
when checking default value, the default is None. Aliases is trying to do an iterate over the parts of a path without checking if it is None first. Need this for the alias tests.