### PR TITLE
refactor exit codes to prevent circular imports for CommandLineArgUtil

### DIFF
--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -44,6 +44,7 @@ from wlsdeploy.util import cla_helper
 from wlsdeploy.util import validate_configuration
 from wlsdeploy.util import variables
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model_context import ModelContext
 from wlsdeploy.util.model_translator import FileToPython
 from wlsdeploy.yaml.yaml_translator import PythonToYaml
@@ -317,7 +318,7 @@ def main():
 
     except CLAException, ex:
         exit_code = 2
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             _logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                            class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -43,6 +43,7 @@ from wlsdeploy.util import getcreds
 from wlsdeploy.util import tool_exit
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.cla_utils import TOOL_TYPE_CREATE
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
 from wlsdeploy.tool.create import atp_helper
 from wlsdeploy.tool.create import ssl_helper
@@ -128,7 +129,7 @@ def __process_java_home_arg(optional_arg_map):
         try:
             java_home = FileUtils.validateExistingDirectory(java_home_name)
         except IllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-12400', _program_name, java_home_name,
                                                        iae.getLocalizedMessage(), error=iae)
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
@@ -149,7 +150,7 @@ def __process_domain_location_args(optional_arg_map):
     has_parent = CommandLineArgUtil.DOMAIN_PARENT_SWITCH in optional_arg_map
 
     if (has_home and has_parent) or (not has_home and not has_parent):
-        ex = exception_helper.create_cla_exception(CommandLineArgUtil.USAGE_ERROR_EXIT_CODE,
+        ex = exception_helper.create_cla_exception(ExitCode.USAGE_ERROR,
                                                    'WLSDPLY-20025', _program_name,
                                                    CommandLineArgUtil.DOMAIN_PARENT_SWITCH,
                                                    CommandLineArgUtil.DOMAIN_HOME_SWITCH)
@@ -183,7 +184,7 @@ def __process_rcu_args(optional_arg_map, domain_type, domain_typedef):
                     try:
                         password = getcreds.getpass('WLSDPLY-12403')
                     except IOException, ioe:
-                        ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                        ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                                    'WLSDPLY-12404', ioe.getLocalizedMessage(),
                                                                    error=ioe)
                         __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
@@ -193,14 +194,14 @@ def __process_rcu_args(optional_arg_map, domain_type, domain_typedef):
                     try:
                         password = getcreds.getpass('WLSDPLY-12405')
                     except IOException, ioe:
-                        ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                        ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                                    'WLSDPLY-12406', ioe.getLocalizedMessage(),
                                                                    error=ioe)
                         __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
                         raise ex
                     optional_arg_map[CommandLineArgUtil.RCU_SCHEMA_PASS_SWITCH] = String(password)
             else:
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.USAGE_ERROR_EXIT_CODE,
+                ex = exception_helper.create_cla_exception(ExitCode.USAGE_ERROR,
                                                            'WLSDPLY-12407', _program_name,
                                                            CommandLineArgUtil.RCU_DB_SWITCH,
                                                            CommandLineArgUtil.RCU_PREFIX_SWITCH)
@@ -223,7 +224,7 @@ def __process_opss_args(optional_arg_map):
         try:
             passphrase = getcreds.getpass('WLSDPLY-20027')
         except IOException, ioe:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-20028', ioe.getLocalizedMessage(), error=ioe)
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
@@ -259,7 +260,7 @@ def validate_rcu_args_and_model(model_context, model, archive_helper, aliases):
                     else:
                         __logger.severe('WLSDPLY-12411', error=None, class_name=_class_name, method_name=_method_name)
                         cla_helper.clean_up_temp_files()
-                        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+                        tool_exit.end(model_context, ExitCode.ERROR)
 
         else:
             if model_context.get_domain_typedef().required_rcu():
@@ -267,7 +268,7 @@ def validate_rcu_args_and_model(model_context, model, archive_helper, aliases):
                     __logger.severe('WLSDPLY-12408', model_context.get_domain_type(), CommandLineArgUtil.RCU_DB_SWITCH,
                                     CommandLineArgUtil.RCU_PREFIX_SWITCH)
                     cla_helper.clean_up_temp_files()
-                    tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+                    tool_exit.end(model_context, ExitCode.ERROR)
 
     return has_atpdbinfo, has_ssldbinfo
 
@@ -303,13 +304,13 @@ def main(args):
 
     WlstHelper(ExceptionType.CREATE).silence()
 
