### PR TITLE
WDT-661 Delete Machines instead of UnixMachines in online

### DIFF
--- a/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/UnixMachine.json
+++ b/core/src/main/resources/oracle/weblogic/deploy/aliases/category_modules/UnixMachine.json
@@ -1,7 +1,7 @@
 {
     "copyright": "Copyright (c) 2017, 2022, Oracle Corporation and/or its affiliates.",
     "license": "Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl",
-    "wlst_type": "UnixMachine${:s}",
+    "wlst_type": "${UnixMachine:Machines}",
     "online_bean": "weblogic.management.configuration.UnixMachineMBean",
     "child_folders_type": "multiple",
     "short_name": "UnixNM",


### PR DESCRIPTION
Fixes WDT-661

The wlst_type was not set correctly for online.