### PR TITLE
apply code font where needed

### DIFF
--- a/documentation/2.0/content/userguide/tools/compare.md
+++ b/documentation/2.0/content/userguide/tools/compare.md
@@ -293,9 +293,9 @@ Comparing the new and old models:
     diffed_model.yaml
     compare_model_stdout
 
-### Parameter table for compareModel
+### Parameter table for `compareModel`
 | Parameter | Definition | Default |
 | --- | --- | --- |
-| `-oracle_home` | Home directory of the Oracle installation. Required if ORACLE_HOME environment variable is not set. |    |
+| `-oracle_home` | Home directory of the Oracle installation. Required if the `ORACLE_HOME` environment variable is not set. |    |
 | `-output_dir` | (Required) Directory in which to store the output. |    |
 | `-variable_file` | Variable file used for token substitution. |    |

--- a/documentation/2.0/content/userguide/tools/create.md
+++ b/documentation/2.0/content/userguide/tools/create.md
@@ -32,7 +32,8 @@ To create more complex domains, it may be necessary to create a custom domain ty
 
 ### Using an encrypted model
 
-If the model or variables file contains passwords encrypted with the WDT Encryption tool, decrypt the passwords during create with the `-use_encryption` flag on the command line to tell the Create Domain Tool that encryption is being used and to prompt for the encryption passphrase.  As with the database passwords, the tool can also read the passphrase from standard input (for example, `stdin`) to allow the tool to run without any user input. You can bypass the stdin prompt with two other options. You can bypass the stdin prompt with two other options: store the passphrase in an environment variable, and use the environment variable name with the command-line option -passphrase_env or create a file with the single value of the passphrase. Provide the name of the file with the command-line option -passphrase_file. The passphrase will be read by the tool from the file. 
+If the model or variables file contains passwords encrypted with the WDT Encryption tool, decrypt the passwords during create with the `-use_encryption` flag on the command line to tell the Create Domain Tool that encryption is being used and to prompt for the encryption passphrase.  As with the database passwords, the tool can also read the passphrase from standard input (for example, `stdin`) to allow the tool to run without any user input. You can bypass the stdin prompt with two other options. You can bypass the stdin prompt with two other options: store the passphrase in an environment variable, and use the environment variable name with the command-line
+option `-passphrase_env` or create a file with the single value of the passphrase. Provide the name of the file with the command-line option `-passphrase_file`. The passphrase will be read by the tool from the file.
 
 ### Using multiple models
 
