### PR TITLE
Use JDBCResource name for flattened folder in JDBCDriverParams Properties

### DIFF
--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/JDBCSystemResource.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/JDBCSystemResource.json
@@ -93,7 +93,7 @@
                             "child_folders_type": "multiple",
                             "flattened_folder_data": {
                                 "wlst_type": "Properties",
-                                "name_value": "${NO_NAME_0:%DATASOURCE%}",
+                                "name_value": "${NO_NAME_0:%JDBCRESOURCE%}",
                                 "path_token": "PROPERTIES"
                             },
                             "folders": { },


### PR DESCRIPTION
Tested with different JDBCSystemResources and JDBCResource folder names.

Internal Jira WDT-615
