### PR TITLE
switching to new jgit build number plugin to address error during release process

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -139,8 +139,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>ru.concerteza.buildnumber</groupId>
-                <artifactId>maven-jgit-buildnumber-plugin</artifactId>
+                <groupId>com.labun.buildnumber</groupId>
+                <artifactId>jgit-buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -47,8 +47,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>ru.concerteza.buildnumber</groupId>
-                <artifactId>maven-jgit-buildnumber-plugin</artifactId>
+                <groupId>com.labun.buildnumber</groupId>
+                <artifactId>jgit-buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,9 +209,9 @@
                     <version>3.9.1.2184</version>
                 </plugin>
                 <plugin>
-                    <groupId>ru.concerteza.buildnumber</groupId>
-                    <artifactId>maven-jgit-buildnumber-plugin</artifactId>
-                    <version>1.2.10</version>
+                    <groupId>com.labun.buildnumber</groupId>
+                    <artifactId>jgit-buildnumber-maven-plugin</artifactId>
+                    <version>2.6.0</version>
                     <configuration>
                         <runOnlyAtExecutionRoot>false</runOnlyAtExecutionRoot>
                     </configuration>


### PR DESCRIPTION
I have verified that this resolves the build number plugin error that was occurring during the release process, forcing us to rebuild the binaries after the release process.