-    exit_code = CommandLineArgUtil.PROG_OK_EXIT_CODE
+    exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
         exit_code = ex.getExitCode()
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
@@ -351,25 +352,25 @@ def main(args):
         __logger.severe('WLSDPLY-12409', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     except CreateException, ex:
         __logger.severe('WLSDPLY-12409', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     except IOException, ex:
         __logger.severe('WLSDPLY-12409', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     except DeployException, ex:
         __logger.severe('WLSDPLY-12410', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     cla_helper.clean_up_temp_files()
 

--- a/core/src/main/python/deploy.py
+++ b/core/src/main/python/deploy.py
@@ -29,6 +29,7 @@ from wlsdeploy.tool.util.wlst_helper import WlstHelper
 from wlsdeploy.util import cla_helper
 from wlsdeploy.util import tool_exit
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model import Model
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
 
@@ -148,7 +149,7 @@ def __deploy_online(model, model_context, aliases):
 
     exit_code = deployer_utils.online_check_save_activate(model_context)
 
-    if exit_code != CommandLineArgUtil.PROG_CANCEL_CHANGES_IF_RESTART_EXIT_CODE:
+    if exit_code != ExitCode.CANCEL_CHANGES_IF_RESTART:
         model_deployer.deploy_applications(model, model_context, aliases, wlst_mode=__wlst_mode)
 
     try:
@@ -225,13 +226,13 @@ def main(args):
 
     __wlst_helper.silence()
 
-    exit_code = CommandLineArgUtil.PROG_OK_EXIT_CODE
+    exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
         exit_code = ex.getExitCode()
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
@@ -251,7 +252,7 @@ def main(args):
         __logger.severe('WLSDPLY-09015', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     cla_helper.clean_up_temp_files()
 

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -55,6 +55,7 @@ from wlsdeploy.util import path_utils
 from wlsdeploy.util import tool_exit
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.cla_utils import TOOL_TYPE_DISCOVER
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model import Model
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
 from wlsdeploy.util import target_configuration_helper
@@ -124,11 +125,11 @@ def __process_model_archive_args(argument_map):
     if CommandLineArgUtil.ARCHIVE_FILE_SWITCH not in argument_map:
         if CommandLineArgUtil.SKIP_ARCHIVE_FILE_SWITCH not in argument_map and \
             CommandLineArgUtil.REMOTE_SWITCH not in argument_map:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.USAGE_ERROR_EXIT_CODE, 'WLSDPLY-06028')
+            ex = exception_helper.create_cla_exception(ExitCode.USAGE_ERROR, 'WLSDPLY-06028')
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
         if CommandLineArgUtil.MODEL_FILE_SWITCH not in argument_map:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.USAGE_ERROR_EXIT_CODE, 'WLSDPLY-06029')
+            ex = exception_helper.create_cla_exception(ExitCode.USAGE_ERROR, 'WLSDPLY-06029')
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
 
@@ -144,7 +145,7 @@ def __process_archive_filename_arg(argument_map):
     if CommandLineArgUtil.SKIP_ARCHIVE_FILE_SWITCH in argument_map or CommandLineArgUtil.REMOTE_SWITCH in argument_map:
         archive_file = WLSDeployArchive.noArchiveFile()
         if CommandLineArgUtil.ARCHIVE_FILE_SWITCH in argument_map:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-06033')
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
@@ -152,14 +153,14 @@ def __process_archive_filename_arg(argument_map):
         archive_file_name = argument_map[CommandLineArgUtil.ARCHIVE_FILE_SWITCH]
         archive_dir_name = path_utils.get_parent_directory(archive_file_name)
         if os.path.exists(archive_dir_name) is False:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-06026', archive_file_name)
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
         try:
             archive_file = WLSDeployArchive(archive_file_name)
         except (IllegalArgumentException, IllegalStateException), ie:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-06013', _program_name, archive_file_name,
                                                        ie.getLocalizedMessage(), error=ie)
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
@@ -182,7 +183,7 @@ def __process_variable_filename_arg(optional_arg_map):
         try:
             FileUtils.validateWritableFile(variable_injector_file_name)
         except IllegalArgumentException, ie:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-06021',
                                                        optional_arg_map[CommandLineArgUtil.VARIABLE_FILE_SWITCH],
                                                        variable_injector_file_name,
@@ -581,13 +582,13 @@ def main(args):
     helper = WlstHelper(ExceptionType.DISCOVER)
     helper.silence()
 
-    exit_code = CommandLineArgUtil.PROG_OK_EXIT_CODE
+    exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
         exit_code = ex.getExitCode()
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
 
@@ -600,7 +601,7 @@ def main(args):
     except DiscoverException, ex:
         __logger.severe('WLSDPLY-06010', _program_name, model_context.get_archive_file_name(),
                         ex.getLocalizedMessage(), error=ex, class_name=_class_name, method_name=_method_name)
-        __log_and_exit(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE, _class_name, _method_name)
+        __log_and_exit(model_context, ExitCode.ERROR, _class_name, _method_name)
 
     aliases = Aliases(model_context, wlst_mode=__wlst_mode, exception_type=ExceptionType.DISCOVER)
     model = None
@@ -623,7 +624,7 @@ def main(args):
         __logger.severe('WLSDPLY-06011', _program_name, model_context.get_domain_name(),
                         model_context.get_domain_home(), ex.getLocalizedMessage(),
                         error=ex, class_name=_class_name, method_name=_method_name)
-        __log_and_exit(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE, _class_name, _method_name)
+        __log_and_exit(model_context, ExitCode.ERROR, _class_name, _method_name)
 
     try:
         __persist_model(model, model_context)
@@ -631,7 +632,7 @@ def main(args):
     except TranslateException, ex:
         __logger.severe('WLSDPLY-20024', _program_name, model_context.get_archive_file_name(), ex.getLocalizedMessage(),
                         error=ex, class_name=_class_name, method_name=_method_name)
-        __log_and_exit(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE, _class_name, _method_name)
+        __log_and_exit(model_context, ExitCode.ERROR, _class_name, _method_name)
 
     __close_archive(model_context)
 

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -25,6 +25,7 @@ from wlsdeploy.util import tool_exit
 from wlsdeploy.util import validate_configuration
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.cla_utils import TOOL_TYPE_EXTRACT
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model import Model
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
 
@@ -88,7 +89,7 @@ def __process_args(args):
         __logger.warning('WLSDPLY-10040', CommandLineArgUtil.DOMAIN_RESOURCE_FILE_SWITCH,
                          CommandLineArgUtil.OUTPUT_DIR_SWITCH, class_name=_class_name, method_name=_method_name)
     elif CommandLineArgUtil.OUTPUT_DIR_SWITCH not in argument_map:
-        ex = exception_helper.create_cla_exception(CommandLineArgUtil.USAGE_ERROR_EXIT_CODE, 'WLSDPLY-20005',
+        ex = exception_helper.create_cla_exception(ExitCode.USAGE_ERROR, 'WLSDPLY-20005',
                                                    _program_name, CommandLineArgUtil.OUTPUT_DIR_SWITCH,
                                                    class_name=_class_name, method_name=_method_name)
         __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
@@ -123,13 +124,13 @@ def main(args):
     for index, arg in enumerate(args):
         __logger.finer('sys.argv[{0}] = {1}', str(index), str(arg), class_name=_class_name, method_name=_method_name)
 
-    exit_code = CommandLineArgUtil.PROG_OK_EXIT_CODE
+    exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
         exit_code = ex.getExitCode()
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
@@ -149,7 +150,7 @@ def main(args):
         __logger.severe('WLSDPLY-09015', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     cla_helper.clean_up_temp_files()
 

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -21,6 +21,7 @@ from wlsdeploy.tool.modelhelp.model_help_utils import ControlOptions
 from wlsdeploy.tool.util import model_context_helper
 from wlsdeploy.util import cla_helper
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 
 _program_name = 'modelHelp'
 _class_name = 'model_help'
@@ -60,7 +61,7 @@ def __process_args(args):
         if key in argument_map:
             if found:
                 types_text = ', '.join(__output_types)
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.USAGE_ERROR_EXIT_CODE,
+                ex = exception_helper.create_cla_exception(ExitCode.USAGE_ERROR,
                                                            'WLSDPLY-10100', types_text)
                 __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
                 raise ex
@@ -97,7 +98,7 @@ def print_help(model_path, model_context):
     printer.print_model_help(model_path, control_option)
 
     __logger.exiting(class_name=_class_name, method_name=_method_name)
-    return CommandLineArgUtil.PROG_OK_EXIT_CODE
+    return ExitCode.OK
 
 
 def main(args):
@@ -115,7 +116,7 @@ def main(args):
         model_context = __process_args(args)
     except CLAException, ex:
         exit_code = ex.getExitCode()
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
@@ -127,7 +128,7 @@ def main(args):
     except CLAException, ve:
         __logger.severe('WLSDPLY-10112', _program_name, ve.getLocalizedMessage(), error=ve,
                         class_name=_class_name, method_name=_method_name)
-        sys.exit(CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        sys.exit(ExitCode.ERROR)
 
     __logger.exiting(result=exit_code, class_name=_class_name, method_name=_method_name)
     sys.exit(exit_code)

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -86,10 +86,10 @@ def main():
 
         obj = ModelPreparer(model_files, model_context, _outputdir)
         obj.prepare_models()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_OK_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.OK)
 
     except CLAException, ex:
-        exit_code = CommandLineArgUtil.PROG_ERROR_EXIT_CODE
+        exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
@@ -99,14 +99,14 @@ def main():
         cla_helper.clean_up_temp_files()
         __logger.severe('WLSDPLY-05801', ex.getLocalizedMessage(), error=ex, class_name=_class_name,
                         method_name=_method_name)
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     except Exception, ex:
         cla_helper.clean_up_temp_files()
         message = str(sys.exc_type) + ': ' + str(sys.exc_value)
         __logger.severe('WLSDPLY-05801', message, error=ex, class_name=_class_name,
                         method_name=_method_name)
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
 
 if __name__ == "__main__" or __name__ == 'main':

--- a/core/src/main/python/update.py
+++ b/core/src/main/python/update.py
@@ -31,6 +31,7 @@ from wlsdeploy.tool.util.rcu_helper import RCUHelper
 from wlsdeploy.util import cla_helper
 from wlsdeploy.util import tool_exit
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model import Model
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
 
@@ -175,7 +176,7 @@ def __update_online(model, model_context, aliases):
     exit_code = deployer_utils.online_check_save_activate(model_context)
     # if user requested cancel changes if restart required stops
 
-    if exit_code != CommandLineArgUtil.PROG_CANCEL_CHANGES_IF_RESTART_EXIT_CODE:
+    if exit_code != ExitCode.CANCEL_CHANGES_IF_RESTART:
         model_deployer.deploy_applications(model, model_context, aliases, wlst_mode=__wlst_mode)
 
     try:
@@ -274,13 +275,13 @@ def main(args):
 
     __wlst_helper.silence()
 
-    exit_code = CommandLineArgUtil.PROG_OK_EXIT_CODE
+    exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
         exit_code = ex.getExitCode()
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
@@ -300,7 +301,7 @@ def main(args):
         __logger.severe('WLSDPLY-09015', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     cla_helper.clean_up_temp_files()
 

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -35,6 +35,7 @@ from wlsdeploy.util import tool_exit
 from wlsdeploy.util import validate_configuration
 from wlsdeploy.util import variables
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
 
 
@@ -92,7 +93,7 @@ def __process_model_args(argument_map):
         if method == validate_configuration.LAX_METHOD:
             __logger.info('WLSDPLY-20032', _program_name, class_name=_class_name, method_name=_method_name)
             model_context = model_context_helper.create_exit_context(_program_name)
-            tool_exit.end(model_context, CommandLineArgUtil.PROG_OK_EXIT_CODE)
+            tool_exit.end(model_context, ExitCode.OK)
         raise ce
     return
 
@@ -158,13 +159,13 @@ def main(args):
     for index, arg in enumerate(args):
         __logger.finer('sys.argv[{0}] = {1}', str(index), arg, class_name=_class_name, method_name=_method_name)
 
-    exit_code = CommandLineArgUtil.PROG_OK_EXIT_CODE
+    exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
         exit_code = ex.getExitCode()
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
@@ -182,12 +183,12 @@ def main(args):
             if summary_handler is not None:
                 summary_level = summary_handler.getMaximumMessageLevel()
                 if summary_level == Level.SEVERE:
-                    exit_code = CommandLineArgUtil.PROG_ERROR_EXIT_CODE
+                    exit_code = ExitCode.ERROR
                 elif summary_level == Level.WARNING:
-                    exit_code = CommandLineArgUtil.PROG_WARNING_EXIT_CODE
+                    exit_code = ExitCode.WARNING
 
     except ValidateException, ve:
-        exit_code = CommandLineArgUtil.PROG_ERROR_EXIT_CODE
+        exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-20000', _program_name, ve.getLocalizedMessage(), error=ve,
                         class_name=_class_name, method_name=_method_name)
 

--- a/core/src/main/python/variable_inject.py
+++ b/core/src/main/python/variable_inject.py
@@ -25,6 +25,7 @@ from wlsdeploy.tool.util import model_context_helper
 from wlsdeploy.tool.util.variable_injector import VariableInjector
 from wlsdeploy.util import model_translator, cla_helper
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model import Model
 from wlsdeploy.util.model_translator import FileToPython
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
@@ -166,14 +167,14 @@ def main(args):
     for index, arg in enumerate(args):
         __logger.finer('sys.argv[{0}] = {1}', str(index), str(arg), class_name=_class_name, method_name=_method_name)
 
-    exit_code = CommandLineArgUtil.PROG_OK_EXIT_CODE
+    exit_code = ExitCode.OK
 
     model_context = None
     try:
         model_context = __process_args(args)
     except CLAException, ex:
         exit_code = ex.getExitCode()
-        if exit_code != CommandLineArgUtil.HELP_EXIT_CODE:
+        if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         __log_and_exit(exit_code, _class_name, _method_name)
@@ -184,7 +185,7 @@ def main(args):
     except TranslateException, te:
         __logger.severe('WLSDPLY-20009', _program_name, model_file, te.getLocalizedMessage(), error=te,
                         class_name=_class_name, method_name=_method_name)
-        sys.exit(CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        sys.exit(ExitCode.ERROR)
 
     inserted, model = __inject(model, model_context)
     if inserted:
@@ -195,7 +196,7 @@ def main(args):
         except TranslateException, ex:
             __logger.severe('WLSDPLY-20024', _program_name, model_context.get_archive_file_name(),
                             ex.getLocalizedMessage(), error=ex, class_name=_class_name, method_name=_method_name)
-            __log_and_exit(CommandLineArgUtil.PROG_ERROR_EXIT_CODE, _class_name, _method_name)
+            __log_and_exit(ExitCode.ERROR, _class_name, _method_name)
 
     __close_archive(model_context)
 

--- a/core/src/main/python/wlsdeploy/exception/exception_helper.py
+++ b/core/src/main/python/wlsdeploy/exception/exception_helper.py
@@ -31,7 +31,7 @@ import oracle.weblogic.deploy.validate.ValidateException as ValidateException
 import oracle.weblogic.deploy.yaml.YamlException as JYamlException
 
 from wlsdeploy.exception.expection_types import ExceptionType
-from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util import tool_exit
 
 _EXCEPTION_TYPE_MAP = {
@@ -495,4 +495,4 @@ def __handle_unexpected_exception(ex, program_name, class_name, logger):
         # Note: since this is Python 2, it seems we can only get the traceback object via sys.exc_info, and of course only
         # while in the except block handling code
         logger.finer('WLSDPLY-20036', program_name, traceback.format_exception(type(ex), ex, sys.exc_info()[2]))
-    __log_and_exit(logger, CommandLineArgUtil.PROG_ERROR_EXIT_CODE, class_name)
+    __log_and_exit(logger, ExitCode.ERROR, class_name)

--- a/core/src/main/python/wlsdeploy/tool/create/domain_typedef.py
+++ b/core/src/main/python/wlsdeploy/tool/create/domain_typedef.py
@@ -15,7 +15,7 @@ from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.util.targeting_types import TargetingType
 from wlsdeploy.tool.util.topology_profiles import TopologyProfile
 from wlsdeploy.util import path_utils
-from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.weblogic_helper import WebLogicHelper
 
 CREATE_DOMAIN = 'createDomain'
@@ -56,14 +56,14 @@ class DomainTypedef(object):
             json_parser = JsonToPython(self._domain_typedef_filename)
             self._domain_typedefs_dict = json_parser.parse()
         except IllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-12300', self._program_name, self._domain_type,
                                                        self._domain_typedef_filename, iae.getLocalizedMessage(),
                                                        error=iae)
             self._logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
             raise ex
         except JsonException, je:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-12301', self._program_name, self._domain_type,
                                                        self._domain_typedef_filename, je.getLocalizedMessage(),
                                                        error=je)
@@ -468,7 +468,7 @@ class DomainTypedef(object):
 
         # there are no valid targeting types for version 12c and up
         if self.wls_helper.is_set_server_groups_supported():
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-12311', targeting_text, self._domain_typedef_filename,
                                                        self.wls_helper.get_weblogic_version())
             self._logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
@@ -476,7 +476,7 @@ class DomainTypedef(object):
 
         # if specified, targeting must be one of the known types
         if targeting_text not in TargetingType:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-12312', targeting_text, self._domain_typedef_filename)
             self._logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
             raise ex
@@ -498,7 +498,7 @@ class DomainTypedef(object):
 
         # there are no valid topology profiles for versions 12.1.x and below
         if not self.wls_helper.is_topology_profile_supported():
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-12314', topology_profile, self._domain_typedef_filename,
                                                        self.wls_helper.get_weblogic_version())
             self._logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
@@ -506,7 +506,7 @@ class DomainTypedef(object):
 
         # if specified, toppology profile must be one of the known types
         if topology_profile not in TopologyProfile:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-12315', topology_profile, self._domain_typedef_filename)
             self._logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)
             raise ex

--- a/core/src/main/python/wlsdeploy/tool/deploy/deployer_utils.py
+++ b/core/src/main/python/wlsdeploy/tool/deploy/deployer_utils.py
@@ -47,7 +47,7 @@ from wlsdeploy.tool.util.string_output_stream import StringOutputStream
 from wlsdeploy.tool.util.wlst_helper import WlstHelper
 from wlsdeploy.util import dictionary_utils
 from wlsdeploy.util import model_helper
-from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 
 from wlsdeploy.aliases.model_constants import RESOURCE_GROUP
 from wlsdeploy.aliases.model_constants import RESOURCE_GROUP_TEMPLATE
@@ -587,13 +587,13 @@ def online_check_save_activate(model_context):
         if model_context.is_cancel_changes_if_restart_required() and restart_required:
             _wlst_helper.cancel_edit()
             _logger.warning('WLSDPLY-09018', is_restartreq_output)
-            exit_code = CommandLineArgUtil.PROG_CANCEL_CHANGES_IF_RESTART_EXIT_CODE
+            exit_code = ExitCode.CANCEL_CHANGES_IF_RESTART
             list_non_dynamic_changes(model_context, is_restartreq_output)
         else:
             _wlst_helper.save()
             _wlst_helper.activate(model_context.get_model_config().get_activate_timeout())
             if restart_required:
-                exit_code = CommandLineArgUtil.PROG_RESTART_REQUIRED
+                exit_code = ExitCode.RESTART_REQUIRED
                 list_non_dynamic_changes(model_context, is_restartreq_output)
                 exit_code = list_restarts(model_context, exit_code)
 

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_help_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_help_printer.py
@@ -13,7 +13,7 @@ from wlsdeploy.tool.modelhelp.model_help_utils import ControlOptions
 from wlsdeploy.tool.modelhelp.model_kubernetes_printer import ModelKubernetesPrinter
 from wlsdeploy.tool.modelhelp.model_sample_printer import ModelSamplePrinter
 from wlsdeploy.util import model
-from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 
 _class_name = "ModelHelpPrinter"
 MODEL_PATH_PATTERN = re.compile(r'(^[a-zA-Z]+:?)?(/[a-zA-Z0-9^/]+)?$')
@@ -87,7 +87,7 @@ class ModelHelpPrinter(object):
 
         match = MODEL_PATH_PATTERN.match(model_path)
         if match is None:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-10108', model_path)
             self._logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
@@ -117,7 +117,7 @@ class ModelHelpPrinter(object):
         all_section_keys.extend(top_level_keys)
 
         if section not in all_section_keys:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-10109', section, str(', '.join(top_level_keys)))
             self._logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
@@ -141,7 +141,7 @@ class ModelHelpPrinter(object):
             if top_folder in folder_keys:
                 return section
 
-        ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-10101', top_folder)
+        ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-10101', top_folder)
         self._logger.throwing(ex, class_name=_class_name, method_name=_method_name)
         raise ex
 

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_kubernetes_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_kubernetes_printer.py
@@ -7,6 +7,7 @@ from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.extract import wko_schema_helper
 from wlsdeploy.tool.modelhelp import model_help_utils
 from wlsdeploy.tool.modelhelp.model_help_utils import ControlOptions
+from wlsdeploy.util.exit_code import ExitCode
 
 
 class ModelKubernetesPrinter(object):
@@ -75,7 +76,7 @@ class ModelKubernetesPrinter(object):
 
             valid_subfolder_keys = _get_folder_names(properties)
             if token not in valid_subfolder_keys:
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                            "WLSDPLY-10111", model_path, token,
                                                            ', '.join(valid_subfolder_keys))
                 self._logger.throwing(ex, class_name=self._class_name, method_name=_method_name)

