### PR TITLE
return result in _process_roles_map to fix role edits

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/wlsroles_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/create/wlsroles_helper.py
@@ -97,6 +97,7 @@ class WLSRoles(object):
             result[role] = expression
 
         self.logger.exiting(class_name=self.__class_name, method_name=_method_name)
+        return result
 
     def _update_xacml_role_mapper(self, role_expression_map):
         """


### PR DESCRIPTION
looks like a previous cleanup commit removed the 'return result' line from _process_roles_map() - that removal prevents process_roles() from calling _update_xacml_role_mapper() with the role changes, so WLSRoles entries were not actually doing anything.