### PR TITLE
Set domain type in domain resource templates

### DIFF
--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -62,6 +62,11 @@ def __process_args(args):
     """
     _method_name = '__process_args'
 
+    # if no target type was specified, use wko
+    if CommandLineArgUtil.TARGET_SWITCH not in args:
+        args.append(CommandLineArgUtil.TARGET_SWITCH)
+        args.append('wko')
+
     cla_util = CommandLineArgUtil(_program_name, __required_arguments, __optional_arguments)
     cla_util.set_allow_multiple_models(True)
     argument_map = cla_util.process_args(args, TOOL_TYPE_EXTRACT)
@@ -75,10 +80,6 @@ def __process_args(args):
 
     # allow unresolved tokens and archive entries
     argument_map[CommandLineArgUtil.VALIDATION_METHOD] = validate_configuration.LAX_METHOD
-
-    # if no target type was specified, use wko
-    if CommandLineArgUtil.TARGET_SWITCH not in argument_map:
-        argument_map[CommandLineArgUtil.TARGET_SWITCH] = 'wko'
 
     # warn about deprecated -domain_resource_file argument.
     # not needed once -domain_resource_file is removed and -output_dir moves to __required_arguments.

--- a/core/src/main/python/wlsdeploy/tool/util/targets/additional_output_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/targets/additional_output_helper.py
@@ -41,6 +41,7 @@ DATASOURCE_PREFIX = 'datasourcePrefix'
 DATASOURCES = 'datasources'
 DATASOURCE_NAME = 'datasourceName'
 DATASOURCE_URL = 'url'
+DOMAIN_HOME_SOURCE_TYPE = 'domainHomeSourceType'
 DOMAIN_NAME = 'domainName'
 DOMAIN_PREFIX = 'domainPrefix'
 DOMAIN_TYPE = 'domainType'
@@ -49,6 +50,7 @@ HAS_ADDITIONAL_SECRETS = 'hasAdditionalSecrets'
 HAS_APPLICATIONS = 'hasApplications'
 HAS_CLUSTERS = 'hasClusters'
 HAS_DATASOURCES = 'hasDatasources'
+HAS_MODEL = 'hasModel'
 NAMESPACE = 'namespace'
 REPLICAS = 'replicas'
 RUNTIME_ENCRYPTION_SECRET = "runtimeEncryptionSecret"
@@ -153,6 +155,10 @@ def _build_template_hash(model, model_context, aliases, credential_injector):
     template_hash[DOMAIN_UID] = domain_uid
     template_hash[DOMAIN_PREFIX] = domain_uid
     template_hash[NAMESPACE] = domain_uid
+
+    # domain home source type
+    template_hash[DOMAIN_HOME_SOURCE_TYPE] = target_configuration.get_domain_home_source_name()
+    template_hash[HAS_MODEL] = target_configuration.uses_wdt_model()
 
     # secrets that should not be included in secrets section
     declared_secrets = []

--- a/core/src/main/python/wlsdeploy/util/cla_utils.py
+++ b/core/src/main/python/wlsdeploy/util/cla_utils.py
@@ -21,11 +21,7 @@ from wlsdeploy.exception import exception_helper
 from wlsdeploy.json.json_translator import JsonToPython
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.util import path_utils
-from wlsdeploy.util import validate_configuration
-from wlsdeploy.util.target_configuration import CREDENTIALS_METHOD
-from wlsdeploy.util.target_configuration import CREDENTIALS_METHODS
 from wlsdeploy.util.target_configuration import TargetConfiguration
-from wlsdeploy.util.target_configuration import VALIDATION_METHOD
 from wlsdeploy.util.validate_configuration import VALIDATION_METHODS
 
 # tool type may indicate variations in argument processing
@@ -1115,29 +1111,9 @@ class CommandLineArgUtil(object):
         else:
             try:
                 # verify the file is in proper format
-                # file_handle = open(target_configuration_file)
-                # config_dictionary = eval(file_handle.read())
                 config_dictionary = JsonToPython(target_configuration_file).parse()
                 target_configuration = TargetConfiguration(config_dictionary)
-                validation_method = target_configuration.get_validation_method()
-                if (validation_method is not None) and \
-                        (validation_method not in validate_configuration.VALIDATION_METHODS):
-                    ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                               'WLSDPLY-01648', target_configuration_file,
-                                                               validation_method, VALIDATION_METHOD,
-                                                               ', '.join(validate_configuration.VALIDATION_METHODS))
-                    self._logger.throwing(ex, class_name=self._class_name, method_name=method_name)
-                    raise ex
-
-                credentials_method = target_configuration.get_credentials_method()
-                if (credentials_method is not None) and (credentials_method not in CREDENTIALS_METHODS):
-                    ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                               'WLSDPLY-01648', target_configuration_file,
-                                                               credentials_method, CREDENTIALS_METHOD,
-                                                               ', '.join(CREDENTIALS_METHODS))
-                    self._logger.throwing(ex, class_name=self._class_name, method_name=method_name)
-                    raise ex
-
+                target_configuration.validate_configuration(self.ARG_VALIDATION_ERROR_EXIT_CODE, target_configuration_file)
             except SyntaxError, se:
                 ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
                                                            'WLSDPLY-01644', target_configuration_file, se)

--- a/core/src/main/python/wlsdeploy/util/target_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/target_configuration.py
@@ -182,8 +182,9 @@ class TargetConfiguration(object):
 
     def uses_wdt_model(self):
         """
