### PR TITLE
WDT-639 consistent exit handling across tools

### DIFF
--- a/core/src/main/python/compare_model.py
+++ b/core/src/main/python/compare_model.py
@@ -318,22 +318,19 @@ def main():
         if _exit_code != ExitCode.HELP:
             _logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                            class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
     except CompareException, ce:
         _exit_code = ExitCode.ERROR
-        cla_helper.clean_up_temp_files()
         _logger.severe('WLSDPLY-05704', ce.getLocalizedMessage(), class_name=_class_name, method_name=_method_name)
     except PyWLSTException, pe:
         _exit_code = ExitCode.ERROR
-        cla_helper.clean_up_temp_files()
         _logger.severe('WLSDPLY-05704', pe.getLocalizedMessage(), class_name=_class_name, method_name=_method_name)
     except:
         exc_type, exc_obj, exc_tb = sys.exc_info()
         _exit_code = ExitCode.ERROR
         ee_string = traceback.format_exception(exc_type, exc_obj, exc_tb)
-        cla_helper.clean_up_temp_files()
         _logger.severe('WLSDPLY-05704', ee_string)
 
+    cla_helper.clean_up_temp_files()
     tool_exit.__log_and_exit(_logger, model_context, _exit_code, _class_name, _method_name)
 
 def format_message(key, *args):

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -329,8 +329,6 @@ def main(args):
         if archive_file_name:
             domain_path = _get_domain_path(model_context, model_dictionary)
             archive_helper = ArchiveHelper(archive_file_name, domain_path, __logger, ExceptionType.CREATE)
-        cla_helper.clean_up_temp_files()
-        tool_exit.__log_and_exit(__logger, model_context, ExitCode.ERROR, _class_name, _method_name)
 
         has_atp, has_ssl = validate_rcu_args_and_model(model_context, model_dictionary, archive_helper, aliases)
 

--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -304,20 +304,20 @@ def main(args):
 
     WlstHelper(ExceptionType.CREATE).silence()
 
-    exit_code = ExitCode.OK
+    _exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
-        exit_code = ex.getExitCode()
-        if exit_code != ExitCode.HELP:
+        _exit_code = ex.getExitCode()
+        if _exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
 
         # create a minimal model for summary logging
         model_context = model_context_helper.create_exit_context(_program_name)
-        tool_exit.end(model_context, exit_code)
+        tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
 
     aliases = Aliases(model_context, wlst_mode=__wlst_mode, exception_type=ExceptionType.CREATE)
 
@@ -329,6 +329,8 @@ def main(args):
         if archive_file_name:
             domain_path = _get_domain_path(model_context, model_dictionary)
             archive_helper = ArchiveHelper(archive_file_name, domain_path, __logger, ExceptionType.CREATE)
+        cla_helper.clean_up_temp_files()
+        tool_exit.__log_and_exit(__logger, model_context, ExitCode.ERROR, _class_name, _method_name)
 
         has_atp, has_ssl = validate_rcu_args_and_model(model_context, model_dictionary, archive_helper, aliases)
 
@@ -349,33 +351,24 @@ def main(args):
             rcu_db_info = RcuDbInfo(model_context, aliases, rcu_properties_map)
             ssl_helper.fix_jps_config(rcu_db_info, model_context)
     except WLSDeployArchiveIOException, ex:
+        _exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-12409', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, ExitCode.ERROR)
-
     except CreateException, ex:
+        _exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-12409', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, ExitCode.ERROR)
-
     except IOException, ex:
+        _exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-12409', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, ExitCode.ERROR)
-
     except DeployException, ex:
+        _exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-12410', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, ExitCode.ERROR)
 
     cla_helper.clean_up_temp_files()
-
-    tool_exit.end(model_context, exit_code)
-
+    tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)

--- a/core/src/main/python/deploy.py
+++ b/core/src/main/python/deploy.py
@@ -226,20 +226,20 @@ def main(args):
 
     __wlst_helper.silence()
 