@@ -59,23 +60,23 @@ topology:
     ProductionModeEnabled: false
 ```
 
-### Parameter table for createDomain
+### Parameter table for `createDomain`
 | Parameter | Definition | Default |
 | --- | --- | --- |
-| `-archive_file` | The path to the archive file to use.  If the -model_file argument is not specified, the model file in this archive will be used.  This can also be specified as a comma-separated list of archive files.  The overlapping contents in each archive take precedence over previous archives in the list. |    |
-| `-domain_home` | Required if -domain_parent is not used. The full directory and name where the domain should be created.
-| `-domain_parent` | Required if -domain_home is not used. The parent directory where the domain should be created. The name is the domain name in the model. |    |
-| `-domain_type` | The type of domain (for example, WLS, JRF). | WLS |
-| `-java_home` | The Java Home to use for the new domain. If not specified, it defaults to the value of the JAVA_HOME environment variable. |    |
+| `-archive_file` | The path to the archive file to use.  If the `-model_file` argument is not specified, the model file in this archive will be used.  This can also be specified as a comma-separated list of archive files.  The overlapping contents in each archive take precedence over previous archives in the list. |    |
+| `-domain_home` | Required if `-domain_parent` is not used. The full directory and name where the domain should be created.
+| `-domain_parent` | Required if `-domain_home` is not used. The parent directory where the domain should be created. The name is the domain name in the model. |    |
+| `-domain_type` | The type of domain (for example, `WLS`, `JRF`). | `WLS` |
+| `-java_home` | The Java home to use for the new domain. If not specified, it defaults to the value of the `JAVA_HOME` environment variable. |    |
 | `-model_file` | The location of the model file.  This can also be specified as a comma-separated list of model locations, where each successive model layers on top of the previous ones. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set.|    |
-| `-opss_wallet_passphrase_env` | An alternative to entering the OPSS wallet passphrase at a prompt. The value is an ENVIRONMENT VARIABLE name that WDT will use to retrieve the passphrase. |    |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set.|    |
+| `-opss_wallet_passphrase_env` | An alternative to entering the OPSS wallet passphrase at a prompt. The value is an environment variable name that WDT will use to retrieve the passphrase. |    |
 | `-opss_wallet_passphrase_file` | An alternative to entering the OPSS wallet passphrase at a prompt. The value is the name of a file with a string value which WDT will read to retrieve the passphrase.
-| `-passphrase_env` | An alternative to entering the encryption passphrase at a prompt. The value is an ENVIRONMENT VARIABLE name that WDT will use to retrieve the passphrase. |    |
+| `-passphrase_env` | An alternative to entering the encryption passphrase at a prompt. The value is an environment variable name that WDT will use to retrieve the passphrase. |    |
 | `-passphrase_file` | An alternative to entering the encryption passphrase at a prompt. The value is the name of a file with a string value which WDT will read to retrieve the passphrase. |    |
 | `-rcu_database` | The RCU database connect string.  |    |
 | `-rcu_prefix` | The RCU prefix to use. |    |
-| `-rcu_db_user` | The RCU dbUser to use. | sys |
+| `-rcu_db_user` | The RCU `dbUser` to use. | `sys` |
 | `-run_rcu` | Run RCU to create the database schemas specified by the domain type using the specified RCU prefix. Running RCU will drop any existing schemas with the same RCU prefix if they exist prior to trying to create them. |    |
 | `-use_encryption` | One or more of the passwords in the model or variables file(s) are encrypted and must be decrypted. Java 8 or later required for this feature. |    |
 | `-variable_file` | The location of the property file containing the values for variables used in the model. This can also be specified as a comma-separated list of property files, where each successive set of properties layers on top of the previous ones. |    |

--- a/documentation/2.0/content/userguide/tools/deploy.md
+++ b/documentation/2.0/content/userguide/tools/deploy.md
@@ -22,42 +22,42 @@ Running the Deploy Applications Tool in WLST offline mode is very similar to run
 
     $ weblogic-deploy\bin\deployApps.cmd -oracle_home c:\wls12213 -domain_home domains\DemoDomain -archive_file DemoDomain.zip -model_file DemoDomain.yaml -variable_file DemoDomain.properties
 
-To run the tool in online mode, add the `-admin_url` and `admin_user` arguments with the necessary values to connect to the WebLogic Server Administration Server. For example:
+To run the tool in online mode, add the `-admin_url` and `-admin_user` arguments with the necessary values to connect to the WebLogic Server Administration Server. For example:
 
     $ weblogic-deploy\bin\deployApps.cmd -oracle_home c:\wls12213 -domain_home domains\DemoDomain -archive_file DemoDomain.zip -model_file DemoDomain.yaml -variable_file DemoDomain.properties -admin_url t3://127.0.0.1:7001 -admin_user weblogic
 
-As usual, the tool will prompt for the password (it can also be supplied by piping it to standard input of the tool). To bypass the prompt, you can use one of two options. Store the password in an environment variable, and use the variable name with command line option -admin_pass_env. Store the password in a file. Provide the file name with command line option -admin_pass_file.
+As usual, the tool will prompt for the password (it can also be supplied by piping it to standard input of the tool). To bypass the prompt, you can use one of two options. Store the password in an environment variable, and use the variable name with command-line option `-admin_pass_env`. Store the password in a file. Provide the file name with command-line option `-admin_pass_file`.
 
 When running the tool in WLST online mode, the deploy operation may require server restarts or a domain restart to pick up the changes.  The deploy operation can also encounter situations where it cannot complete its operation until the domain is restarted.  To communicate these conditions to scripts that may be calling the Deploy Applications Tool, the shell scripts have three special, non-zero exit codes to communicate these states:
 
 - `103` - The entire domain needs to be restarted.
-- `104` - The domain changes have been canceled because the changes in the model requires a domain restart and -cancel_changes_if_restart_required is specified.
+- `104` - The domain changes have been canceled because the changes in the model requires a domain restart and `-cancel_changes_if_restart_required` is specified.
 
 ### Using an encrypted model
 
-If the model or variables file contains passwords encrypted with the WDT Encryption tool, decrypt the passwords during create with the `-use_encryption` flag on the command line to tell the Deploy Applications Tool that encryption is being used and to prompt for the encryption passphrase.  As with the database passwords, the tool can also read the passphrase from standard input (for example, `stdin`) to allow the tool to run without any user input. You can bypass the stdin prompt with two other options. Store the passphrase in an environment variable, and use the environment variable name with command line option -passphrase_env. Another option is to create a file containing the passphrase value. Pass this filename using the command line option -passphrase_file
+If the model or variables file contains passwords encrypted with the WDT Encryption tool, decrypt the passwords during create with the `-use_encryption` flag on the command line to tell the Deploy Applications Tool that encryption is being used and to prompt for the encryption passphrase.  As with the database passwords, the tool can also read the passphrase from standard input (for example, `stdin`) to allow the tool to run without any user input. You can bypass the stdin prompt with two other options. Store the passphrase in an environment variable, and use the environment variable name with command-line option `-passphrase_env`. Another option is to create a file containing the passphrase value. Pass this filename using the command-line option `-passphrase_file`.
 
 
 ### Using multiple models
 
 The Deploy Applications Tool supports the use of multiple models, as described in [Using multiple models]({{< relref "/concepts/model#using-multiple-models" >}}).
 
-### Parameter table for deployApps
+### Parameter table for `deployApps`
 | Parameter | Definition | Default |
 | ---- | ---- | ---- |
-| `-admin_pass_env` | An alternative to entering the admin password at a prompt. The value is an ENVIRONMENT VARIABLE name that WDT will use to retrieve the password. |    |
+| `-admin_pass_env` | An alternative to entering the admin password at a prompt. The value is an environment variable name that WDT will use to retrieve the password. |    |
 | `-admin_pass_file` |  An alternative to entering the admin password at a prompt. The value is a the name of a file that contains a password string that the tool will read to retrieve the password. |    |
 | `-admin_url` | The admin server URL used for online deploy. |    |
-| `-admin_user` | The admin username used for online deploy. |    |
-| `-archive_file` | The path to the archive file. If the model_file argument is not used, the model file in this file will be used. This can also be specified as a comma-separated list of archive files.  The overlapping contents in each archive take precedence over previous archives in the list. |    |
-| `-cancel_changes_if_restart_required` | Cancel the changes if the update requires domain restart. |    |
-| `-discard_current_edit` | Discard all current domain edits before starting update. |    |
+| `-admin_user` | The admin user name used for online deploy. |    |
+| `-archive_file` | The path to the archive file. If the `-model_file` argument is not used, the model file in this file will be used. This can also be specified as a comma-separated list of archive files.  The overlapping contents in each archive take precedence over previous archives in the list. |    |
+| `-cancel_changes_if_restart_required` | Cancel the changes if the update requires a domain restart. |    |
+| `-discard_current_edit` | Discard all current domain edits before starting the update. |    |
 | `-domain_home` | (Required). The location of the existing domain home. |    |
-| `-domain_type` | The type of domain.  (for example, WLS, JRF) | WLS |
+| `-domain_type` | The type of domain.  (for example, `WLS`, `JRF`) | `WLS` |
 | `-model_file` | The location of the model file. This can also be specified as a comma-separated list of model locations, where each successive model layers on top of the previous ones. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set.|    |
-| `-output_dir` | If present, write restart information to this directory as restart.file, or, if cancel_changes_if_restart_required used, write non dynamic changes information to file. |    |
-| `-passphrase_env` | An alternative to entering the encryption passphrase at a prompt. The value is an ENVIRONMENT VARIABLE name that WDT will use to retrieve the passphrase. |    |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set.|    |
+| `-output_dir` | If present, write restart information to this directory as `restart.file`, or, if `cancel_changes_if_restart_required` used, write non-dynamic changes information to file. |    |
+| `-passphrase_env` | An alternative to entering the encryption passphrase at a prompt. The value is an environment variable name that WDT will use to retrieve the passphrase. |    |
 | `-passphrase_file` | An alternative to entering the encryption passphrase at a prompt. The value is the name of a file with a string value which WDT will read to retrieve the passphrase. |    |
-| `-use_encryption` | One or more of the passwords in the model or variables file(s) are encrypted and must be decrypted. Java 8 or later required for this feature. |    |
+| `-use_encryption` | One or more of the passwords in the model or variables file(s) are encrypted and must be decrypted. Java 8 or later is required for this feature. |    |
 | `-variable_file` | The location of the property file containing the values for variables used in the model. This can also be specified as a comma-separated list of property files, where each successive set of properties layers on top of the previous ones. |    |

--- a/documentation/2.0/content/userguide/tools/discover.md
+++ b/documentation/2.0/content/userguide/tools/discover.md
@@ -23,11 +23,11 @@ When creating the archive, the tool will try to gather all binaries, scripts, an
 
 You can customize what is generated in the model for password attributes by providing a variable file location and name. This file is a text properties file which will contain a key=value for each password found in the model. The key is a unique token name for a password attribute, and the value is the replacement value; in this case, an empty string. The attribute in the model is injected with the token name and property field notation. For example, `@@PROP:AdminUserName@@` or `@@PROP:JDBCSystemResource.<Name>.JdbcResource.JDBCDriverParams.PasswordEncrypted@@`.
 
-A command line example containing the variable file name:
+A command-line example containing the variable file name:
 
     $ weblogic-deploy\bin\discoverDomain.cmd -oracle_home c:\wls12213 -domain_home domains\DemoDomain -archive_file DiscoveredDemoDomain.zip -model_file DiscoveredDemoDomain.json -variable_file DiscoverDemoDomain.properties
 
-To discover the domain using online WLST, simply include the admin user name and admin URL on the command line. The tool will prompt for a password to be entered into STDIN. To bypass the prompt, you can use one of two options. Store the password in an environment variable, and use the variable name with command line option -admin_pass_env. Store the password value in a file. Provide the file name with command line option -admin_pass_file.
+To discover the domain using online WLST, simply include the admin user name and admin URL on the command line. The tool will prompt for a password to be entered into STDIN. To bypass the prompt, you can use one of two options. Store the password in an environment variable, and use the variable name with command-line option `-admin_pass_env`. Store the password value in a file. Provide the file name with command-line option `-admin_pass_file`.
 
 An example of running in online WLST mode:
 
@@ -77,21 +77,20 @@ The following environment variables may be set.
 
 Please provide the `STDOUT` and `STDERR` log streams in the GitHub Issue. If the summary is not listed (unhandled exception stack trace occurs), be sure and include the Oracle and WDT install versions and whether the tool was run in online or offline WLST mode. If possible, provide the model, variable and archive files, and the log file, `discoverDomain.log`, from location `<install home>\weblogic-deploy\log`.
 
-### Parameter table for discoverDomain
+### Parameter table for `discoverDomain`
 | Parameter | Definition | Default |
 | ---- | ---- | ---- |
 | `-archive_file` | The path to the archive file. |    |
-| `-admin_pass_env` | An alternative to entering the admin password at a prompt. The value is a ENVIRONMENT VARIABLE name that WDT will use to retrieve the password. |    |
+| `-admin_pass_env` | An alternative to entering the admin password at a prompt. The value is a environment variable name that WDT will use to retrieve the password. |    |
 | `-admin_pass_file` | An alternative to entering the admin password at a prompt. The value is a the name of a file that contains a password string that the tool will read to retrieve the password. |    |
 | `-admin_url` | The admin server URL used for online discovery. |    |
 | `-admin_user` | The admin user used for online discovery. |    |
 | `-domain_home` | (Required). The location of the existing domain home. |    |
-| `-domain_type` | The type of domain.  (for example, WLS, JRF) | WLS |
-| `-java_home` | Overrides the JAVA_HOME value when discovering domain values to be replaced with the java home global token. |    |
+| `-domain_type` | The type of domain.  (for example, `WLS`, `JRF`) | `WLS` |
+| `-java_home` | Overrides the `JAVA_HOME`  value when discovering domain values to be replaced with the Java home global token. |    |
 | `-model_file` | The path to the model file. If not present, model file will be stored in archive file. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set. |    |
-| `-output_dir` | Output directory required for -target. |    |
-| `-skip_archive` | Do not generate an archive file. The archive_file option will be ignored. |    |
-| `-target` | Targeting platform - k8s, wko, vz. |    |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set. |    |
+| `-output_dir` | Output directory required for `-target`. |    |
+| `-skip_archive` | Do not generate an archive file. The `-archive_file` option will be ignored. |    |
+| `-target` | Targeting platform - `k8s`, `wko`, `vz`. |    |
 | `-variable_file` | The location to write properties for attributes that have been replaced with tokens by the variable injector. If this is included, all credentials will automatically be replaced by tokens and the property written to this file. |    |
-

--- a/documentation/2.0/content/userguide/tools/encrypt.md
+++ b/documentation/2.0/content/userguide/tools/encrypt.md
@@ -90,7 +90,7 @@ To run the encryption tool on the model, run the following command:
 
     $ weblogic-deploy\bin\encryptModel.cmd -oracle_home c:\wls12213 -model_file UnencryptedDemoDomain.yaml
 
-The tool will prompt for the encryption passphrase twice and then encrypt any passwords it finds in the model, skipping any password fields that have variable values, to produce a result that looks like the following model. You can bypass the stdin prompt with two other options. Store the passphrase in an environment variable, and use the environment variable name with command line option -passphrase_env. Another option is to create a file containing the passphrase value. Pass this filename using the command line option -passphrase_file
+The tool will prompt for the encryption passphrase twice and then encrypt any passwords it finds in the model, skipping any password fields that have variable values, to produce a result that looks like the following model. You can bypass the stdin prompt with two other options. Store the passphrase in an environment variable, and use the environment variable name with command-line option `-passphrase_env`. Another option is to create a file containing the passphrase value. Pass this filename using the command-line option `-passphrase_file`.
 
 ```yaml
 domainInfo:
@@ -220,12 +220,12 @@ The variable file will now look something like the following:
     db.password={AES}czFXMkNFWNG9jNTNYd0hRL2R1anBnb0hDUlp4K1liQWFBdVM4UTlvMnE0NU1aMUZ5UVhiK25oaWFBc2lIQ20\=
     mymailsession.password={AES}RW9nRnUzcE41WGNMdnEzNDdRQVVNWm1LMGhidkFBVXg6OUN3aXcyci82cmh3cnpNQTpmY2UycUp5YWl4UT0\=
 
-### Parameter table for encrypt tool
+### Parameter table for `encryptModel`
 | Parameter | Definition | Default |
 | ---- | ---- | ---- |
 | `-manual` | Run without a model and get an encrypted value for a single password. |    |
 | `-model_file` | The location of the model file or a set of model files. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set. |    |
-| `-passphrase_env` | An alternative to entering the encryption passphrase at a prompt. The value is a ENVIRONMENT VARIABLE name that WDT will use to retrieve the passphrase. |    |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set. |    |
+| `-passphrase_env` | An alternative to entering the encryption passphrase at a prompt. The value is a environment variable name that WDT will use to retrieve the passphrase. |    |
 | `-passphrase_file` | An alternative to entering the encryption passphrase at a prompt. The value is a the name of a file with a string value which WDT will read to retrieve the passphrase. |    |
 | `-variable_file` | The location and name of the property file containing the variable values for all variables used in the model(s). |    |

