### PR TITLE
JIRA WDT-638 - Should never exit with uncaught exceptions

### DIFF
--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -354,4 +354,4 @@ if __name__ == "__main__":
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name,  _logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name,  _logger)

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -22,7 +22,6 @@ import java.io.FileOutputStream as JFileOutputStream
 import java.io.IOException as JIOException
 import java.io.PrintWriter as JPrintWriter
 from java.lang import System
-from java.lang import Throwable
 from oracle.weblogic.deploy.compare import CompareException
 from oracle.weblogic.deploy.exception import ExceptionHelper
 from oracle.weblogic.deploy.util import CLAException
@@ -352,5 +351,5 @@ def format_message(key, *args):
 if __name__ == "__main__":
     try:
         main()
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name,  _logger)

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -351,5 +351,7 @@ def format_message(key, *args):
 if __name__ == "__main__":
     try:
         main()
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name,  _logger)

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -350,5 +350,5 @@ def format_message(key, *args):
 if __name__ == "__main__":
     try:
         main()
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name,  _logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name,  _logger)

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -11,6 +11,7 @@
 #
 #   If the flag is not provided then all output is written to the standard out.
 #
+import exceptions
 import os
 import sets
 import sys
@@ -21,6 +22,7 @@ import java.io.FileOutputStream as JFileOutputStream
 import java.io.IOException as JIOException
 import java.io.PrintWriter as JPrintWriter
 from java.lang import System
+from java.lang import Throwable
 from oracle.weblogic.deploy.compare import CompareException
 from oracle.weblogic.deploy.exception import ExceptionHelper
 from oracle.weblogic.deploy.util import CLAException
@@ -350,5 +352,5 @@ def format_message(key, *args):
 if __name__ == "__main__":
     try:
         main()
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name,  _logger)

--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -348,4 +348,7 @@ def format_message(key, *args):
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name,  _logger)

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -378,5 +378,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -380,6 +380,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
-

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -376,4 +376,7 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -12,7 +12,6 @@ from java.io import IOException
 from java.lang import IllegalArgumentException
 from java.lang import String
 from java.lang import System
-from java.lang import Throwable
 from oracle.weblogic.deploy.create import CreateException
 from oracle.weblogic.deploy.deploy import DeployException
 from oracle.weblogic.deploy.util import CLAException
@@ -381,6 +380,6 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
 

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -4,12 +4,15 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The main module for the WLSDeploy tool to create empty domains.
 """
+import exceptions
 import os
 import sys
+
 from java.io import IOException
 from java.lang import IllegalArgumentException
 from java.lang import String
 from java.lang import System
+from java.lang import Throwable
 from oracle.weblogic.deploy.create import CreateException
 from oracle.weblogic.deploy.deploy import DeployException
 from oracle.weblogic.deploy.util import CLAException
@@ -378,5 +381,6 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -383,4 +383,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/deploy.py
+++ b/core/src/main/python/deploy.py
@@ -265,4 +265,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/deploy.py
+++ b/core/src/main/python/deploy.py
@@ -4,8 +4,11 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The entry point for the deployApps tool.
 """
+import exceptions
 import os
 import sys
+
+from java.lang import Throwable
 
 from oracle.weblogic.deploy.deploy import DeployException
 from oracle.weblogic.deploy.exception import BundleAwareException
@@ -261,5 +264,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/deploy.py
+++ b/core/src/main/python/deploy.py
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(sys.argv[0])))
 # imports from local packages start here
 from wlsdeploy.aliases.aliases import Aliases
 from wlsdeploy.aliases.wlst_modes import WlstModes
+from wlsdeploy.exception import exception_helper
 from wlsdeploy.exception.expection_types import ExceptionType
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.deploy import deployer_utils
@@ -258,4 +259,7 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/deploy.py
+++ b/core/src/main/python/deploy.py
@@ -262,5 +262,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/deploy.py
+++ b/core/src/main/python/deploy.py
@@ -261,5 +261,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/deploy.py
+++ b/core/src/main/python/deploy.py
@@ -8,8 +8,6 @@ import exceptions
 import os
 import sys
 
-from java.lang import Throwable
-
 from oracle.weblogic.deploy.deploy import DeployException
 from oracle.weblogic.deploy.exception import BundleAwareException
 from oracle.weblogic.deploy.util import CLAException