-    exit_code = ExitCode.OK
+    _exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
-        exit_code = ex.getExitCode()
-        if exit_code != ExitCode.HELP:
+        _exit_code = ex.getExitCode()
+        if _exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
 
         # create a minimal model for summary logging
         model_context = model_context_helper.create_exit_context(_program_name)
-        tool_exit.end(model_context, exit_code)
+        tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
 
     aliases = Aliases(model_context, wlst_mode=__wlst_mode, exception_type=ExceptionType.DEPLOY)
 
@@ -247,17 +247,14 @@ def main(args):
 
     try:
         model = Model(model_dictionary)
-        exit_code = __deploy(model, model_context, aliases)
+        _exit_code = __deploy(model, model_context, aliases)
     except DeployException, ex:
+        _exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-09015', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, ExitCode.ERROR)
 
     cla_helper.clean_up_temp_files()
-
-    tool_exit.end(model_context, exit_code)
-
+    tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -347,6 +347,8 @@ def __clear_archive_file(model_context):
             __logger.throwing(class_name=_class_name, method_name=_method_name, error=de)
             raise de
 
+    __logger.exiting(class_name=_class_name, method_name=_method_name)
+
 
 def __close_archive(model_context):
     """
@@ -508,6 +510,7 @@ def __check_and_customize_model(model, model_context, aliases, credential_inject
                                         archive_file_name=model_context.get_archive_file_name())
     except ValidateException, ex:
         __logger.warning('WLSDPLY-06015', ex.getLocalizedMessage(), class_name=_class_name, method_name=_method_name)
+    __logger.exiting(_class_name, _method_name)
     return model
 
 
@@ -554,19 +557,6 @@ def __remote_report(model_context):
         print key, ' ', wls_archive
     print ''
 
-
-def __log_and_exit(model_context, exit_code, class_name, method_name):
-    """
-    Helper method to log the exiting message and call sys.exit()
-    :param exit_code: the exit code to use
-    :param class_name: the class name to pass  to the logger
-    :param method_name: the method name to pass to the logger
-    """
-    __logger.exiting(result=exit_code, class_name=class_name, method_name=method_name)
-
-    tool_exit.end(model_context, exit_code)
-
-
 def main(args):
     """
     The main entry point for the discoverDomain tool.
@@ -594,14 +584,14 @@ def main(args):
 
         # create a minimal model for summary logging
         model_context = model_context_helper.create_exit_context(_program_name)
-        __log_and_exit(model_context, exit_code, _class_name, _method_name)
+        tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
     try:
         __clear_archive_file(model_context)
     except DiscoverException, ex:
         __logger.severe('WLSDPLY-06010', _program_name, model_context.get_archive_file_name(),
                         ex.getLocalizedMessage(), error=ex, class_name=_class_name, method_name=_method_name)
-        __log_and_exit(model_context, ExitCode.ERROR, _class_name, _method_name)
+        tool_exit.__log_and_exit(__logger, model_context, ExitCode.ERROR, _class_name, _method_name)
 
     aliases = Aliases(model_context, wlst_mode=__wlst_mode, exception_type=ExceptionType.DISCOVER)
     model = None
@@ -624,7 +614,7 @@ def main(args):
         __logger.severe('WLSDPLY-06011', _program_name, model_context.get_domain_name(),
                         model_context.get_domain_home(), ex.getLocalizedMessage(),
                         error=ex, class_name=_class_name, method_name=_method_name)
-        __log_and_exit(model_context, ExitCode.ERROR, _class_name, _method_name)
+        tool_exit.__log_and_exit(__logger, model_context, ExitCode.ERROR, _class_name, _method_name)
 
     try:
         __persist_model(model, model_context)
@@ -632,11 +622,11 @@ def main(args):
     except TranslateException, ex:
         __logger.severe('WLSDPLY-20024', _program_name, model_context.get_archive_file_name(), ex.getLocalizedMessage(),
                         error=ex, class_name=_class_name, method_name=_method_name)