--- a/documentation/2.0/content/userguide/tools/kubernetes.md
+++ b/documentation/2.0/content/userguide/tools/kubernetes.md
@@ -45,7 +45,7 @@ spec:
         replicas: 4
 ```
 
-In this example, the value for `domainHome` was set as an input parameter to the extractDomainResource script from the command line. The `kind` and `name` were set to the domain name derived from the topology section of the model, or the default `base_domain`. The cluster entries are pulled from the topology section of the model, and their replica counts were derived from the number of servers for each cluster.
+In this example, the value for `domainHome` was set as an input parameter to the `extractDomainResource` script from the command line. The `kind` and `name` were set to the domain name derived from the topology section of the model, or the default `base_domain`. The cluster entries are pulled from the topology section of the model, and their replica counts were derived from the number of servers for each cluster.
 
 The user is expected to fill in the image and secrets information identified by `--FIX ME--` in the domain resource output.
 
@@ -124,12 +124,12 @@ The [Model Help Tool]({{< relref "/userguide/tools/model_help.md" >}}) can be us
 
 The content in the `kubernetes` section is not generated when a model is discovered by the Discover Domain Tool.  
 
-### Parameter table for extractResources
+### Parameter table for `extractResources`
 | Parameter | Definition | Default |
 | ---- | ---- | ---- |
-| `-archive_file` | The path to the archive file.  If the -model_file argument is not specified, the model file in this archive will be used.  This can also be specified as a comma-separated list of archive files.  The overlapping contents in each archive take precedence over previous archives in the list. |    |
+| `-archive_file` | The path to the archive file.  If the `-model_file` argument is not specified, the model file in this archive will be used.  This can also be specified as a comma-separated list of archive files.  The overlapping contents in each archive take precedence over previous archives in the list. |    |
 | `-domain_home` | (Required) The domain home directory. |    |
 | `-domain_resource_file` | (Required) The location of the extracted domain resource file. |    |
 | `-model_file` | The location of the model file.  This can also be specified as a comma-separated list of model locations, where each successive model layers on top of the previous ones. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set. |    |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set. |    |
 | `-variable_file` | The location of the property file containing the values for variables used in the model. This can also be specified as a comma-separated list of property files, where each successive set of properties layers on top of the previous ones. |    |

--- a/documentation/2.0/content/userguide/tools/model_help.md
+++ b/documentation/2.0/content/userguide/tools/model_help.md
@@ -127,11 +127,11 @@ resources:
                 'SubDeployment-1':
 ```
 