@@ -264,5 +262,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -645,4 +645,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -11,7 +11,6 @@ from java.io import File
 from java.io import IOException
 from java.lang import IllegalArgumentException
 from java.lang import IllegalStateException
-from java.lang import RuntimeException
 from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.discover import DiscoverException
 from oracle.weblogic.deploy.json import JsonException

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -642,6 +642,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
-

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The entry point for the discoverDomain tool.
 """
+import exceptions
 import os
 import sys
 
@@ -11,6 +12,7 @@ from java.io import File
 from java.io import IOException
 from java.lang import IllegalArgumentException
 from java.lang import IllegalStateException
+from java.lang import Throwable
 from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.discover import DiscoverException
 from oracle.weblogic.deploy.json import JsonException
@@ -234,6 +236,7 @@ def __discover(model_context, aliases, credential_injector, helper):
     model = Model()
     base_location = LocationContext()
     __connect_to_domain(model_context, helper)
+
     try:
         _add_domain_name(base_location, aliases, helper)
         DomainInfoDiscoverer(model_context, model.get_model_domain_info(), base_location, wlst_mode=__wlst_mode,
@@ -640,6 +643,6 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
 

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -367,6 +367,7 @@ def __disconnect_domain(helper):
     _method_name = '__disconnect_domain'
 
     __logger.entering(class_name=_class_name, method_name=_method_name)
+
     if __wlst_mode == WlstModes.ONLINE:
         try:
             helper.disconnect()
@@ -571,7 +572,6 @@ def main(args):
     :return:
     """
     _method_name = 'main'
-
     __logger.entering(class_name=_class_name, method_name=_method_name)
     for index, arg in enumerate(args):
         __logger.finer('sys.argv[{0}] = {1}', str(index), str(arg), class_name=_class_name, method_name=_method_name)
@@ -638,4 +638,8 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -12,7 +12,6 @@ from java.io import File
 from java.io import IOException
 from java.lang import IllegalArgumentException
 from java.lang import IllegalStateException
-from java.lang import Throwable
 from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.discover import DiscoverException
 from oracle.weblogic.deploy.json import JsonException
@@ -643,6 +642,6 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
 

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -11,6 +11,7 @@ from java.io import File
 from java.io import IOException
 from java.lang import IllegalArgumentException
 from java.lang import IllegalStateException
+from java.lang import RuntimeException
 from oracle.weblogic.deploy.aliases import AliasException
 from oracle.weblogic.deploy.discover import DiscoverException
 from oracle.weblogic.deploy.json import JsonException
@@ -640,6 +641,6 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
 

--- a/core/src/main/python/encrypt.py
+++ b/core/src/main/python/encrypt.py
@@ -8,7 +8,7 @@ import exceptions
 import sys
 
 from java.io import IOException
-from java.lang import String, System, Throwable
+from java.lang import String, System
 
 from oracle.weblogic.deploy.encrypt import EncryptionException
 from oracle.weblogic.deploy.util import CLAException
@@ -256,5 +256,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/encrypt.py
+++ b/core/src/main/python/encrypt.py
@@ -255,5 +255,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/encrypt.py
+++ b/core/src/main/python/encrypt.py
@@ -4,10 +4,11 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The main module for the WLSDeploy tool to encrypt passwords.
 """
+import exceptions
 import sys
 
 from java.io import IOException
-from java.lang import String, System
+from java.lang import String, System, Throwable
 
 from oracle.weblogic.deploy.encrypt import EncryptionException
 from oracle.weblogic.deploy.util import CLAException
@@ -255,5 +256,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/encrypt.py
+++ b/core/src/main/python/encrypt.py
@@ -256,5 +256,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/encrypt.py
+++ b/core/src/main/python/encrypt.py
@@ -253,4 +253,7 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/encrypt.py
+++ b/core/src/main/python/encrypt.py
@@ -259,4 +259,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -7,7 +7,6 @@ The entry point for the extractDomainResource tool.
 import exceptions
 import sys
 
-from java.lang import Throwable
 from oracle.weblogic.deploy.deploy import DeployException
 from oracle.weblogic.deploy.util import CLAException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
@@ -162,5 +161,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -4,8 +4,10 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The entry point for the extractDomainResource tool.
 """