-        __log_and_exit(model_context, ExitCode.ERROR, _class_name, _method_name)
+        tool_exit.__log_and_exit(__logger, model_context, ExitCode.ERROR, _class_name, _method_name)
 
     __close_archive(model_context)
 
-    __log_and_exit(model_context, exit_code, _class_name, _method_name)
+    tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
 
 if __name__ == '__main__' or __name__ == 'main':
@@ -646,4 +636,4 @@ if __name__ == '__main__' or __name__ == 'main':
     except exceptions.SystemExit, ex:
         raise ex
     except (exceptions.Exception, java.lang.Exception), ex:
-        exception_helper.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)
+        tool_exit.__handle_unexpected_exception(ex, _program_name, _class_name, __logger)

--- a/core/src/main/python/encrypt.py
+++ b/core/src/main/python/encrypt.py
@@ -25,8 +25,10 @@ from wlsdeploy.exception import exception_helper
 from wlsdeploy.exception.expection_types import ExceptionType
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.encrypt import encryption_utils
+from wlsdeploy.tool.util import model_context_helper
 from wlsdeploy.util import cla_utils
 from wlsdeploy.util import getcreds
+from wlsdeploy.util import tool_exit
 from wlsdeploy.util import variables as variable_helper
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.exit_code import ExitCode
@@ -215,6 +217,7 @@ def _process_request(args):
         if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
+        __logger.exiting(class_name=_class_name, method_name=_method_name, result=exit_code)
         return exit_code
 
     if model_context.is_encryption_manual():
@@ -249,9 +252,9 @@ def main(args):
         __logger.finer('sys.argv[{0}] = {1}', str(index), str(arg), class_name=_class_name, method_name=_method_name)
 
     exit_code = _process_request(args)
-    __logger.exiting(class_name=_class_name, method_name=_method_name, result=exit_code)
-    sys.exit(exit_code)
-
+    # create a minimal model for summary logging
+    model_context = model_context_helper.create_exit_context(_program_name)
+    tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)

--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -124,20 +124,20 @@ def main(args):
     for index, arg in enumerate(args):
         __logger.finer('sys.argv[{0}] = {1}', str(index), str(arg), class_name=_class_name, method_name=_method_name)
 
-    exit_code = ExitCode.OK
+    _exit_code = ExitCode.OK
 
     try:
         model_context = __process_args(args)
     except CLAException, ex:
-        exit_code = ex.getExitCode()
-        if exit_code != ExitCode.HELP:
+        _exit_code = ex.getExitCode()
+        if _exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
 
         # create a minimal model for summary logging
         model_context = model_context_helper.create_exit_context(_program_name)
-        tool_exit.end(model_context, exit_code)
+        tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
 
     aliases = Aliases(model_context, wlst_mode=__wlst_mode)
 
@@ -145,16 +145,14 @@ def main(args):
 
     try:
         model = Model(model_dictionary)
-        exit_code = __extract_resource(model, model_context, aliases)
+        _exit_code = __extract_resource(model, model_context, aliases)
     except DeployException, ex:
+        _exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-09015', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, ExitCode.ERROR)
 
     cla_helper.clean_up_temp_files()
-
-    tool_exit.end(model_context, exit_code)
+    tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
     return
 
 

--- a/core/src/main/python/model_help.py
+++ b/core/src/main/python/model_help.py
@@ -12,9 +12,7 @@ from oracle.weblogic.deploy.util import CLAException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
 
 # Jython tools don't require sys.path modification
-
 from wlsdeploy.aliases.aliases import Aliases
-from wlsdeploy.aliases.wlst_modes import WlstModes
 from wlsdeploy.exception import exception_helper
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.modelhelp.model_help_printer import ModelHelpPrinter
@@ -22,6 +20,7 @@ from wlsdeploy.tool.modelhelp.model_help_utils import ControlOptions
 from wlsdeploy.tool.util import model_context_helper
 from wlsdeploy.util import cla_helper
 from wlsdeploy.util import model