-### Parameter table for model_help
+### Parameter table for `model_help`
 | Parameter | Definition | Default |
-| ---- | ---- | ---- | 
+| ---- | ---- | ---- |
 | `-attributes_only` | List only the attributes for the specified model path. |    |
 | `-folders_only` | List only the folders for the specified model path. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set. |    |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set. |    |
 | `-recursive` | List only the folders for the specified model path, and recursively include the folders below that path. |    |
 | `<model_path>` | The path to the model element to be examined. The format is [^<section^>:][/^<folder^>]... |    |

--- a/documentation/2.0/content/userguide/tools/prepare.md
+++ b/documentation/2.0/content/userguide/tools/prepare.md
@@ -37,13 +37,13 @@ wko-domain.yaml
 You can then customize the `wko_variable.properties` and `create_k8s_secrets.sh` to provide environment-specific values.
 
 
-For more information about additional target environments and options, see [Target environments]({{< relref "/userguide/target_env.md" >}}). 
+For more information about additional target environments and options, see [Target environments]({{< relref "/userguide/target_env.md" >}}).
 
-### Parameter table for prepareModel
+### Parameter table for `prepareModel`
 | Parameter | Definition | Default |
 | ---- | ---- | ---- |
 | `-model_file` | (Required). Location of the model file. This can also be specified as a comma-separated list of models, where each successive model layers on top of the previous ones. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set. |    |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set. |    |
 | `-output_dir` | (Required) Location where to write the output files. |    |
