### PR TITLE
Wdt 636 -  Remove the usage of getDatabaseDefaults for creating JRF domain 

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -1071,9 +1071,6 @@ class DomainCreator(Creator):
         rcu_db_info = rcudbinfo_helper.create(self.model.get_model(), self.model_context, self.aliases)
 
         self.set_rcu_datasource_parameters(rcu_db_info)
-        if self.model_context.get_update_rcu_schema_pass() is True:
-            rcu_helper = RCUHelper(self.model, self.model_context, self.aliases, modifyBootStrapCredential=False)
-            rcu_helper.update_rcu_password()
 
         self.logger.exiting(class_name=self.__class_name, method_name=_method_name)
         return

--- a/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_creator.py
@@ -1157,8 +1157,10 @@ class DomainCreator(Creator):
 
             wlst_path = self.aliases.get_wlst_attributes_path(location)
             self.wlst_helper.cd(wlst_path)
-            orig_user = self.wlst_helper.get('Value')
-            schema_user = re.sub('^DEV_', rcu_prefix + '_', orig_user)
+
+            # Change the schema from the template and just change the prefix
+            template_schema_user = self.wlst_helper.get('Value')
+            schema_user = re.sub('^DEV_', rcu_prefix + '_', template_schema_user)
             wlst_name, wlst_value = \
                 self.aliases.get_wlst_attribute_name_and_value(location, DRIVER_PARAMS_PROPERTY_VALUE,
                                                                schema_user)


### PR DESCRIPTION
This PR changes domain creator not to use getDatabaseDefaults for regular database for JRF domain,  this avoid all the problem with shadow table such as wrong jdbc url is returned.   It reuses the same logic for ATP and SSL database where we update the RCU datasource template with user provided information.