+from wlsdeploy.util import tool_exit
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.exit_code import ExitCode
 
@@ -435,7 +434,7 @@ def main(args):
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
-        sys.exit(exit_code)
+        tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
     try:
         model_path = model_context.get_trailing_argument(0)
@@ -443,10 +442,9 @@ def main(args):
     except CLAException, ve:
         __logger.severe('WLSDPLY-10112', _program_name, ve.getLocalizedMessage(), error=ve,
                         class_name=_class_name, method_name=_method_name)
-        sys.exit(ExitCode.ERROR)
+        exit_code  = ExitCode.ERROR
 
-    __logger.exiting(result=exit_code, class_name=_class_name, method_name=_method_name)
-    sys.exit(exit_code)
+    tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
 
 if __name__ == '__main__' or __name__ == 'main':

--- a/core/src/main/python/prepare_model.py
+++ b/core/src/main/python/prepare_model.py
@@ -24,6 +24,7 @@ from wlsdeploy.util import cla_helper
 from wlsdeploy.util import target_configuration_helper
 from wlsdeploy.util import tool_exit
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
+from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model_context import ModelContext
 
 _program_name = 'prepareModel'
@@ -70,6 +71,7 @@ def main():
     :param args: the command-line arguments
     """
     _method_name = 'main'
+    _exit_code = ExitCode.OK
 
     __logger.entering(class_name=_class_name, method_name=_method_name)
     for index, arg in enumerate(sys.argv):
@@ -86,28 +88,24 @@ def main():
 
         obj = ModelPreparer(model_files, model_context, _outputdir)
         obj.prepare_models()
-        tool_exit.end(model_context, ExitCode.OK)
+        tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
 
     except CLAException, ex:
-        exit_code = ExitCode.ERROR
+        _exit_code = ex.getExitCode()
         __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, exit_code)
-
     except (PrepareException, PyWLSTException), ex:
-        cla_helper.clean_up_temp_files()
+        _exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-05801', ex.getLocalizedMessage(), error=ex, class_name=_class_name,
                         method_name=_method_name)
-        tool_exit.end(model_context, ExitCode.ERROR)
-
     except Exception, ex:
-        cla_helper.clean_up_temp_files()
+        _exit_code = ExitCode.ERROR
         message = str(sys.exc_type) + ': ' + str(sys.exc_value)
         __logger.severe('WLSDPLY-05801', message, error=ex, class_name=_class_name,
                         method_name=_method_name)
-        tool_exit.end(model_context, ExitCode.ERROR)
 
+    cla_helper.clean_up_temp_files()
+    tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
 
 if __name__ == "__main__" or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)

--- a/core/src/main/python/update.py
+++ b/core/src/main/python/update.py
@@ -268,6 +268,7 @@ def main(args):
     :return:
     """
     _method_name = 'main'
+    _exit_code = ExitCode.OK
 
     __logger.entering(args[0], class_name=_class_name, method_name=_method_name)
     for index, arg in enumerate(args):
@@ -275,20 +276,18 @@ def main(args):
 
     __wlst_helper.silence()
 
-    exit_code = ExitCode.OK
-
     try:
         model_context = __process_args(args)
     except CLAException, ex:
-        exit_code = ex.getExitCode()
-        if exit_code != ExitCode.HELP:
+        _exit_code = ex.getExitCode()
+        if _exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
         cla_helper.clean_up_temp_files()
 
         # create a minimal model for summary logging
         model_context = model_context_helper.create_exit_context(_program_name)
-        tool_exit.end(model_context, exit_code)
+        tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
 
     aliases = Aliases(model_context, wlst_mode=__wlst_mode, exception_type=ExceptionType.DEPLOY)
 
@@ -296,16 +295,14 @@ def main(args):
 
     try:
         model = Model(model_dictionary)