-| `-target` | (Required) Name of the target configuration such as wko, vz, k8s. |    |
+| `-target` | (Required) Name of the target configuration such as `wko`, `vz`, `k8s`. |    |
 | `-variable_file` | The location of the property file containing the values for variables used in the model. This can also be specified as a comma-separated list of property files, where each successive set of properties layers on top of the previous ones. |    |

--- a/documentation/2.0/content/userguide/tools/update.md
+++ b/documentation/2.0/content/userguide/tools/update.md
@@ -19,7 +19,7 @@ In WLST online mode, simply add the information on how to connect to the WebLogi
 
     $ weblogic-deploy\bin\updateDomain.cmd -oracle_home c:\wls12213 -domain_type WLS -domain_home domains\DemoDomain -archive_file DemoDomain.zip -model_file DemoDomain.yaml -variable_file DemoDomain.properties -admin_url t3://127.0.0.1:7001 -admin_user weblogic
 
-As usual, the tool will prompt for the password (it can also be supplied by piping it to standard input of the tool). To bypass the prompt, you can use one of two options. Store the password in an environment variable, and use the variable name with command line option -admin_pass_env. Store the password in a file. Provide the file name with command line option -admin_pass_file.
+As usual, the tool will prompt for the password (it can also be supplied by piping it to standard input of the tool). To bypass the prompt, you can use one of two options. Store the password in an environment variable, and use the variable name with command-line option `-admin_pass_env`. Store the password in a file. Provide the file name with command-line option `-admin_pass_file`.
 
 Unlike the Create Domain Tool, the full domain home directory is specified, rather than the domain's parent directory, because the domain has already been established.
 
@@ -28,32 +28,32 @@ The Update Domain Tool will not attempt to recreate or add schemas for the RCU d
 When running the tool in WLST online mode, the update operation may require server restarts or a domain restart to pick up the changes.  The update operation can also encounter situations where it cannot complete its operation until the domain is restarted.  To communicate these conditions to scripts that may be calling the Update Domain Tool, the shell scripts have two special, non-zero exit codes to communicate these states:
 
 - `103` - The entire domain needs to be restarted.
-- `104` - The domain changes have been canceled because the changes in the model requires a domain restart and -cancel_changes_if_restart_required is specified.
+- `104` - The domain changes have been canceled because the changes in the model requires a domain restart and `-cancel_changes_if_restart_required` is specified.
 
 ### Using an encrypted model
 
-If the model or variables file contains passwords encrypted with the WDT Encryption tool, decrypt the passwords during create with the `-use_encryption` flag on the command line to tell the Update Domain Tool that encryption is being used and to prompt for the encryption passphrase.  As with the database passwords, the tool can also read the passphrase from standard input (for example, `stdin`) to allow the tool to run without any user input.You can bypass the stdin prompt with two other options. Store the passphrase in an environment variable, and use the environment variable name with command line option -passphrase_env. Another option is to create a file containing the passphrase value. Pass this filename with the command line option -passphrase_file
+If the model or variables file contains passwords encrypted with the WDT Encryption tool, decrypt the passwords during create with the `-use_encryption` flag on the command line to tell the Update Domain Tool that encryption is being used and to prompt for the encryption passphrase.  As with the database passwords, the tool can also read the passphrase from standard input (for example, `stdin`) to allow the tool to run without any user input. You can bypass the stdin prompt with two other options. Store the passphrase in an environment variable, and use the environment variable name with command-line option `-passphrase_env`. Another option is to create a file containing the passphrase value. Pass this filename with the command-line option `-passphrase_file`.
 
 ### Using multiple models
 
 The Update Domain Tool supports the use of multiple models, as described in [Using multiple models]({{< relref "/concepts/model#using-multiple-models" >}}).
 
