### PR TITLE
slim down console output with environment variable

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/logging/SummaryHandler.java
+++ b/core/src/main/java/oracle/weblogic/deploy/logging/SummaryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle Corporation and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.logging;
@@ -276,6 +276,7 @@ public class SummaryHandler extends Handler implements WLSDeployLogEndHandler {
     private Handler getConsoleHandler() {
         Handler handler = LoggingUtils.getHandlerInstance(WLSDeployLoggingConfig.getStdoutHandler());
         handler.setFilter(null);
+        handler.setLevel(Level.INFO);
         return handler;
     }
 

--- a/core/src/main/java/oracle/weblogic/deploy/logging/WLSDeployLoggingConfig.java
+++ b/core/src/main/java/oracle/weblogic/deploy/logging/WLSDeployLoggingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
  * Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
  */
 package oracle.weblogic.deploy.logging;
@@ -106,6 +106,11 @@ public class WLSDeployLoggingConfig {
      * set the ConsoleHandler level to INFO.
      */
     public static final String WLSDEPLOY_DEBUG_TO_STDOUT_PROP = WLSDEPLOY_LOGGER_NAME + ".debugToStdout";
+
+    /**
+     * The environment variable used to minimize console log statements.
+     */
+    public static final String WLSDEPLOY_TURN_OFF_CONSOLE = "WLSDEPLOY_TURN_OFF_CONSOLE";
 
     private static File loggingDirectory;
     private static File loggingPropertiesFile;
@@ -290,11 +295,16 @@ public class WLSDeployLoggingConfig {
 
     private static void configureStdoutConsoleHandler(Properties logProps) {
         String consoleHandler = getStdoutHandler();
-        String debugToStdoutString = System.getProperty(WLSDEPLOY_DEBUG_TO_STDOUT_PROP, DEFAULT_DEBUG_TO_STDOUT);
-        if (Boolean.parseBoolean(debugToStdoutString)) {
-            logProps.setProperty(consoleHandler + HANDLER_LEVEL_PROP, Level.ALL.toString());
+        Boolean noOutputToStdoutString = new Boolean(System.getenv(WLSDEPLOY_TURN_OFF_CONSOLE));
+        if (noOutputToStdoutString) {
+            logProps.setProperty(consoleHandler + HANDLER_LEVEL_PROP, Level.OFF.toString());
         } else {
-            logProps.setProperty(consoleHandler + HANDLER_LEVEL_PROP, DEFAULT_CONSOLE_HANDLER_LEVEL);
+            String debugToStdoutString = System.getProperty(WLSDEPLOY_DEBUG_TO_STDOUT_PROP, DEFAULT_DEBUG_TO_STDOUT);
+            if (Boolean.parseBoolean(debugToStdoutString)) {
+                logProps.setProperty(consoleHandler + HANDLER_LEVEL_PROP, Level.ALL.toString());
+            } else {
+                logProps.setProperty(consoleHandler + HANDLER_LEVEL_PROP, DEFAULT_CONSOLE_HANDLER_LEVEL);
+            }
         }
         logProps.setProperty(consoleHandler + HANDLER_FORMATTER_PROP, DEFAULT_CONSOLE_FORMATTER_PROP);
         logProps.setProperty(consoleHandler + HANDLER_FILTER_PROP, DEFAULT_STDOUT_FILTER_PROP);


### PR DESCRIPTION
Fixes Jira 537

Turn off logging on Stdout Console. Leave Stderr the same. Reset when time to write Summary.