### PR TITLE
Remove archive_file argument from extractDomainResource

### DIFF
--- a/core/src/main/python/extract_resource.py
+++ b/core/src/main/python/extract_resource.py
@@ -43,7 +43,6 @@ __optional_arguments = [
     # Used by shell script to locate WLST
     CommandLineArgUtil.DOMAIN_TYPE_SWITCH,
     CommandLineArgUtil.DOMAIN_HOME_SWITCH,
-    CommandLineArgUtil.ARCHIVE_FILE_SWITCH,
     CommandLineArgUtil.TARGET_SWITCH,
     CommandLineArgUtil.VARIABLE_FILE_SWITCH,
     CommandLineArgUtil.USE_ENCRYPTION_SWITCH,
@@ -70,13 +69,11 @@ def __process_args(args):
     cla_util.set_allow_multiple_models(True)
     argument_map = cla_util.process_args(args, TOOL_TYPE_EXTRACT)
 
-    cla_helper.validate_optional_archive(_program_name, argument_map)
-
     cla_helper.validate_required_model(_program_name, argument_map)
     cla_helper.validate_variable_file_exists(_program_name, argument_map)
     cla_helper.process_encryption_args(argument_map)
 
-    # allow unresolved tokens and archive entries
+    # allow unresolved tokens and entries
     argument_map[CommandLineArgUtil.VALIDATION_METHOD] = validate_configuration.LAX_METHOD
 
     return model_context_helper.create_context(_program_name, argument_map)

--- a/installer/src/main/bin/extractDomainResource.cmd
+++ b/installer/src/main/bin/extractDomainResource.cmd
@@ -2,7 +2,7 @@
 @rem **************************************************************************
 @rem extractDomainResource.cmd
 @rem
-@rem Copyright (c) 2020, 2022, Oracle Corporation and/or its affiliates.  All rights reserved.
+@rem Copyright (c) 2020, 2023, Oracle Corporation and/or its affiliates.  All rights reserved.
 @rem Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 @rem
 @rem     NAME
@@ -74,7 +74,6 @@ ECHO              [-domain_home ^<domain_home^>]
 ECHO              [-output_dir ^<output_dir^>]
 ECHO              [-target ^<target^>]
 ECHO              [-domain_resource_file ^<domain_resource_file^>]
-ECHO              [-archive_file ^<archive_file^>]
 ECHO              [-model_file ^<model_file^>]
 ECHO              [-variable_file ^<variable_file^>]
 ECHO.
@@ -92,12 +91,6 @@ ECHO         target          - the target output type. The default is wko.
 ECHO.
 ECHO         domain_resource_file - the location of the extracted domain resource file.
 ECHO                                This is deprecated, use -output_dir to specify output location
-ECHO.
-ECHO         archive_file    - the path to the archive file to use.  If the -model_file
-ECHO                           argument is not specified, the model file in this archive
-ECHO                           will be used.  This can also be specified as a
-ECHO                           comma-separated list of archive files.  The overlapping contents in
-ECHO                           each archive take precedence over previous archives in the list.
 ECHO.
 ECHO         model_file      - the location of the model file to use.  This can also be specified as a
 ECHO                           comma-separated list of model locations, where each successive model

--- a/installer/src/main/bin/extractDomainResource.sh
+++ b/installer/src/main/bin/extractDomainResource.sh
@@ -2,7 +2,7 @@
 # *****************************************************************************
 # extractDomainResource.sh
 #
-# Copyright (c) 2020, 2022, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright (c) 2020, 2023, Oracle Corporation and/or its affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 #     NAME
@@ -35,7 +35,6 @@ usage() {
   echo "          [-output_dir <output_dir>]"
   echo "          [-target <target>]"
   echo "          [-domain_resource_file <domain_resource_file>]"
-  echo "          [-archive_file <archive_file>]"
   echo "          [-model_file <model_file>]"
   echo "          [-variable_file <variable_file>]"
   echo ""
@@ -53,12 +52,6 @@ usage() {
   echo ""
   echo "        domain_resource_file - the location of the extracted domain resource file."
   echo "                               This is deprecated, use -output_dir to specify output location"
-  echo ""
-  echo "        archive_file    - the path to the archive file to use  If the -model_file"
-  echo "                          argument is not specified, the model file in this archive"
-  echo "                          will be used.  This can also be specified as a"
-  echo "                          comma-separated list of archive files.  The overlapping contents in"
-  echo "                          each archive take precedence over previous archives in the list."
   echo ""
   echo "        model_file      - the location of the model file to use.  This can also be specified as a"
   echo "                          comma-separated list of model locations, where each successive model layers"


### PR DESCRIPTION
Fixes Jira WDT-708

-archive_file is not longer needed because it does not contain the model