-        exit_code = __update(model, model_context, aliases)
+        _exit_code = __update(model, model_context, aliases)
     except DeployException, ex:
+        _exit_code = ExitCode.ERROR
         __logger.severe('WLSDPLY-09015', _program_name, ex.getLocalizedMessage(), error=ex,
                         class_name=_class_name, method_name=_method_name)
-        cla_helper.clean_up_temp_files()
-        tool_exit.end(model_context, ExitCode.ERROR)
 
     cla_helper.clean_up_temp_files()
-
-    tool_exit.end(model_context, exit_code)
+    tool_exit.__log_and_exit(__logger, model_context, _exit_code, _class_name, _method_name)
     return
 
 

--- a/core/src/main/python/validate.py
+++ b/core/src/main/python/validate.py
@@ -171,7 +171,7 @@ def main(args):
         cla_helper.clean_up_temp_files()
         # create a minimal model for summary logging
         model_context = model_context_helper.create_exit_context(_program_name)
-        tool_exit.end(model_context, exit_code)
+        tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
     model_file_name = model_context.get_model_file()
 
@@ -193,10 +193,7 @@ def main(args):
                         class_name=_class_name, method_name=_method_name)
 
     cla_helper.clean_up_temp_files()
-
-    tool_exit.end(model_context, exit_code)
-    return
-
+    tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)

--- a/core/src/main/python/variable_inject.py
+++ b/core/src/main/python/variable_inject.py
@@ -14,7 +14,6 @@ from oracle.weblogic.deploy.util import FileUtils
 from oracle.weblogic.deploy.util import TranslateException
 from oracle.weblogic.deploy.util import WLSDeployArchiveIOException
 from oracle.weblogic.deploy.util import WebLogicDeployToolingVersion
-
 # Jython tools don't require sys.path modification
 
 import wlsdeploy.tool.util.variable_injector as variable_injector
@@ -23,7 +22,7 @@ from wlsdeploy.exception import exception_helper
 from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.util import model_context_helper
 from wlsdeploy.tool.util.variable_injector import VariableInjector
-from wlsdeploy.util import model_translator, cla_helper
+from wlsdeploy.util import model_translator, cla_helper, tool_exit
 from wlsdeploy.util.cla_utils import CommandLineArgUtil
 from wlsdeploy.util.exit_code import ExitCode
 from wlsdeploy.util.model import Model
@@ -143,17 +142,6 @@ def __persist_model(model, model_context):
     __logger.exiting(class_name=_class_name, method_name=_method_name)
 
 