+import exceptons
 import sys
 
+from java.lang import Throwable
 from oracle.weblogic.deploy.deploy import DeployException
 from oracle.weblogic.deploy.util import CLAException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
@@ -160,5 +162,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -161,5 +161,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -4,7 +4,7 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The entry point for the extractDomainResource tool.
 """
-import exceptons
+import exceptions
 import sys
 
 from java.lang import Throwable

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -164,4 +164,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -158,4 +158,7 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -160,5 +160,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -4,7 +4,7 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The entry point for the modelHelp tool.
 """
-import excpetions
+import exceptions
 import os
 import sys
 

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -137,5 +137,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -4,8 +4,12 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The entry point for the modelHelp tool.
 """
+import excpetions
 import os
 import sys
+
+from java.lang import Throwable
+
 from oracle.weblogic.deploy.util import CLAException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
 
@@ -135,5 +139,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -140,4 +140,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -133,4 +133,7 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -135,5 +135,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -8,8 +8,6 @@ import exceptions
 import os
 import sys
 
-from java.lang import Throwable
-
 from oracle.weblogic.deploy.util import CLAException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
 
@@ -139,5 +137,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -113,5 +113,7 @@ if __name__ == "__main__" or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main()
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -112,5 +112,5 @@ if __name__ == "__main__" or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main()
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -11,8 +11,6 @@ import exceptions
 import sys
 import traceback
 
-from java.lang import Throwable
-
 from oracle.weblogic.deploy.util import CLAException
 from oracle.weblogic.deploy.util import PyWLSTException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
@@ -115,5 +113,5 @@ if __name__ == "__main__" or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main()
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -15,6 +15,7 @@ from oracle.weblogic.deploy.util import PyWLSTException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
 
 from oracle.weblogic.deploy.prepare import PrepareException
+from wlsdeploy.exception import exception_helper
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.prepare.model_preparer import ModelPreparer
 from wlsdeploy.tool.util import model_context_helper
@@ -109,4 +110,7 @@ def main():
 
 if __name__ == "__main__" or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main()
+    try:
+        main()
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -7,9 +7,12 @@
 #
 #   This code prepare a list of models for deploying to WebLogic Kubernetes Operator Environment.
 
+import exceptions
+import sys
 import traceback
 
-import sys
+from java.lang import Throwable
+
 from oracle.weblogic.deploy.util import CLAException
 from oracle.weblogic.deploy.util import PyWLSTException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
@@ -112,5 +115,5 @@ if __name__ == "__main__" or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main()
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -116,4 +116,4 @@ if __name__ == "__main__" or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/update.py
+++ b/core/src/main/python/update.py
@@ -8,8 +8,6 @@ import exceptions
 import os
 import sys
 
-from java.lang import Throwable
-
 from oracle.weblogic.deploy.deploy import DeployException
 from oracle.weblogic.deploy.exception import BundleAwareException
 from oracle.weblogic.deploy.util import CLAException
@@ -314,5 +312,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/update.py
+++ b/core/src/main/python/update.py
@@ -312,5 +312,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/update.py
+++ b/core/src/main/python/update.py
@@ -309,4 +309,7 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/update.py
+++ b/core/src/main/python/update.py
@@ -4,8 +4,11 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The entry point for the updateDomain tool.
 """
+import exceptions
 import os
 import sys
+
+from java.lang import Throwable
 
 from oracle.weblogic.deploy.deploy import DeployException
 from oracle.weblogic.deploy.exception import BundleAwareException
@@ -311,5 +314,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/update.py
+++ b/core/src/main/python/update.py
@@ -311,5 +311,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/update.py
+++ b/core/src/main/python/update.py
@@ -315,4 +315,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -196,4 +196,7 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -9,7 +9,6 @@ import copy
 import exceptions
 import sys
 
-from java.lang import Throwable
 from java.util.logging import Level
 
 from oracle.weblogic.deploy.logging import WLSDeployLogEndHandler