--- a/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
+++ b/core/src/main/python/wlsdeploy/tool/modelhelp/model_sample_printer.py
@@ -8,7 +8,7 @@ from wlsdeploy.aliases.validation_codes import ValidationCodes
 from wlsdeploy.tool.modelhelp import model_help_utils
 from wlsdeploy.tool.modelhelp.model_help_utils import ControlOptions
 from wlsdeploy.exception import exception_helper
-from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 
 _class_name = "ModelSamplePrinter"
 
@@ -85,7 +85,7 @@ class ModelSamplePrinter(object):
         section_name = model_path_tokens[0]
         top_folder = model_path_tokens[1]
         if top_folder not in valid_section_folder_keys:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-10110', section_name + ':', top_folder,
                                                        ', '.join(valid_section_folder_keys))
             self._logger.throwing(ex, class_name=_class_name, method_name=_method_name)
@@ -103,7 +103,7 @@ class ModelSamplePrinter(object):
             if indent > 0:
                 code, message = self._aliases.is_valid_model_folder_name(model_location, token)
                 if code != ValidationCodes.VALID:
-                    ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                    ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                                "WLSDPLY-05027", message)
                     self._logger.throwing(ex, class_name=_class_name, method_name=_method_name)
                     raise ex

--- a/core/src/main/python/wlsdeploy/tool/util/archive_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/archive_helper.py
@@ -15,6 +15,7 @@ from oracle.weblogic.deploy.util import WLSDeployArchiveIOException
 
 from wlsdeploy.exception import exception_helper
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 
 
 class ArchiveHelper(object):
