### PR TITLE
Write missing archive entries from discover to a results file if configured

### DIFF
--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -137,6 +137,11 @@ def __process_archive_filename_arg(argument_map):
 
     if CommandLineArgUtil.SKIP_ARCHIVE_FILE_SWITCH in argument_map or CommandLineArgUtil.REMOTE_SWITCH in argument_map:
         archive_file = WLSDeployArchive.noArchiveFile()
+        if CommandLineArgUtil.ARCHIVE_FILE_SWITCH in argument_map:
+            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                                                       'WLSDPLY-06033')
+            __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
+            raise ex
     else:
         archive_file_name = argument_map[CommandLineArgUtil.ARCHIVE_FILE_SWITCH]
         archive_dir_name = path_utils.get_parent_directory(archive_file_name)
@@ -245,20 +250,6 @@ def __discover(model_context, aliases, credential_injector, helper):
         raise ex
     __disconnect_domain(helper)
 
-    if model_context.is_remote():
-        print ''
-        remote_map = WLSDeployArchive.getRemoteList()
-        if len(remote_map) == 0:
-            message = exception_helper.get_message('WLSDPLY-06030')
-        else:
-            message = exception_helper.get_message('WLSDPLY-06031')
-        print message
-        print ''
-        for key in remote_map:
-            other_map = remote_map[key]
-            wls_archive = other_map[WLSDeployArchive.REMOTE_ARCHIVE_DIR]
-            print key, ' ', wls_archive
-            print ''
     return model
 
 

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -569,6 +569,8 @@ WLSDPLY-06031=Remote discovery created a model that references files or director
   that could not be collected.  Please collect the items at the paths listed below and add them to the archive \
   file at the specified locations.
 WLSDPLY-06032=Model file name was not included in command arguments and either -skip_archive or -remote was included
+WLSDPLY-06033=Archive file name was included in command arguments and either -skip_archive or -remote was selected
+
 # discoverer.py
 WLSDPLY-06100=Find attributes at location {0}
 WLSDPLY-06102=The attributes found at path {0} are {1}

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -570,6 +570,8 @@ WLSDPLY-06031=Remote discovery created a model that references files or director
   file at the specified locations.
 WLSDPLY-06032=Model file name was not included in command arguments and either -skip_archive or -remote was included
 WLSDPLY-06033=Archive file name was included in command arguments and either -skip_archive or -remote was selected
+WLSDPLY-06034=Writing results file {0}
+WLSDPLY-06035=Unable to write the results file specified by environment variable {0}: {1}
 
 # discoverer.py
 WLSDPLY-06100=Find attributes at location {0}


### PR DESCRIPTION
Don't allow -archive_file to be specified with -remote or -skip_archive.
Remove duplicate invalid report section.

Interrnal Jira WDT-646 

Sample output file content:
```
{
    "missingArchiveEntries" : [
        {
            "sourceFile" : "wlsdeploy/sharedLibraries/sample_lib.jar",
            "type" : "SHARED_LIBRARIES",
            "path" : "wlsdeploy/sharedLibraries/sample_lib.jar"
        },
        {
            "sourceFile" : "wlsdeploy/applications/sample_war.war",
            "type" : "APPLICATIONS",
            "path" : "C:/tmp/archives/wlsdeploy/applications/sample_war.war"
        }
    ]
}
```