### PR TITLE
Return false for derived default false

### DIFF
--- a/integration-tests/alias-test/generate/src/test/python/aliastest/generate/generator_base.py
+++ b/integration-tests/alias-test/generate/src/test/python/aliastest/generate/generator_base.py
@@ -80,7 +80,7 @@ class GeneratorBase(object):
         if self._model_context.get_target_wlst_mode() == WlstModes.ONLINE:
             if cmo_helper is not None:
                 value = cmo_helper.derived_default_value()
-            if value is not None and value:
+            if value is not None:
                 dictionary[DERIVED_DEFAULT] = value
 
         self.__logger.exiting(class_name=self.__class_name, method_name=_method_name, result=value)

--- a/integration-tests/alias-test/generate/src/test/python/aliastest/generate/mbean_info_helper.py
+++ b/integration-tests/alias-test/generate/src/test/python/aliastest/generate/mbean_info_helper.py
@@ -351,7 +351,10 @@ class MBeanInfoAttributeHelper(object):
     def derived_default_value(self):
         if self.__attribute_info is None:
             return None
-        return self.__attribute_info.getValue('restDerivedDefault')
+        value = self.__attribute_info.getValue('restDerivedDefault')
+        if value is None:
+            value = False
+        return value
 
     def attribute_value(self):
         if self.is_valid_getter():


### PR DESCRIPTION
attribute exists now gets derived_default = False while attribute does not exists does not get a derived default value.