@@ -97,7 +98,7 @@ class ArchiveHelper(object):
                     break
 
         except (IllegalArgumentException, IllegalStateException, WLSDeployArchiveIOException), archex:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-20010', program_name, self.__archive_files_text,
                                                        archex.getLocalizedMessage(), error=archex)
             self.__logger.throwing(ex, class_name=self.__class_name, method_name=_method_name)

--- a/core/src/main/python/wlsdeploy/util/cla_helper.py
+++ b/core/src/main/python/wlsdeploy/util/cla_helper.py
@@ -31,6 +31,7 @@ from wlsdeploy.util import path_utils
 from wlsdeploy.util import tool_exit
 from wlsdeploy.util import variables
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model_translator import FileToPython
 
 
@@ -59,7 +60,7 @@ def validate_optional_archive(program_name, optional_arg_map):
             try:
                 FileUtils.validateExistingFile(archive_file)
             except IllegalArgumentException, iae:
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                            'WLSDPLY-20014', program_name, archive_file_name,
                                                            iae.getLocalizedMessage(), error=iae)
                 __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
@@ -89,7 +90,7 @@ def validate_model_present(program_name, optional_arg_map):
             try:
                 FileUtils.validateExistingFile(model_file)
             except IllegalArgumentException, iae:
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                            'WLSDPLY-20006', program_name, model_file,
                                                            iae.getLocalizedMessage(), error=iae)
                 __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
