### PR TITLE
Wdt 608 undo adjudicator code

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/security_provider_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/security_provider_creator.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.
 Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 """
 


### PR DESCRIPTION
fixes Jira 608

Changing adjudicator in versions 12.2.1.3 and below encounters a WLST problem with the xsi type in the config.xml. Have opened  WLST bug 33847230. put changes in to handle version specific problems with the adjudicator.