-### Parameter table for updateDomain
+### Parameter table for `updateDomain`
 | Parameter | Definition | Default |
 | ---- | ---- | ---- |
-| `-admin_pass_env` | An alternative to entering the admin password at a prompt. The value is a ENVIRONMENT VARIABLE name that WDT will use to retrieve the password. |    |
+| `-admin_pass_env` | An alternative to entering the admin password at a prompt. The value is a environment variable name that WDT will use to retrieve the password. |    |
 | `-admin_pass_file` | An alternative to entering the admin password at a prompt. The value is a the name of a file that contains a password string that the tool will read to retrieve the password. |    |
 | `-admin_url` | The admin server URL for online update. |    |
-| `-admin_user` | The admin username for online update. |    |
-| `-archive_file` | The path to the archive file to use. If the -model_file argument is not specified, the model file in this archive will be used. This can also be specified as a comma-separated list of archive files. The overlapping contents in each archive take precedence over previous archives in the list. |    |
+| `-admin_user` | The admin user name for online update. |    |
+| `-archive_file` | The path to the archive file to use. If the `-model_file` argument is not specified, the model file in this archive will be used. This can also be specified as a comma-separated list of archive files. The overlapping contents in each archive take precedence over previous archives in the list. |    |
 | `-cancel_changes_if_restart_required` | Cancel the changes if the update requires domain restart. |   |
 | `-discard_current_edit` | Discard all existing domain edits before the update. |    |
 | `-domain_home` | (Required) The location of the existing domain home. |    |
-| `-domain_type` | The type of domain.  (for example, WLS, JRF) | WLS |
+| `-domain_type` | The type of domain.  (for example, `WLS`, `JRF`) | `WLS` |
 | `-model_file` | The location of the model file. This can also be specified as a comma-separated list of model locations, where each successive model layers on top of the previous ones. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set. |    |
-| `-passphrase_env` | An alternative to entering the encryption passphrase at a prompt. The value is a ENVIRONMENT VARIABLE name that WDT will use to retrieve the passphrase. |    |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set. |    |
+| `-passphrase_env` | An alternative to entering the encryption passphrase at a prompt. The value is a environment variable name that WDT will use to retrieve the passphrase. |    |
 | `-passphrase_file` | An alternative to entering the encryption passphrase at a prompt. The value is a the name of a file with a string value which WDT will read to retrieve the passphrase. |    |
-| `-update_dir` | If present, write restart information to this directory as restart.file, or if cancel_changes_if_restart_required used, write non dynamic changes information to non_dynamic_changes file. |    |
+| `-update_dir` | If present, write restart information to this directory as `restart.file`, or if `cancel_changes_if_restart_required` used, write non-dynamic changes information to `non_dynamic_changes` file. |    |
 | `-use_encryption` | One or more of the passwords in the model or variables file(s) are encrypted and must be decrypted. Java 8 or later required for this feature. |    |
 | `-variable_home` | The location of the property file containing the values for variables used in the model. This can also be specified as a comma-separated list of property files, where each successive set of properties layers on top of the previous ones. |    |

--- a/documentation/2.0/content/userguide/tools/validate.md
+++ b/documentation/2.0/content/userguide/tools/validate.md
@@ -100,13 +100,13 @@ Results in output similar to that shown below, if the `simpleear.ear` file is no
 
 The Validate Model Tool supports the use of multiple models, as described in [Using multiple models]({{< relref "/concepts/model#using-multiple-models" >}}).
 
-### Parameter table for validateModel
+### Parameter table for `validateModel`
 | Parameter | Definition | Default |
 | ---- | ---- | ---- |
 | `-archive_file` | The path to the archive file to use.  If the archive file is not provided, validation will only validate the artifacts provided.  This can also be specified as a comma-separated list of archive files.  The overlapping contents in each archive take precedence over previous archives in the list. |    |
-| `-domain_type` | The type of domain.  (for example, WLS, JRF) | WLS |
+| `-domain_type` | The type of domain.  (for example, `WLS`, `JRF`) | `WLS` |
 | `-model_file` | The location of the model file to use.  This can also be specified as a comma-separated list of model locations, where each successive model layers on top of the previous ones. If not specified, the tool will look for the model in the archive. If the model is not found, validation will only validate the artifacts provided. |    |
-| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if ORACLE_HOME environment variable is not set. |    |
-| `-target_mode` | The target WLST mode that the tool should use to validate the model content.  The only valid values are online or offline. | offline |
+| `-oracle_home` | Home directory of the Oracle WebLogic installation. Required if the `ORACLE_HOME` environment variable is not set. |    |
+| `-target_mode` | The target WLST mode that the tool should use to validate the model content.  The only valid values are `online` or `offline`. | `offline` |
 | `-target_version` | The target version of WebLogic Server the tool should use to validate the model content.  This version number can be different than the version being used to run the tool.  | Oracle home version   |
 | `-variable_file` | The location of the property file containing the variable values for all variables used in the model. If the variable file is not provided, validation will only validate the artifacts provided. |    |

--- a/documentation/2.0/content/userguide/tools/variable_injection.md
+++ b/documentation/2.0/content/userguide/tools/variable_injection.md
@@ -88,8 +88,8 @@ Server.soa_server2.ListenPort=8001
 Server.soa_server2.SSL.ListenPort=8002
 ```
 
-To specify the name and location of the variable properties file for the Discover Domain Tool, use the argument `-variable_properties_file` on the command line. Usage of the `variable_properties_file` argument without the presence of the model variable injector file in the `<WLSDEPLOY>/lib` directory will cause an error condition and the tool will exit. If the model variable injector file exists in the directory, but the command-line argument is not used, the variable properties file is created with the following defaults:
-* If the `model_file` command-line argument is used on the Discover Domain Tool run, the properties file name and location will be the same as the model file, with the file extension `.properties`.
+To specify the name and location of the variable properties file for the Discover Domain Tool, use the argument `-variable_properties_file` on the command line. Usage of the `-variable_properties_file` argument without the presence of the model variable injector file in the `<WLSDEPLOY>/lib` directory will cause an error condition and the tool will exit. If the model variable injector file exists in the directory, but the command-line argument is not used, the variable properties file is created with the following defaults:
+* If the `-model_file` command-line argument is used on the Discover Domain Tool run, the properties file name and location will be the same as the model file, with the file extension `.properties`.
 * If only the archive file argument is present, the archive file name and location will be used.
 
 As with the archive and model file, each run of the Discover Domain Tool will overwrite the contents of an existing variable property file with the values from the current run.
@@ -215,11 +215,11 @@ A custom injector for the Administration Server SSL listen port is:
 
 A sample of a `model_variable_injector.json` file and a custom injector JSON file are installed in the `WLSDEPLOY/samples` directory.
 
-### Parameter table for injectVariables
+### Parameter table for `injectVariables`
 | Parameter | Definition | Default |
 | ---- | ---- | ---- |
-| `-archive_file` | The path to the archive file that contains a model in which the variables will be injected. If the -model_file argument is used, this argument will be ignored. |    |
-| `-model_file` | The location of the model file in which variables will be injected. If not specified, the tool will look for the model in the archive file. Either the model_file or the archive_file argument must be provided. |    |
-| `-oracle_home` | Home directory for the Oracle WebLogic installation. This is required unless the ORACLE_HOME environment variable is set. |    |
-| `-variable_injector_file` | The location of the variable injector file which contains the variable injector keywords for this model injection run. If this argument is not provided, the `model_variable_injector.json` file must exist in the lib directory in the WLSDEPLOY_HOME location. |    |
+| `-archive_file` | The path to the archive file that contains a model in which the variables will be injected. If the `-model_file` argument is used, this argument will be ignored. |    |
+| `-model_file` | The location of the model file in which variables will be injected. If not specified, the tool will look for the model in the archive file. Either the `-model_file` or the `-archive_file` argument must be provided. |    |
+| `-oracle_home` | Home directory for the Oracle WebLogic installation. This is required unless the `ORACLE_HOME` environment variable is set. |    |
+| `-variable_injector_file` | The location of the variable injector file which contains the variable injector keywords for this model injection run. If this argument is not provided, the `model_variable_injector.json` file must exist in the `lib` directory in the `WLSDEPLOY_HOME` location. |    |
 | `-variable_properties_file` | The location of the property file in which to store any variable names injected into the model. If this command-line argument is not specified, the variable will be located and named based on the model file or archive file name and location. If the file exists, the file will be updated with new variable values. |    |


### PR DESCRIPTION
According to Oracle style guidelines, "Use of the Monospace Font for in-text code elements: Use monospace/code font for names of arguments, attributes, classes, commands/statements, directories, fields, files, methods, modules, nodes, packages, parameters, properties, roles, and schemas, as well as values."