@@ -104,13 +105,13 @@ def validate_model_present(program_name, optional_arg_map):
             model_file_name = FileUtils.fixupFileSeparatorsForJython(tmp_model_file.getAbsolutePath())
             optional_arg_map[CommandLineArgUtil.MODEL_FILE_SWITCH] = model_file_name
         else:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-20026', program_name, archive_file,
                                                        CommandLineArgUtil.MODEL_FILE_SWITCH)
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
     else:
-        ex = exception_helper.create_cla_exception(CommandLineArgUtil.USAGE_ERROR_EXIT_CODE,
+        ex = exception_helper.create_cla_exception(ExitCode.USAGE_ERROR,
                                                    'WLSDPLY-20015', program_name,
                                                    CommandLineArgUtil.MODEL_FILE_SWITCH,
                                                    CommandLineArgUtil.ARCHIVE_FILE_SWITCH)
@@ -135,7 +136,7 @@ def validate_variable_file_exists(program_name, argument_map):
                 variable_file = FileUtils.validateExistingFile(file)
                 result_files.append(variable_file.getAbsolutePath())
             except IllegalArgumentException, iae:
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                            'WLSDPLY-20031', program_name, file,
                                                            iae.getLocalizedMessage(), error=iae)
                 __logger.throwing(ex, class_name=_class_name, method_name=method_name)
@@ -158,7 +159,7 @@ def process_encryption_args(optional_arg_map):
         try:
             passphrase = getcreds.getpass('WLSDPLY-20002')
         except IOException, ioe:
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-20003', ioe.getLocalizedMessage(), error=ioe)
             __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
             raise ex