-def __log_and_exit(exit_code, class_name, _method_name):
-    """
-    Helper method to log the exiting message and call sys.exit()
-    :param exit_code: the exit code to use
-    :param class_name: the class name to pass  to the logger
-    :param _method_name: the method name to pass to the logger
-    """
-    __logger.exiting(result=exit_code, class_name=class_name, method_name=_method_name)
-    sys.exit(exit_code)
-
-
 def main(args):
     """
     The main entry point for the discoverDomain tool.
@@ -177,7 +165,7 @@ def main(args):
         if exit_code != ExitCode.HELP:
             __logger.severe('WLSDPLY-20008', _program_name, ex.getLocalizedMessage(), error=ex,
                             class_name=_class_name, method_name=_method_name)
-        __log_and_exit(exit_code, _class_name, _method_name)
+        tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
     model_file = model_context.get_model_file()
     try:
@@ -185,7 +173,7 @@ def main(args):
     except TranslateException, te:
         __logger.severe('WLSDPLY-20009', _program_name, model_file, te.getLocalizedMessage(), error=te,
                         class_name=_class_name, method_name=_method_name)
-        sys.exit(ExitCode.ERROR)
+        tool_exit.__log_and_exit(__logger, model_context, ExitCode.ERROR, _class_name, _method_name)
 
     inserted, model = __inject(model, model_context)
     if inserted:
@@ -196,13 +184,11 @@ def main(args):
         except TranslateException, ex:
             __logger.severe('WLSDPLY-20024', _program_name, model_context.get_archive_file_name(),
                             ex.getLocalizedMessage(), error=ex, class_name=_class_name, method_name=_method_name)
-            __log_and_exit(ExitCode.ERROR, _class_name, _method_name)
+            tool_exit.__log_and_exit(__logger, model_context, ExitCode.ERROR, _class_name, _method_name)
 
     __close_archive(model_context)
 
-    __logger.exiting(result=exit_code, class_name=_class_name, method_name=_method_name)
-    sys.exit(exit_code)
-
+    tool_exit.__log_and_exit(__logger, model_context, exit_code, _class_name, _method_name)
 
 if __name__ == '__main__' or __name__ == 'main':
     WebLogicDeployToolingVersion.logVersionInfo(_program_name)

--- a/core/src/main/python/wlsdeploy/exception/exception_helper.py
+++ b/core/src/main/python/wlsdeploy/exception/exception_helper.py
@@ -465,15 +465,6 @@ def _return_exception_params(*args, **kwargs):
     error = kwargs.pop('error', None)
     return arg_list, error
 
-def __log_and_exit(logger, exit_code, class_name):
-    """
-    Helper method to log the exiting message and call sys.exit()
-    :param logger:  the logger to use
-    :param exit_code: the exit code to use
-    :param class_name: the class name to pass  to the logger
-    """
-    logger.exiting(result=exit_code, class_name=class_name, method_name=None)
-    tool_exit.end(None, exit_code)
 
 def __handle_unexpected_exception(ex, program_name, class_name, logger):
     """
@@ -495,4 +486,4 @@ def __handle_unexpected_exception(ex, program_name, class_name, logger):
         # Note: since this is Python 2, it seems we can only get the traceback object via sys.exc_info, and of course only
         # while in the except block handling code
         logger.finer('WLSDPLY-20036', program_name, traceback.format_exception(type(ex), ex, sys.exc_info()[2]))
-    __log_and_exit(logger, ExitCode.ERROR, class_name)
+    tool_exit.end(logger, ExitCode.ERROR, class_name)

--- a/core/src/main/python/wlsdeploy/util/tool_exit.py
+++ b/core/src/main/python/wlsdeploy/util/tool_exit.py
@@ -9,7 +9,6 @@ import oracle.weblogic.deploy.util.WLSDeployContext.WLSTMode as mode
 
 from wlsdeploy.aliases.wlst_modes import WlstModes
 
-
 def end(model_context, exit_code):
     """
     Tools python code should use this tool to perform end actions, clean-up, and exit with exit code
@@ -25,3 +24,15 @@ def end(model_context, exit_code):
         if model_context.get_target_wlst_mode() == WlstModes.ONLINE:
             wlst_mode = mode.ONLINE
     WLSDeployExit.exit(WLSDeployContext(program, version, wlst_mode), exit_code)
+
+def __log_and_exit(logger, model_context, exit_code, class_name, _method_name=None):
+    """
+    Helper method to log the exiting message and exit
+    :param logger:  the logger to use
+    :param model_context:  the model_context to use
+    :param exit_code: the exit code to use
+    :param class_name: the class name to pass  to the logger
+    :param _method_name: the method name to pass to the logger
+    """
+    logger.exiting(result=exit_code, class_name=class_name, method_name=_method_name)
+    end(model_context, exit_code)


### PR DESCRIPTION
I tried to ensure wherever there was a call to logger.entering() that there was a matching logger.exiting().  Also, all tool exits should now be handled consistently, using either _tool_exit.__log_and_exit() to do a logger.exiting() and tool_exit.end() if there was a __logger.entering() or simply tool_exit.end() if not.
Also, removed duplicate code in multiple except blocks, setting an exit code, and after the except blocks, cleaning up temp files and exiting with whatever exit code was set.