@@ -202,5 +201,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -4,8 +4,12 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The WLS Deploy tooling entry point for the validateModel tool.
 """
+
 import copy
+import exceptions
 import sys
+
+from java.lang import Throwable
 from java.util.logging import Level
 
 from oracle.weblogic.deploy.logging import WLSDeployLogEndHandler
@@ -198,5 +202,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -204,4 +204,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -198,5 +198,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -201,5 +201,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/variable_inject.py
+++ b/core/src/main/python/variable_inject.py
@@ -206,5 +206,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except:
-        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)
+    except Exception, ex:
+        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/variable_inject.py
+++ b/core/src/main/python/variable_inject.py
@@ -207,5 +207,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except (exceptions.Exception, Throwable), ex:
+    except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/variable_inject.py
+++ b/core/src/main/python/variable_inject.py
@@ -4,6 +4,7 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
 
 The entry point for the injectVariables tool.
 """
+import exceptions
 import sys
 
 from java.io import File
@@ -206,5 +207,5 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
-    except Exception, ex:
+    except (exceptions.Exception, Throwable), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/variable_inject.py
+++ b/core/src/main/python/variable_inject.py
@@ -204,4 +204,7 @@ def main(args):
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
-    main(sys.argv)
+    try:
+        main(sys.argv)
+    except:
+        exception_helper.__handleUnexpectedException(sys.exc_info(), _program_name, _class_name, __logger)

--- a/core/src/main/python/variable_inject.py
+++ b/core/src/main/python/variable_inject.py
@@ -207,5 +207,7 @@ if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)
     try:
         main(sys.argv)
+    except exceptions.SystemExit, ex:
+        raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
         exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/variable_inject.py
+++ b/core/src/main/python/variable_inject.py
@@ -210,4 +210,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handleUnexpectedException(ex, _program_name, _class_name, __logger)
+        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/wlsdeploy/exception/exception_helper.py
+++ b/core/src/main/python/wlsdeploy/exception/exception_helper.py
@@ -31,6 +31,8 @@ import oracle.weblogic.deploy.validate.ValidateException as ValidateException
 import oracle.weblogic.deploy.yaml.YamlException as JYamlException
 
 from wlsdeploy.exception.expection_types import ExceptionType
