### PR TITLE
Run code coverage during test phase, but after all other plugins complete

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -89,10 +89,6 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
@@ -166,6 +162,10 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
                         </execution>
                         <execution>
                             <id>report</id>
-                            <phase>post-integration-test</phase>
+                            <phase>test</phase>
                             <goals>
                                 <goal>report</goal>
                             </goals>


### PR DESCRIPTION
Allow the build to generate code coverage reports without having to run the verify step.