### PR TITLE
removed message when no PSU was found

### DIFF
--- a/core/src/main/java/oracle/weblogic/deploy/util/XPathUtil.java
+++ b/core/src/main/java/oracle/weblogic/deploy/util/XPathUtil.java
@@ -58,7 +58,7 @@ public class XPathUtil {
     public String getPSU() {
         // find the names in the directory first
         if (!(new File(patchesHome)).exists()) {
-            LOGGER.info("No patches home at {0}", patchesHome);
+            LOGGER.fine("No PSU, patches directory not found at {0}", patchesHome);
             return null;
         }
         List<String> patchFiles = findPatchFiles();

--- a/core/src/main/python/wlsdeploy/util/model_context.py
+++ b/core/src/main/python/wlsdeploy/util/model_context.py
@@ -122,8 +122,9 @@ class ModelContext(object):
             psu = XPathUtil(self._oracle_home).getPSU()
             if psu is not None:
                 self._wl_version += '.' + psu
-                self._logger.info('WLSDPLY-01050', self._wl_version, class_name=self._class_name,
-                method_name=_method_name)
+
+            self._logger.info('WLSDPLY-01050', self._wl_version, class_name=self._class_name,
+                              method_name=_method_name)
             self._wl_home = self._wls_helper.get_weblogic_home(self._oracle_home)
 
         if CommandLineArgUtil.JAVA_HOME_SWITCH in arg_map:


### PR DESCRIPTION
Moved message to FINE, instead of INFO, and changed the wording from:
####<Jul 27, 2022 3:07:04 PM> <INFO> <XPathUtil> <getPSU> <> <No patches home at .../Oracle/Middleware14.1.1.0.0/inventory/patches>

Only when a PSU was found would the following message be printed:
####<Jul 27, 2022 10:24:14 PM> <INFO> <ModelContext> <__copy_from_args> <WLSDPLY-01050> <WebLogic version for aliases is 12.2.1.4.0.220105>

Changed to print the message whether a PSU was found or not:
####<Jul 27, 2022 10:26:38 PM> <INFO> <ModelContext> <__copy_from_args> <WLSDPLY-01050> <WebLogic version for aliases is 12.2.1.4.0>