@@ -189,12 +190,12 @@ def validate_model(program_name, model_dictionary, model_context, aliases, wlst_
         __logger.severe('WLSDPLY-20000', program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     if return_code == Validator.ReturnCode.STOP:
         __logger.severe('WLSDPLY-20001', program_name, class_name=_class_name, method_name=_method_name)
         clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
 
 def load_model(program_name, model_context, aliases, filter_type, wlst_mode):
@@ -221,7 +222,7 @@ def load_model(program_name, model_context, aliases, filter_type, wlst_mode):
         __logger.severe('WLSDPLY-20004', program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     model_file_value = model_context.get_model_file()
     try:
@@ -230,7 +231,7 @@ def load_model(program_name, model_context, aliases, filter_type, wlst_mode):
         __logger.severe('WLSDPLY-09014', program_name, model_file_value, te.getLocalizedMessage(), error=te,
                         class_name=_class_name, method_name=_method_name)
         clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     try:
         variables.substitute(model_dictionary, variable_map, model_context)
@@ -238,7 +239,7 @@ def load_model(program_name, model_context, aliases, filter_type, wlst_mode):
         __logger.severe('WLSDPLY-20004', program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
         clean_up_temp_files()
-        tool_exit.end(model_context, CommandLineArgUtil.PROG_ERROR_EXIT_CODE)
+        tool_exit.end(model_context, ExitCode.ERROR)
 
     filter_helper.apply_filters(model_dictionary, filter_type, model_context)
 
@@ -264,7 +265,7 @@ def process_online_args(optional_arg_map):
             try:
                 username = getcreds.getuser('WLSDPLY-09001')
             except IOException, ioe:
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                            'WLSDPLY-09002', ioe.getLocalizedMessage(), error=ioe)
                 __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
                 raise ex
@@ -274,7 +275,7 @@ def process_online_args(optional_arg_map):
             try:
                 password = getcreds.getpass('WLSDPLY-09003')
             except IOException, ioe:
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+                ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                            'WLSDPLY-09004', ioe.getLocalizedMessage(), error=ioe)
                 __logger.throwing(ex, class_name=_class_name, method_name=_method_name)
                 raise ex

--- a/core/src/main/python/wlsdeploy/util/cla_utils.py
+++ b/core/src/main/python/wlsdeploy/util/cla_utils.py
@@ -17,10 +17,11 @@ import java.net.URISyntaxException as JURISyntaxException
 import oracle.weblogic.deploy.aliases.VersionUtils as JVersionUtils
 import oracle.weblogic.deploy.util.FileUtils as JFileUtils
 
-from wlsdeploy.exception import exception_helper
+from wlsdeploy.exception.exception_helper import create_cla_exception
 from wlsdeploy.json.json_translator import JsonToPython
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.util import path_utils
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.target_configuration import TargetConfiguration
 from wlsdeploy.util.validate_configuration import VALIDATION_METHODS
 
@@ -124,15 +125,6 @@ class CommandLineArgUtil(object):
     ARCHIVE_FILES_SEPARATOR = ','
     MODEL_FILES_SEPARATOR = ','
 
-    HELP_EXIT_CODE                 = 100
-    USAGE_ERROR_EXIT_CODE          = 99
-    ARG_VALIDATION_ERROR_EXIT_CODE = 98
-    PROG_RESTART_REQUIRED          = 103
-    PROG_CANCEL_CHANGES_IF_RESTART_EXIT_CODE = 104
-    PROG_ERROR_EXIT_CODE           = 2
-    PROG_WARNING_EXIT_CODE         = 1
-    PROG_OK_EXIT_CODE              = 0
-
     def __init__(self, program_name, required_args, optional_args):
         self._program_name = program_name
 
@@ -179,7 +171,7 @@ class CommandLineArgUtil(object):
 
         args_len = len(args)
         if args_len == 1:
-            ex = exception_helper.create_cla_exception(self.HELP_EXIT_CODE, 'Dummy Key')
+            ex = create_cla_exception(ExitCode.HELP, 'Dummy Key')
             raise ex
 
         args = self._check_trailing_arguments(args, trailing_arg_count)
@@ -190,7 +182,7 @@ class CommandLineArgUtil(object):
             key = args[idx]
             _logger.fine('WLSDPLY-01600', key, class_name=self._class_name, method_name=method_name)
             if self.is_help_key(key):
-                ex = exception_helper.create_cla_exception(self.HELP_EXIT_CODE, 'Dummy Key')
+                ex = create_cla_exception(ExitCode.HELP, 'Dummy Key')
                 raise ex
             elif self.is_oracle_home_key(key):
                 value, idx = self._get_arg_value(args, idx)
@@ -349,8 +341,7 @@ class CommandLineArgUtil(object):
                 value = self._validate_target_arg(value)
                 self._add_arg(key, value, True)
             else:
-                ex = exception_helper.create_cla_exception(self.USAGE_ERROR_EXIT_CODE,
-                                                           'WLSDPLY-01601', self._program_name, key)
+                ex = create_cla_exception(ExitCode.USAGE_ERROR, 'WLSDPLY-01601', self._program_name, key)
                 _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
                 raise ex
             idx += 1
@@ -376,8 +367,7 @@ class CommandLineArgUtil(object):
 
         # check that key is valid here, to avoid validation if it is not
         if (key not in self._required_args) and (key not in self._optional_args):
-            ex = exception_helper.create_cla_exception(self.USAGE_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01632', key, self._program_name)
+            ex = create_cla_exception(ExitCode.USAGE_ERROR, 'WLSDPLY-01632', key, self._program_name)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -405,8 +395,7 @@ class CommandLineArgUtil(object):
 
         # verify there are enough arguments for any trailing (no switch) args
         if args_len < trailing_arg_count + 1:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01639', trailing_arg_count)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01639', trailing_arg_count)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -432,8 +421,7 @@ class CommandLineArgUtil(object):
 
         for req_arg in required_arguments:
             if req_arg not in required_arg_map:
-                ex = exception_helper.create_cla_exception(CommandLineArgUtil.USAGE_ERROR_EXIT_CODE,
-                                                           'WLSDPLY-20005', program_name, req_arg)
+                ex = create_cla_exception(ExitCode.USAGE_ERROR, 'WLSDPLY-20005', program_name, req_arg)
                 _logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
                 raise ex
 
@@ -456,8 +444,8 @@ class CommandLineArgUtil(object):
         try:
             oh = JFileUtils.validateExistingDirectory(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01602', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01602', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -467,17 +455,15 @@ class CommandLineArgUtil(object):
         try:
             JFileUtils.validateExistingDirectory(wl_home_name)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01603', wl_home_name, oh_name,
-                                                       iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01603', wl_home_name, oh_name,
+                                      iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
         wl_version = wl_helper.get_actual_weblogic_version()
         if not wl_helper.is_supported_weblogic_version():
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01604', oh_name, wl_version,
-                                                       wl_helper.MINIMUM_WEBLOGIC_VERSION)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01604', oh_name, wl_version,
+                                      wl_helper.MINIMUM_WEBLOGIC_VERSION)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -500,8 +486,8 @@ class CommandLineArgUtil(object):
         try:
             jh = JFileUtils.validateExistingDirectory(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01605', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01605', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -526,8 +512,8 @@ class CommandLineArgUtil(object):
             parent_dir = os.path.dirname(value)
             JFileUtils.validateWritableDirectory(parent_dir)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01606', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01606', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -542,7 +528,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_domain_home_arg_for_extract'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01620')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01620')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -563,8 +549,8 @@ class CommandLineArgUtil(object):
         try:
             dp = JFileUtils.validateWritableDirectory(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01608', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01608', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return dp.getAbsolutePath()
@@ -583,7 +569,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_domain_type_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01609')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01609')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -599,8 +585,8 @@ class CommandLineArgUtil(object):
         try:
             wlst_path = JFileUtils.validateExistingDirectory(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01610', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01610', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -616,7 +602,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_admin_url_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01611')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01611')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -626,15 +612,15 @@ class CommandLineArgUtil(object):
         #
         url_separator_index = value.find('://')
         if not url_separator_index > 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01612', value)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01612', value)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
         try:
             JURI(value)
         except JURISyntaxException, use:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01613', value, use.getLocalizedMessage(), error=use)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01613', value, use.getLocalizedMessage(), error=use)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -648,7 +634,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_admin_user_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01614')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01614')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -668,7 +654,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_admin_pass_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01615')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01615')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -693,8 +679,8 @@ class CommandLineArgUtil(object):
                 archive_file = archive_file.getAbsolutePath()
                 result_archive_files.append(archive_file)
             except JIllegalArgumentException, iae:
