### PR TITLE
Fixed missing WLS schema component causing ATP rcu creation failure

### DIFF
--- a/core/src/main/typedefs/JRF-Compact.json
+++ b/core/src/main/typedefs/JRF-Compact.json
@@ -26,7 +26,7 @@
             ],
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "WLS" ]
         },
         "JRF_12CR2": {
             "baseTemplate": "Basic WebLogic Server Domain",
@@ -38,7 +38,7 @@
             ],
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "WLS" ]
         },
         "JRF_12CR2_LAST": {
             "baseTemplate": "Basic WebLogic Server Domain",
@@ -50,7 +50,7 @@
             ],
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "WLS" ]
         }
     },
     "system-elements": {

--- a/core/src/main/typedefs/JRF-Compact.json
+++ b/core/src/main/typedefs/JRF-Compact.json
@@ -26,7 +26,7 @@
             ],
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "STB" ]
         },
         "JRF_12CR2": {
             "baseTemplate": "Basic WebLogic Server Domain",
@@ -38,7 +38,7 @@
             ],
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "STB" ]
         },
         "JRF_12CR2_LAST": {
             "baseTemplate": "Basic WebLogic Server Domain",
@@ -50,7 +50,7 @@
             ],
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "STB" ]
         }
     },
     "system-elements": {

--- a/core/src/main/typedefs/JRF.json
+++ b/core/src/main/typedefs/JRF.json
@@ -61,7 +61,7 @@
             ],
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "WLS" ]
         },
         "JRF_12CR2": {
             "baseTemplate": "Basic WebLogic Server Domain",
@@ -74,7 +74,7 @@
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
             "dynamicClusterServerGroupsToTarget" : [ "WSMPM-DYN-CLUSTER" ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "WLS" ]
         },
         "JRF_12CR2_LAST": {
             "baseTemplate": "Basic WebLogic Server Domain",
@@ -87,7 +87,7 @@
             "customExtensionTemplates": [ ],
             "serverGroupsToTarget": [ "JRF-MAN-SVR", "WSMPM-MAN-SVR" ],
             "dynamicClusterServerGroupsToTarget" : [ "WSMPM-DYN-CLUSTER", "WSM-CACHE-DYN-CLUSTER" ],
-            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB" ]
+            "rcuSchemas": [ "MDS", "IAU", "IAU_VIEWER", "IAU_APPEND", "OPSS", "STB", "WLS" ]
         }
     },
     "system-elements": {


### PR DESCRIPTION
Add JRF schema component WLS to typedefs, I think the scheme is added in 12.2.1 and above for BI?  ATP has  different default table space than regular oracle database.  If the WLS component is not specified in the typedefs for JRF,  then rcu automatically creates the component but with the regular db default table space name internally and results in ORA-01031: insufficient privileges.  This change will force the component in the command line with the correct  tablespace for ATP. 