+from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util import tool_exit
 
 _EXCEPTION_TYPE_MAP = {
     ExceptionType.ALIAS:                 'create_alias_exception',
@@ -462,3 +464,29 @@ def _return_exception_params(*args, **kwargs):
     arg_list = list(args)
     error = kwargs.pop('error', None)
     return arg_list, error
+
+def __log_and_exit(logger, exit_code, class_name):
+    """
+    Helper method to log the exiting message and call sys.exit()
+    :param logger:  the logger to use
+    :param exit_code: the exit code to use
+    :param class_name: the class name to pass  to the logger
+    """
+    logger.exiting(result=exit_code, class_name=class_name, method_name=None)
+    tool_exit.end(None, exit_code)
+
+def __handleUnexpectedException(ex, program_name, class_name, logger):
+    """
+    Helper method to log and unexpected exception with exiting message and call sys.exit()
+    Note that the user sees the 'Unexpected' message along with the exception, but no stack trace.
+    The stack trace goes to the log
+    :param ex:  the exception thrown
+    :param program_name: the program where it occurred
+    :param class_name: the class where it occurred
+    :param logger: the logger to use
+    """
+    exc_type, exc_obj, exc_tb = sys.exc_info()
+    ee_string = traceback.format_exception(exc_type, exc_obj, exc_tb)
+    logger.severe('WLSDPLY-20035', program_name, exc_obj)
+    logger.finer('WLSDPLY-20036', program_name, ee_string)
+    __log_and_exit(logger, CommandLineArgUtil.PROG_ERROR_EXIT_CODE, class_name)

--- a/core/src/main/python/wlsdeploy/exception/exception_helper.py
+++ b/core/src/main/python/wlsdeploy/exception/exception_helper.py
@@ -486,5 +486,13 @@ def __handleUnexpectedException(ex, program_name, class_name, logger):
     :param logger: the logger to use
     """
     logger.severe('WLSDPLY-20035', program_name, ex)
-    logger.finer('WLSDPLY-20036', program_name, ex.stackTrace)
+
+    if hasattr(ex, 'stackTrace'):
+        # this works best for java exceptions, and gets the full stacktrace all the way back to weblogic.WLST
+        logger.finer('WLSDPLY-20036', program_name, ex.stackTrace)
+    else:
+        # this is for Python exceptions
+        # Note: since this is Python 2, it seems we can only get the traceback object via sys.exc_info, and of course only
+        # while in the except block handling code
+        logger.finer('WLSDPLY-20036', program_name, traceback.format_exception(type(ex), ex, sys.exc_info()[2]))
     __log_and_exit(logger, CommandLineArgUtil.PROG_ERROR_EXIT_CODE, class_name)

--- a/core/src/main/python/wlsdeploy/exception/exception_helper.py
+++ b/core/src/main/python/wlsdeploy/exception/exception_helper.py
@@ -485,8 +485,6 @@ def __handleUnexpectedException(ex, program_name, class_name, logger):
     :param class_name: the class where it occurred
     :param logger: the logger to use
     """
-    exc_type, exc_obj, exc_tb = sys.exc_info()
-    ee_string = traceback.format_exception(exc_type, exc_obj, exc_tb)
-    logger.severe('WLSDPLY-20035', program_name, exc_obj)
-    logger.finer('WLSDPLY-20036', program_name, ee_string)
+    logger.severe('WLSDPLY-20035', program_name, ex)
+    logger.finer('WLSDPLY-20036', program_name, ex.stackTrace)
     __log_and_exit(logger, CommandLineArgUtil.PROG_ERROR_EXIT_CODE, class_name)

--- a/core/src/main/python/wlsdeploy/exception/exception_helper.py
+++ b/core/src/main/python/wlsdeploy/exception/exception_helper.py
@@ -485,7 +485,7 @@ def __handleUnexpectedException(ex, program_name, class_name, logger):
     :param class_name: the class where it occurred
     :param logger: the logger to use
     """
-    logger.severe('WLSDPLY-20035', program_name, ex)
+    logger.severe('WLSDPLY-20035', program_name, sys.exc_info()[0])
 
     if hasattr(ex, 'stackTrace'):
         # this works best for java exceptions, and gets the full stacktrace all the way back to weblogic.WLST

--- a/core/src/main/python/wlsdeploy/exception/exception_helper.py
+++ b/core/src/main/python/wlsdeploy/exception/exception_helper.py
@@ -475,7 +475,7 @@ def __log_and_exit(logger, exit_code, class_name):
     logger.exiting(result=exit_code, class_name=class_name, method_name=None)
     tool_exit.end(None, exit_code)
 
-def __handleUnexpectedException(ex, program_name, class_name, logger):
+def __handle_unexpected_exception(ex, program_name, class_name, logger):
     """
     Helper method to log and unexpected exception with exiting message and call sys.exit()
     Note that the user sees the 'Unexpected' message along with the exception, but no stack trace.

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1671,6 +1671,8 @@ WLSDPLY-20031={0} specified Variable File {1} is not a valid file: {2}
 WLSDPLY-20032=No model specified and no model in archive, no validation performed
 WLSDPLY-20033=Applying filter with name "{0}"
 WLSDPLY-20034=Applying filter with ID "{0}"
+WLSDPLY-20035={0} encountered an unexpected runtime exception.  Please file an issue on GitHub and attach the log file and stdout. Error: {1}
+WLSDPLY-20036={0} encountered an unexpected runtime exception.  Stacktrace: {1}
 
 # Messages for internal filters
 WLSDPLY-20201=Unsupported attribute {0} at location {1} removed from model

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1671,7 +1671,7 @@ WLSDPLY-20031={0} specified Variable File {1} is not a valid file: {2}
 WLSDPLY-20032=No model specified and no model in archive, no validation performed
 WLSDPLY-20033=Applying filter with name "{0}"
 WLSDPLY-20034=Applying filter with ID "{0}"
-WLSDPLY-20035={0} encountered an unexpected runtime exception.  Please file an issue on GitHub and attach the log file and stdout. Error: {1}
+WLSDPLY-20035={0} encountered an unexpected runtime exception.  Please file an issue on GitHub and attach the log file and stdout. Exception: {1}
 WLSDPLY-20036={0} encountered an unexpected runtime exception.  Stacktrace: {1}
 
 # Messages for internal filters


### PR DESCRIPTION
Created a try/except around mains of discover.py, create.py, etc.  to deal with unanticipated exceptions.  Inform user of the issue, and request they create an issue, attaching the log and standard output.  Two different messages are created, one for the user without a stack trace, and one for the log with a stack trace.