-                ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01616',
-                                                           archive_file, iae.getLocalizedMessage(), error=iae)
+                ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01616',
+                                          archive_file, iae.getLocalizedMessage(), error=iae)
                 _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
                 raise ex
 
@@ -718,7 +704,7 @@ class CommandLineArgUtil(object):
     def _validate_opss_passphrase_arg(self, value):
         method_name = '_validate_opss_passphrase_arg'
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01615')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01615')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -739,8 +725,8 @@ class CommandLineArgUtil(object):
         try:
             opss_wallet = JFileUtils.validateDirectoryName(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01646', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01646', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return opss_wallet.getAbsolutePath()
@@ -766,8 +752,8 @@ class CommandLineArgUtil(object):
                 model_file = model_file.getAbsolutePath()
                 result_model_files.append(model_file)
             except JIllegalArgumentException, iae:
-                ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01617',
-                                                           model_file, iae.getLocalizedMessage(), error=iae)
+                ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01617',
+                                          model_file, iae.getLocalizedMessage(), error=iae)
                 _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
                 raise ex
 
@@ -785,8 +771,8 @@ class CommandLineArgUtil(object):
         try:
             model = JFileUtils.validateFileName(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01618', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01618', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return model.getAbsolutePath()
@@ -798,12 +784,11 @@ class CommandLineArgUtil(object):
         method_name = '_validate_validate_method_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-20029')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-20029')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         elif value not in VALIDATION_METHODS:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-20030', value, VALIDATION_METHODS)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-20030', value, VALIDATION_METHODS)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return value
@@ -824,7 +809,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_rcu_database_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01621')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01621')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -837,7 +822,7 @@ class CommandLineArgUtil(object):
     def _validate_rcu_dbuser_arg(self, value):
         method_name = '_validate_rcu_dbuser_arg'
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01622')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01622')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -851,7 +836,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_rcu_prefix_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01622')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01622')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -865,7 +850,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_rcu_sys_pass_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01623')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01623')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -879,7 +864,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_rcu_schema_pass_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01624')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01624')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -887,7 +872,7 @@ class CommandLineArgUtil(object):
         _method_name = '_get_env_var_value'
         value = System.getenv(env_var)
         if not value:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01649', env_var)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01649', env_var)
             _logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
             raise ex
         return value
@@ -904,7 +889,7 @@ class CommandLineArgUtil(object):
         except IOException:
             if ifile:
                 ifile.close()
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01651', file_var)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01651', file_var)
             _logger.throwing(ex, class_name=self._class_name, method_name=_method_name)
             raise ex
 
@@ -924,7 +909,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_passphrase_switch'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01625')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01625')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -938,7 +923,7 @@ class CommandLineArgUtil(object):
         method_name = '_validate_one_pass_switch'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01626')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01626')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -958,17 +943,17 @@ class CommandLineArgUtil(object):
         # predict future version numbers...
         #
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01627')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01627')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         elif not JVersionUtils.isVersion(value):
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01628', value)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01628', value)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         else:
             wl_helper = WebLogicHelper(_logger, value)
             if not wl_helper.is_supported_weblogic_version():
-                ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01629', value)
+                ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01629', value)
                 _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
                 raise ex
 
