### PR TITLE
Fix deletetarget and nontargetupdate

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -671,7 +671,12 @@ class ApplicationsDeployer(Deployer):
                                 existing_app_targets = dictionary_utils.get_element(existing_app_ref, 'target')
                                 existing_app_targets_set = Set(existing_app_targets)
 
-                                if existing_app_targets_set.issuperset(model_targets_set):
+                                if existing_app_targets_set == model_targets_set:
+                                    self.logger.info('WLSDPLY-09336', src_path,
+                                                     class_name=self._class_name, method_name=_method_name)
+                                    if versioned_name not in stop_and_undeploy_app_list:
+                                        stop_and_undeploy_app_list.append(versioned_name)
+                                elif existing_app_targets_set.issuperset(model_targets_set):
                                     self.__remove_app_from_deployment(model_apps, app)
                                 else:
                                     # Adjust the targets to only the new targets so that existing apps on
@@ -685,8 +690,7 @@ class ApplicationsDeployer(Deployer):
                                     if app_dict['SourcePath'] is None and src_path is not None:
                                         app_dict['SourcePath'] = src_path
                             else:
-                                self.logger.info('WLSDPLY-09336', src_path,
-                                                 class_name=self._class_name, method_name=_method_name)
+                                # same hash but different path, so redeploy it
                                 if versioned_name not in stop_and_undeploy_app_list:
                                     stop_and_undeploy_app_list.append(versioned_name)
                         else:

--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -672,6 +672,7 @@ class ApplicationsDeployer(Deployer):
                                 existing_app_targets_set = Set(existing_app_targets)
 
                                 if existing_app_targets_set == model_targets_set:
+                                    # redeploy the app if everything is the same
                                     self.logger.info('WLSDPLY-09336', src_path,
                                                      class_name=self._class_name, method_name=_method_name)
                                     if versioned_name not in stop_and_undeploy_app_list:

--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -405,13 +405,6 @@ class ApplicationsDeployer(Deployer):
                 absolute_planpath = attributes_map['AbsolutePlanPath']
                 config_targets = self.__get_config_targets()
 
-                # AppRuntimeStateRuntime/AppRuntimeStateRuntime always return the app even if not targeted
-                # skip as if it is not there
-                if len(config_targets) == 0:
-                    continue
-                # There are case in application where absolute source path is not set but sourepath is
-                # if source path is not absolute then we need to add the domain path
-
                 if absolute_planpath is None:
                     absolute_planpath = attributes_map['PlanPath']
 
@@ -666,8 +659,8 @@ class ApplicationsDeployer(Deployer):
                     existing_plan_hash = self.__get_file_hash(plan_path)
                     if model_src_hash == existing_src_hash:
                         if model_plan_hash == existing_plan_hash:
-                            if not (os.path.isabs(src_path) and os.path.isabs(model_src_path) and
-                                    FileUtils.getCanonicalPath(src_path) == FileUtils.getCanonicalPath(model_src_path)):
+                            if (FileUtils.getCanonicalPath(src_path) == FileUtils.getCanonicalPath(model_src_path)):
+
                                 # If model hashes match existing hashes, the application did not change.
                                 # Unless targets were added, there's no need to redeploy.
                                 # If it is an absolute path, there is nothing to compare so assume redeploy

--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -679,7 +679,6 @@ class ApplicationsDeployer(Deployer):
                                 existing_app_targets = dictionary_utils.get_element(existing_app_ref, 'target')
                                 existing_app_targets_set = Set(existing_app_targets)
 
-
                                 if existing_app_targets_set == model_targets_set and len(existing_app_targets_set) > 0:
                                     # redeploy the app if everything is the same
                                     self.logger.info('WLSDPLY-09336', src_path,

--- a/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/applications_deployer.py
@@ -678,7 +678,7 @@ class ApplicationsDeployer(Deployer):
                                     if versioned_name not in stop_and_undeploy_app_list:
                                         stop_and_undeploy_app_list.append(versioned_name)
                                 elif existing_app_targets_set.issuperset(model_targets_set):
-                                    self.__remove_app_from_deployment(model_apps, app)
+                                    self.__remove_app_from_deployment(model_apps, app, "superset")
                                 else:
                                     # Adjust the targets to only the new targets so that existing apps on
                                     # already targeted servers are not impacted.
@@ -831,9 +831,14 @@ class ApplicationsDeployer(Deployer):
             adjusted_targets = ','.join(adjusted_set)
             model_libs[lib][TARGET] = adjusted_targets
 
-    def __remove_app_from_deployment(self, model_dict, app_name):
-        self.logger.info('WLSDPLY-09337', app_name,
-                         class_name=self._class_name, method_name='remove_app_from_deployment')
+    def __remove_app_from_deployment(self, model_dict, app_name, reason="delete"):
+        if "delete" == reason:
+            self.logger.info('WLSDPLY-09337', app_name,
+                             class_name=self._class_name, method_name='remove_app_from_deployment')
+        elif "superset" == reason:
+            self.logger.info('WLSDPLY-09338', app_name,
+                             class_name=self._class_name, method_name='remove_app_from_deployment')
+
         model_dict.pop(app_name)
 
     def __remove_lib_from_deployment(self, model_dict, lib_name):

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1151,6 +1151,8 @@ WLSDPLY-09334=Application {0} not found. Please specify a valid application for 
 WLSDPLY-09335=Undeploying {0} {1} from targets: {2}
 WLSDPLY-09336=Redeployed application {0} because the old and the new binary have the same path.
 WLSDPLY-09337=Removing {0} from model deployment because it is started with a delete notation. It will be undeployed.
+WLSDPLY-09338=Removing {0} from model deployment because the existing application's targets is a superset of \
+  the targets in the model. 
 
 # wlsdeploy/tool/deploy/common_resources_deployer.py
 WLSDPLY-09400=ResourceGroup was specified in the test file but are not supported in WebLogic Server version {0}

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1151,7 +1151,7 @@ WLSDPLY-09334=Application {0} not found. Please specify a valid application for 
 WLSDPLY-09335=Undeploying {0} {1} from targets: {2}
 WLSDPLY-09336=Redeployed application {0} because the old and the new binary have the same path.
 WLSDPLY-09337=Removing {0} from model deployment because it is started with a delete notation. It will be undeployed.
-WLSDPLY-09338=Removing {0} from model deployment because the existing application's targets is a superset of \
+WLSDPLY-09338=Removing {0} from model deployment because the running application's targets are a superset of \
   the targets in the model. 
 
 # wlsdeploy/tool/deploy/common_resources_deployer.py

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1153,6 +1153,8 @@ WLSDPLY-09336=Redeployed application {0} because the old and the new binary have
 WLSDPLY-09337=Removing {0} from model deployment because it is started with a delete notation. It will be undeployed.
 WLSDPLY-09338=Removing {0} from model deployment because the running application's targets are a superset of \
   the targets in the model. 
+WLSDPLY-09339=Removing {0} from model deployment because the running application's has no target and \
+  also no targets in the model. 
 
 # wlsdeploy/tool/deploy/common_resources_deployer.py
 WLSDPLY-09400=ResourceGroup was specified in the test file but are not supported in WebLogic Server version {0}


### PR DESCRIPTION
This PR fixes regression for 1144 (stop application with no target in online update domain) and 937 which failed if the source path is absolute path.  It also causes regression wko online update untargeting applications.