-        Determine if this configuration uses a WDT model to build the domain.
-        :return: True if a model is used, False otherwise
+        Determine if this configuration will include WDT model content in the output file.
+        WKO builds the domain using this model content for the model-in-image source type.
+        :return: True if a model is included, False otherwise
         """
         source_type = self._get_domain_home_source_type()
         return source_type == MODEL_IN_IMAGE_SOURCE_TYPE

--- a/core/src/main/targetconfigs/templates/vz-application.yaml
+++ b/core/src/main/targetconfigs/templates/vz-application.yaml
@@ -52,7 +52,7 @@ spec:
 
           # WebLogic Image Tool provides domainHome, domainHomeSourceType, and imageName
           domainHome: '{{{domainHome}}}'
-          domainHomeSourceType: '{{{domainHomeSourceType}}}'
+          domainHomeSourceType: {{{domainHomeSourceType}}}
           image: '{{{imageName}}}'
 
           imagePullSecrets:
@@ -62,6 +62,7 @@ spec:
             name: {{{webLogicCredentialsSecret}}}
           configuration:
             introspectorJobActiveDeadlineSeconds: 900
+{{#hasModel}}
             model:
               configMap: {{{domainPrefix}}}-configmap
               domainType: {{{domainType}}}
@@ -74,6 +75,7 @@ spec:
               # used only for model-in-image deployment, can be removed for other types.
               runtimeEncryptionSecret: {{{runtimeEncryptionSecret}}}
 {{/runtimeEncryptionSecret}}
+{{/hasModel}}
 {{#hasAdditionalSecrets}}
 
             secrets:

--- a/core/src/main/targetconfigs/templates/wko-domain.yaml
+++ b/core/src/main/targetconfigs/templates/wko-domain.yaml
@@ -14,7 +14,7 @@ spec:
 
   # The domain home source type
   # Set to PersistentVolume for domain-in-pv, Image for domain-in-image, or FromModel for model-in-image
-  domainHomeSourceType: '{{{domainHomeSourceType}}}'
+  domainHomeSourceType: {{{domainHomeSourceType}}}
 
   # The WebLogic Server Docker image that the Operator uses to start the domain
   image: '{{{imageName}}}'
@@ -77,6 +77,7 @@ spec:
     istio:
       enabled: false
     introspectorJobActiveDeadlineSeconds: 900
+{{#hasModel}}
     model:
       domainType: {{{domainType}}}
 
@@ -88,6 +89,7 @@ spec:
       # used only for model-in-image deployment, can be removed for other types.
       runtimeEncryptionSecret: {{{runtimeEncryptionSecret}}}
 {{/runtimeEncryptionSecret}}
+{{/hasModel}}
 {{#hasAdditionalSecrets}}
 
     # Secrets that are referenced by model yaml macros

--- a/core/src/main/targetconfigs/vz-dii/target.json
+++ b/core/src/main/targetconfigs/vz-dii/target.json
@@ -6,6 +6,7 @@
     },
     "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
     "validation_method" : "lax",
+    "domain_home_source_type" : "dii",
     "credentials_output_method" : "script",
     "exclude_domain_bin_contents": true,
     "additional_output" : "vz-application.yaml"

--- a/core/src/main/targetconfigs/vz-pv/target.json
+++ b/core/src/main/targetconfigs/vz-pv/target.json
@@ -6,6 +6,7 @@
     },
     "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
     "validation_method" : "lax",
+    "domain_home_source_type" : "pv",
     "credentials_output_method" : "script",
     "exclude_domain_bin_contents": true,
     "use_persistent_volume" : true,

--- a/core/src/main/targetconfigs/vz/target.json
+++ b/core/src/main/targetconfigs/vz/target.json
@@ -7,6 +7,7 @@
     },
     "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
     "validation_method" : "lax",
+    "domain_home_source_type" : "mii",
     "credentials_method" : "secrets",
     "credentials_output_method" : "script",
     "exclude_domain_bin_contents": true,

--- a/core/src/main/targetconfigs/wko-dii/target.json
+++ b/core/src/main/targetconfigs/wko-dii/target.json
@@ -6,6 +6,7 @@
   },
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
+  "domain_home_source_type" : "dii",
   "credentials_output_method" : "script",
   "exclude_domain_bin_contents": true,
   "additional_output" : "wko-domain.yaml"

--- a/core/src/main/targetconfigs/wko-pv/target.json
+++ b/core/src/main/targetconfigs/wko-pv/target.json
@@ -6,6 +6,7 @@
   },
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
+  "domain_home_source_type" : "pv",
   "credentials_output_method" : "script",
   "exclude_domain_bin_contents": true,
   "use_persistent_volume" : true,

--- a/core/src/main/targetconfigs/wko/target.json
+++ b/core/src/main/targetconfigs/wko/target.json
@@ -7,6 +7,7 @@
   },
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
+  "domain_home_source_type" : "mii",
   "credentials_method" : "secrets",
   "credentials_output_method" : "script",
   "exclude_domain_bin_contents": true,


### PR DESCRIPTION
Hide the spec / configuration / model section unless the domain source type is model-in-image.
Move target configuration validation to target_configuration.py .
Assign default extract target type before processing arguments.

Internal JIRA WDT-613