@@ -982,11 +967,11 @@ class CommandLineArgUtil(object):
         method_name = '_validate_target_mode_arg'
 
         if value is None or len(value) == 0:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01630')
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01630')
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         elif value.lower() != 'online' and value.lower() != 'offline':
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01631', value)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01631', value)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
@@ -1002,8 +987,8 @@ class CommandLineArgUtil(object):
         try:
             injector = JFileUtils.validateExistingFile(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01635', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01635', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return injector.getAbsolutePath()
@@ -1020,8 +1005,8 @@ class CommandLineArgUtil(object):
         try:
             keywords = JFileUtils.validateExistingFile(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01636', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01636', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return keywords.getAbsolutePath()
@@ -1039,8 +1024,8 @@ class CommandLineArgUtil(object):
         try:
             variables = JFileUtils.validateFileName(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01620', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01620', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return variables.getAbsolutePath()
@@ -1054,8 +1039,8 @@ class CommandLineArgUtil(object):
         try:
             variables = JFileUtils.validateFileName(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01637', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01637', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return variables.getAbsolutePath()
@@ -1071,8 +1056,8 @@ class CommandLineArgUtil(object):
         try:
             variables = JFileUtils.validateDirectoryName(value)
         except JIllegalArgumentException, iae:
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01647', value, iae.getLocalizedMessage(), error=iae)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                      'WLSDPLY-01647', value, iae.getLocalizedMessage(), error=iae)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         return variables.getAbsolutePath()
@@ -1086,7 +1071,7 @@ class CommandLineArgUtil(object):
         # Check if the target configuration file exists
         target_configuration_file = path_utils.find_config_path(os.path.join('targets', value, 'target.json'))
         if not os.path.exists(target_configuration_file):
-            ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE, 'WLSDPLY-01643', value, target_configuration_file)
+            ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01643', value, target_configuration_file)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
         else:
@@ -1095,11 +1080,10 @@ class CommandLineArgUtil(object):
                 config_dictionary = JsonToPython(target_configuration_file).parse()
                 target_configuration = TargetConfiguration(config_dictionary)
 
-                target_configuration.validate_configuration(self.ARG_VALIDATION_ERROR_EXIT_CODE, target_configuration_file)
+                target_configuration.validate_configuration(ExitCode.ARG_VALIDATION_ERROR, target_configuration_file)
 
             except SyntaxError, se:
-                ex = exception_helper.create_cla_exception(self.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                           'WLSDPLY-01644', target_configuration_file, se)
+                ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01644', target_configuration_file, se)
                 _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
                 raise ex
 
@@ -1122,13 +1106,12 @@ class CommandLineArgUtil(object):
         elif key in self._optional_args:
             self._optional_result[key] = fixed_value
         else:
-            ex = exception_helper.create_cla_exception(self.USAGE_ERROR_EXIT_CODE,
-                                                       'WLSDPLY-01632', key, self._program_name)
+            ex = create_cla_exception(ExitCode.USAGE_ERROR, 'WLSDPLY-01632', key, self._program_name)
             _logger.throwing(ex, class_name=self._class_name, method_name=method_name)
             raise ex
 
     def _get_out_of_args_exception(self, key):
-        ex = exception_helper.create_cla_exception(self.USAGE_ERROR_EXIT_CODE, 'WLSDPLY-01638', key, self._program_name)
+        ex = create_cla_exception(ExitCode.USAGE_ERROR, 'WLSDPLY-01638', key, self._program_name)
         return ex
 
 
@@ -1162,8 +1145,8 @@ def validate_domain_home_arg(value):
     try:
         dh = JFileUtils.validateExistingDirectory(value)
     except JIllegalArgumentException, iae:
-        ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                   'WLSDPLY-01606', value, iae.getLocalizedMessage(), error=iae)
+        ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
+                                  'WLSDPLY-01606', value, iae.getLocalizedMessage(), error=iae)
         _logger.throwing(ex, class_name='CommandLineArgUtil', method_name=method_name)
         raise ex
 
@@ -1171,10 +1154,8 @@ def validate_domain_home_arg(value):
     try:
         config_xml = JFileUtils.validateExistingFile(config_xml.getAbsolutePath())
     except JIllegalArgumentException, iae:
-        ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
-                                                   'WLSDPLY-01607', dh.getAbsolutePath(),
-                                                   config_xml.getAbsolutePath(),
-                                                   iae.getLocalizedMessage(), error=iae)
+        ex = create_cla_exception(ExitCode.ARG_VALIDATION_ERROR, 'WLSDPLY-01607', dh.getAbsolutePath(),
+                                  config_xml.getAbsolutePath(), iae.getLocalizedMessage(), error=iae)
         _logger.throwing(ex, class_name='CommandLineArgUtil', method_name=method_name)
         raise ex
 

--- a/core/src/main/python/wlsdeploy/util/exit_code.py
+++ b/core/src/main/python/wlsdeploy/util/exit_code.py
@@ -1,0 +1,22 @@
+"""
+Copyright (c) 2022, Oracle Corporation and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+Standard exit codes for command-line utilities.
+"""
+
+class ExitCode(object):
+    """
+    Standard exit codes for command-line utilities.
+    """
+
+    OK                         = 0
+    WARNING                    = 1
+    ERROR                      = 2
+
+    ARG_VALIDATION_ERROR       = 98
+    USAGE_ERROR                = 99
+
+    HELP                       = 100
+    RESTART_REQUIRED           = 103
+    CANCEL_CHANGES_IF_RESTART  = 104

--- a/core/src/main/python/wlsdeploy/util/target_configuration_helper.py
+++ b/core/src/main/python/wlsdeploy/util/target_configuration_helper.py
@@ -22,6 +22,7 @@ from wlsdeploy.tool.util.targets import additional_output_helper
 from wlsdeploy.tool.util.targets import file_template_helper
 from wlsdeploy.util import dictionary_utils
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.json.json_translator import PythonToJson
 
 
@@ -86,7 +87,7 @@ def process_target_arguments(argument_map):
         # if -target is specified -output_dir is required
         output_dir = dictionary_utils.get_element(argument_map, CommandLineArgUtil.OUTPUT_DIR_SWITCH)
         if (output_dir is None) or (not os.path.isdir(output_dir)):
-            ex = exception_helper.create_cla_exception(CommandLineArgUtil.ARG_VALIDATION_ERROR_EXIT_CODE,
+            ex = exception_helper.create_cla_exception(ExitCode.ARG_VALIDATION_ERROR,
                                                        'WLSDPLY-01642', CommandLineArgUtil.OUTPUT_DIR_SWITCH,
                                                        CommandLineArgUtil.TARGET_SWITCH, target_name)
             __logger.throwing(ex, class_name=__class_name, method_name=_method_name)


### PR DESCRIPTION
Removing circular imports from and to CommandLineArgUtil.  Exit code constants moved out of CommandLineArgUtil and into simple class, ExitCode.