### PR TITLE
Corrected alias name lookup for OracleIdentityCloudIntegrator

### DIFF
--- a/core/src/main/python/wlsdeploy/aliases/alias_constants.py
+++ b/core/src/main/python/wlsdeploy/aliases/alias_constants.py
@@ -179,7 +179,8 @@ AUTHENTICATION_PROVIDER_NAME_MAP = {
         'weblogic.security.providers.authentication.OracleUnifiedDirectoryAuthenticator',
     'OracleVirtualDirectoryAuthenticator':
         'weblogic.security.providers.authentication.OracleVirtualDirectoryAuthenticator',
-    'OracleIdentityCloudIntegrator': 'weblogic.security.providers.authentication.OracleIdentityCloudIntegrator',
+    'weblogic.security.providers.authentication.OracleIdentityCloudIntegrator':
+        'weblogic.security.providers.authentication.OracleIdentityCloudIntegrator',
     'ReadOnlySQLAuthenticator': 'weblogic.security.providers.authentication.ReadOnlySQLAuthenticator',
     'SQLAuthenticator': 'weblogic.security.providers.authentication.SQLAuthenticator',
     'VirtualUserAuthenticator': 'weblogic.security.providers.authentication.VirtualUserAuthenticator',


### PR DESCRIPTION
Offline discover was failing for a domain with this provider.

Partial fix for the offline discovery mentioned in #1126 .
