### PR TITLE
Perform final filtering on full, merged model

### DIFF
--- a/core/src/main/python/create.py
+++ b/core/src/main/python/create.py
@@ -35,6 +35,7 @@ from wlsdeploy.tool.util import model_context_helper
 from wlsdeploy.tool.util.archive_helper import ArchiveHelper
 from wlsdeploy.tool.util.wlst_helper import WlstHelper
 from wlsdeploy.tool.util import wlst_helper
+from wlsdeploy.tool.validate.content_validator import ContentValidator
 from wlsdeploy.util import cla_helper
 from wlsdeploy.util import getcreds
 from wlsdeploy.util import tool_main
@@ -312,6 +313,10 @@ def main(model_context):
         aliases = Aliases(model_context, wlst_mode=__wlst_mode, exception_type=ExceptionType.CREATE)
         model_dictionary = cla_helper.load_model(_program_name, model_context, aliases, "create", __wlst_mode,
                                                  validate_crd_sections=False)
+
+        # check for any content problems in the merged, substituted model
+        content_validator = ContentValidator(model_context)
+        content_validator.validate_model(model_dictionary)
 
         archive_helper = None
         archive_file_name = model_context.get_archive_file_name()

--- a/core/src/main/python/discover.py
+++ b/core/src/main/python/discover.py
@@ -498,6 +498,8 @@ def __check_and_customize_model(model, model_context, aliases, credential_inject
     if filter_helper.apply_filters(model.get_model(), "discover", model_context):
         __logger.info('WLSDPLY-06014', _class_name=_class_name, method_name=_method_name)
 
+    filter_helper.apply_final_filters(model.get_model(), model.get_model(), model_context)
+
     # target config always present in model context, default config if not declared
     target_configuration = model_context.get_target_configuration()
 

--- a/core/src/main/python/wlsdeploy/tool/prepare/model_preparer.py
+++ b/core/src/main/python/wlsdeploy/tool/prepare/model_preparer.py
@@ -23,6 +23,7 @@ from wlsdeploy.tool.util.archive_helper import ArchiveHelper
 from wlsdeploy.tool.util.credential_injector import CredentialInjector
 from wlsdeploy.tool.util.variable_injector import VARIABLE_FILE_UPDATE
 from wlsdeploy.tool.util.variable_injector import VariableInjector
+from wlsdeploy.tool.validate.content_validator import ContentValidator
 from wlsdeploy.tool.validate.validator import Validator
 from wlsdeploy.util import cla_helper
 from wlsdeploy.util import model
@@ -366,6 +367,10 @@ class ModelPreparer:
 
             # correct any secret values that point to @@PROP values
             self.fix_property_secrets(variable_map)
+
+            # check for any content problems in the merged, substituted model
+            content_validator = ContentValidator(self.model_context)
+            content_validator.validate_model(merged_model_dictionary)
 
             target_configuration_helper.generate_all_output_files(Model(merged_model_dictionary), self._aliases,
                                                                   self.credential_injector, self.model_context,

--- a/core/src/main/python/wlsdeploy/tool/util/filters/wko_filter.py
+++ b/core/src/main/python/wlsdeploy/tool/util/filters/wko_filter.py
@@ -7,9 +7,7 @@
 # WDT filters to prepare a model for use a target environment, using the createDomain or prepareModel tools.
 # These operations can be invoked as a single call, or independently of each other.
 from oracle.weblogic.deploy.util import PyRealBoolean
-from oracle.weblogic.deploy.util import PyOrderedDict
 from wlsdeploy.aliases import alias_utils
-from wlsdeploy.aliases.model_constants import ADMIN_SERVER_NAME
 from wlsdeploy.aliases.model_constants import AUTO_MIGRATION_ENABLED
 from wlsdeploy.aliases.model_constants import CALCULATED_LISTEN_PORTS
 from wlsdeploy.aliases.model_constants import CANDIDATE_MACHINE
@@ -17,7 +15,6 @@ from wlsdeploy.aliases.model_constants import CANDIDATE_MACHINES_FOR_MIGRATABLE_
 from wlsdeploy.aliases.model_constants import CLUSTER
 from wlsdeploy.aliases.model_constants import CLUSTER_MESSAGING_MODE
 from wlsdeploy.aliases.model_constants import DATABASE_LESS_LEASING_BASIS
-from wlsdeploy.aliases.model_constants import DEFAULT_ADMIN_SERVER_NAME
 from wlsdeploy.aliases.model_constants import DYNAMIC_SERVERS
 from wlsdeploy.aliases.model_constants import LISTEN_PORT
 from wlsdeploy.aliases.model_constants import MACHINE
@@ -34,7 +31,6 @@ from wlsdeploy.aliases.model_constants import RESOURCE_MANAGEMENT
 from wlsdeploy.aliases.model_constants import RESOURCE_MANAGER
 from wlsdeploy.aliases.model_constants import SECURITY_CONFIGURATION
 from wlsdeploy.aliases.model_constants import SERVER
-from wlsdeploy.aliases.model_constants import SERVER_NAME_PREFIX
 from wlsdeploy.aliases.model_constants import SERVER_START
 from wlsdeploy.aliases.model_constants import SERVER_TEMPLATE
 from wlsdeploy.aliases.model_constants import TOPOLOGY
@@ -48,8 +44,6 @@ from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.util.filters.model_traverse import ModelTraverse
 from wlsdeploy.util import dictionary_utils
 import wlsdeploy.util.unicode_helper as str_helper
-
-FIX_PREFIX_TEMPLATE = '-- FIX PREFIX %s --'
 
 _class_name = 'wko_filter'
 _logger = PlatformLogger('wlsdeploy.tool.util')
@@ -67,7 +61,6 @@ def filter_model(model, model_context):
     filter_resources(model, model_context)
     filter_online_attributes(model, model_context)
     check_clustered_server_ports(model, model_context)
-    check_dynamic_cluster_prefixes(model, model_context)
 
 
 def filter_model_for_wko(model, model_context):
@@ -78,17 +71,6 @@ def filter_model_for_wko(model, model_context):
     :param model_context: used by nested filters
     """
     filter_model(model, model_context)
-
-
-def filter_model_for_wko3(model, model_context):
-    """
-    Perform filtering operations on the specified model to prepare for WKO deployment.
-    Currently matches the general k8s target filtering.
-    :param model: the model to be filtered
-    :param model_context: used by nested filters
-    """
-    filter_model(model, model_context)
-    check_admin_server_defined(model, model_context)
 
 
 def filter_model_for_vz(model, model_context):
@@ -161,71 +143,6 @@ def check_clustered_server_ports(model, _model_context):
                 server_port_map[server_cluster] = {"firstServer": server_name, "serverPort": server_port_text}
 
 
-def check_dynamic_cluster_prefixes(model, _model_context):
-    """
-    All Dynamic Clusters must have a DynamicServers section with the ServerNamePrefix field explicitly declared.
-    Ensure each cluster uses a unique value for this field.
-    :param model: the model to be updated
-    :param _model_context: unused, passed by filter_helper if called independently
-    :return:
-    """
-    _method_name = 'check_dynamic_cluster_prefixes'
-
-    server_name_prefixes = []
-    topology_folder = dictionary_utils.get_dictionary_element(model, TOPOLOGY)
-    clusters_folder = dictionary_utils.get_dictionary_element(topology_folder, CLUSTER)
-    for cluster_name, cluster_fields in clusters_folder.items():
-        dynamic_folder = dictionary_utils.get_element(cluster_fields, DYNAMIC_SERVERS)
-        if dynamic_folder:
-            server_name_prefix = dictionary_utils.get_element(dynamic_folder, SERVER_NAME_PREFIX)
-
-            if not server_name_prefix:
-                _logger.warning('WLSDPLY-20204', cluster_name, SERVER_NAME_PREFIX, class_name=_class_name,
-                                method_name=_method_name)
-                server_name_prefix = _get_unused_prefix(server_name_prefixes)
-                dynamic_folder[SERVER_NAME_PREFIX] = server_name_prefix
-
-            elif server_name_prefix in server_name_prefixes:
-                _logger.warning('WLSDPLY-20205', SERVER_NAME_PREFIX, server_name_prefix, class_name=_class_name,
-                                method_name=_method_name)
-                server_name_prefix = _get_unused_prefix(server_name_prefixes)
-                dynamic_folder[SERVER_NAME_PREFIX] = server_name_prefix
-
-            server_name_prefixes.append(server_name_prefix)
-
-
-def check_admin_server_defined(model, _model_context):
-    """
-    Ensure that the AdminServerName attribute is set, and that the server is defined.
-    This is required by WKO 3.0, and not by 4.0 and later.
-    :param model: the model to be filtered
-    :param _model_context: unused, passed by filter_helper if called independently
-    """
-    _method_name = 'check_admin_server_defined'
-
-    topology_folder = dictionary_utils.get_element(model, TOPOLOGY)
-    if topology_folder is None:
-        # for cases with multiple models, avoid adding topology and admin server for
-        # models with only resources, applications, etc.
-        return
-
-    admin_server_name = dictionary_utils.get_element(topology_folder, ADMIN_SERVER_NAME)
-    if not admin_server_name:
-        admin_server_name = DEFAULT_ADMIN_SERVER_NAME
-        _logger.info('WLSDPLY-20206', ADMIN_SERVER_NAME, admin_server_name, class_name=_class_name,
-                     method_name=_method_name)
-        topology_folder[ADMIN_SERVER_NAME] = admin_server_name
-
-    servers_folder = dictionary_utils.get_element(topology_folder, SERVER)
-    if servers_folder is None:
-        servers_folder = PyOrderedDict()
-        topology_folder[SERVER] = servers_folder
-
-    if admin_server_name not in servers_folder:
-        _logger.info('WLSDPLY-20207', SERVER, admin_server_name, class_name=_class_name, method_name=_method_name)
-        servers_folder[admin_server_name] = PyOrderedDict()
-
-
 def filter_topology(model, _model_context):
     """
     Remove elements from the topology section of the model that are not relevant in a Kubernetes environment.
@@ -282,18 +199,6 @@ def filter_resources(model, _model_context):
                        RESOURCE_MANAGEMENT, RESOURCE_MANAGER, VIRTUAL_HOST]:
         if delete_key in resources:
             del resources[delete_key]
-
-
-def _get_unused_prefix(used_prefixes):
-    """
-    Find a recognizable, unused prefix that can be used in the filtered model.
-    :param used_prefixes: prefixes that have already been used in the model
-    :return: an unused prefix
-    """
-    i = 1
-    while FIX_PREFIX_TEMPLATE % i in used_prefixes:
-        i += 1
-    return FIX_PREFIX_TEMPLATE % i
 
 
 class OnlineAttributeFilter(ModelTraverse):

--- a/core/src/main/python/wlsdeploy/tool/util/filters/wko_final_filter.py
+++ b/core/src/main/python/wlsdeploy/tool/util/filters/wko_final_filter.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# ------------
+# Description:
+# ------------
+# WDT final filters prepare a model for use in a target environment, using the createDomain or prepareModel tools.
+# These filters are applied to a merged, substituted model.
+# They apply any updates to a specified update model, to support use cases with multiple models.
+# These operations can be invoked as a single call, or independently of each other.
+from oracle.weblogic.deploy.util import PyOrderedDict
+
+from wlsdeploy.aliases.model_constants import ADMIN_SERVER_NAME
+from wlsdeploy.aliases.model_constants import CLUSTER
+from wlsdeploy.aliases.model_constants import DEFAULT_ADMIN_SERVER_NAME
+from wlsdeploy.aliases.model_constants import DYNAMIC_SERVERS
+from wlsdeploy.aliases.model_constants import SERVER
+from wlsdeploy.aliases.model_constants import SERVER_NAME_PREFIX
+from wlsdeploy.aliases.model_constants import TOPOLOGY
+from wlsdeploy.logging.platform_logger import PlatformLogger
+from wlsdeploy.util import dictionary_utils
+
+_class_name = 'wko_final_filter'
+_logger = PlatformLogger('wlsdeploy.tool.util')
+
+
+def filter_final_model(model, update_model, model_context):
+    """
+    Perform the following operations on the specified model:
+    - Remove any online-only attributes
+    - Check if dynamic cluster prefixes are specified and unique
+    :param model: the model to be filtered
+    :param update_model: the model to be updated with any changes
+    :param model_context: used by nested filters
+    """
+    check_dynamic_cluster_prefixes(model, update_model, model_context)
+
+
+def filter_final_model_for_wko(model, update_model, model_context):
+    """
+    Perform filtering operations on the specified model to prepare for WKO deployment.
+    Currently, matches the general k8s target filtering.
+    :param model: the model to be filtered
+    :param update_model: the model to be updated with any changes
+    :param model_context: used by nested filters
+    """
+    filter_final_model(model, update_model, model_context)
+
+
+def filter_final_model_for_wko3(model, update_model, model_context):
+    """
+    Perform filtering operations on the specified model to prepare for WKO deployment:
+    - Perform general k8s target filtering
+    - Check for explicit admin server declarations
+    :param model: the model to be filtered
+    :param update_model: the model to be updated with any changes
+    :param model_context: used by nested filters
+    """
+    filter_final_model(model, update_model, model_context)
+    check_admin_server_defined(model, update_model, model_context)
+
+
+def filter_final_model_for_vz(model, update_model, model_context):
+    """
+    Perform filtering operations on the specified model to prepare for Verrazzano deployment.
+    Currently, matches the general k8s target filtering.
+    :param model: the model to be filtered
+    :param update_model: the model to be updated with any changes
+    :param model_context: used by nested filters
+    """
+    filter_final_model(model, update_model, model_context)
+
+
+def check_dynamic_cluster_prefixes(model, update_model, _model_context):
+    """
+    All Dynamic Clusters must have a DynamicServers section with the ServerNamePrefix field explicitly declared.
+    Ensure each cluster uses a unique value for this field.
+    :param model: the model to be updated
+    :param update_model: the model to be updated with any changes
+    :param _model_context: unused, passed by filter_helper if called independently
+    :return:
+    """
+    _method_name = 'check_dynamic_cluster_prefixes'
+
+    server_name_prefixes = []
+    target_key = _model_context.get_target_configuration().get_product_key()
+    topology_folder = dictionary_utils.get_dictionary_element(model, TOPOLOGY)
+    clusters_folder = dictionary_utils.get_dictionary_element(topology_folder, CLUSTER)
+    for cluster_name, cluster_fields in clusters_folder.items():
+        dynamic_folder = dictionary_utils.get_element(cluster_fields, DYNAMIC_SERVERS)
+        if dynamic_folder:
+            server_name_prefix = dictionary_utils.get_element(dynamic_folder, SERVER_NAME_PREFIX)
+
+            if not server_name_prefix:
+                # missing server prefix can be fixed by assigning the default: "clusterName-"
+                server_name_prefix = cluster_name + '-'
+                _logger.info('WLSDPLY-20204', SERVER_NAME_PREFIX, server_name_prefix, cluster_name, target_key,
+                             class_name=_class_name, method_name=_method_name)
+                update_dynamic_folder = _get_folder(update_model, TOPOLOGY, CLUSTER, cluster_name, DYNAMIC_SERVERS)
+                update_dynamic_folder[SERVER_NAME_PREFIX] = server_name_prefix
+
+            elif server_name_prefix in server_name_prefixes:
+                # issue a warning for non-unique prefix - we won't try to fix this
+                _logger.warning('WLSDPLY-20205', SERVER_NAME_PREFIX, server_name_prefix, class_name=_class_name,
+                                method_name=_method_name)
+
+            server_name_prefixes.append(server_name_prefix)
+
+
+def check_admin_server_defined(model, update_model, _model_context):
+    """
+    Ensure that the AdminServerName attribute is set, and that the server is defined.
+    This is required by WKO 3.0, and not by 4.0 and later.
+    :param model: the model to be filtered
+    :param update_model: the model to be updated with any changes
+    :param _model_context: unused, passed by filter_helper if called independently
+    """
+    _method_name = 'check_admin_server_defined'
+
+    target_key = _model_context.get_target_configuration().get_product_key()
+    topology_folder = dictionary_utils.get_dictionary_element(model, TOPOLOGY)
+    admin_server_name = dictionary_utils.get_element(topology_folder, ADMIN_SERVER_NAME)
+    if not admin_server_name:
+        admin_server_name = DEFAULT_ADMIN_SERVER_NAME
+        _logger.info('WLSDPLY-20206', ADMIN_SERVER_NAME, admin_server_name, target_key, class_name=_class_name,
+                     method_name=_method_name)
+        update_topology_folder = _get_folder(update_model, TOPOLOGY)
+        update_topology_folder[ADMIN_SERVER_NAME] = admin_server_name
+
+    servers_folder = dictionary_utils.get_dictionary_element(topology_folder, SERVER)
+    if admin_server_name not in servers_folder:
+        _logger.info('WLSDPLY-20207', SERVER, admin_server_name, target_key, class_name=_class_name,
+                     method_name=_method_name)
+        update_servers_folder = _get_folder(update_model, TOPOLOGY, SERVER)
+        update_servers_folder[admin_server_name] = PyOrderedDict()
+
+
+def _get_folder(folder, *args):
+    """
+    Find or create nested sub-folders for the specified folder based on the argument list.
+    :param folder: the top-level folder
+    :param args: the names of the nested sub-folders to find or create
+    :return: the nested sub-folder
+    """
+    result = folder
+    for arg in args:
+        if arg not in result:
+            result[arg] = PyOrderedDict()
+        result = result[arg]
+    return result

--- a/core/src/main/python/wlsdeploy/tool/validate/content_validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/content_validator.py
@@ -14,10 +14,9 @@ class ContentValidator(object):
     """
     Class for validating consistency and compatibility of model folders and attributes.
     These checks are done after alias folder and attribute checks.
-    The model may be a partial model from a multiple-model configuration.
+    These checks should be performed against a complete, merged model.
 
     Dynamic clusters is currently the only validation.
-    Other non-alias validations might fit here (RcuDbInfo?).
     """
     _class_name = 'ContentValidator'
     _logger = PlatformLogger('wlsdeploy.validate')

--- a/core/src/main/python/wlsdeploy/tool/validate/validator.py
+++ b/core/src/main/python/wlsdeploy/tool/validate/validator.py
@@ -21,7 +21,6 @@ from wlsdeploy.logging.platform_logger import PlatformLogger
 from wlsdeploy.tool.create import wlsroles_helper
 from wlsdeploy.tool.util.archive_helper import ArchiveHelper
 from wlsdeploy.tool.validate import validation_utils
-from wlsdeploy.tool.validate.content_validator import ContentValidator
 from wlsdeploy.tool.validate.crd_sections_validator import CrdSectionsValidator
 from wlsdeploy.tool.validate.validator_logger import ValidatorLogger
 from wlsdeploy.util import dictionary_utils
@@ -265,9 +264,6 @@ class Validator(object):
         if self._validate_crd_sections:
             k8s_validator = CrdSectionsValidator(self._model_context)
             k8s_validator.validate_model(model_dict)
-
-        content_validator = ContentValidator(self._model_context)
-        content_validator.validate_model(model_dict)
 
         self._logger.exiting(class_name=_class_name, method_name=_method_name)
 

--- a/core/src/main/python/wlsdeploy/util/target_configuration.py
+++ b/core/src/main/python/wlsdeploy/util/target_configuration.py
@@ -134,6 +134,16 @@ class TargetConfiguration(object):
         """
         return dictionary_utils.get_dictionary_element(self.config_dictionary, 'model_filters')
 
+    def get_final_model_filters(self):
+        """
+        Return a list of final model filters for this target environment.
+        :return: the list of final model filters
+        """
+        result = dictionary_utils.get_element(self.config_dictionary, 'final_filters')
+        if result is None:
+            result = []
+        return result
+
     def get_variable_injectors(self):
         """
         Return a dictionary of variable injectors for this target environment.

--- a/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
+++ b/core/src/main/resources/oracle/weblogic/deploy/messages/wlsdeploy_rb.properties
@@ -1775,15 +1775,17 @@ WLSDPLY-20033=Applying filter with name "{0}"
 WLSDPLY-20034=Applying filter with ID "{0}"
 WLSDPLY-20035={0} encountered an unexpected runtime exception.  Please file an issue on GitHub and attach the log file and stdout. Exception: {1}
 WLSDPLY-20036={0} encountered an unexpected runtime exception.  Stacktrace: {1}
+WLSDPLY-20037=Final filter ID {0} is invalid
+WLSDPLY-20038=Error applying final filter configuration: {0}
 
 # Messages for internal filters
 WLSDPLY-20201=Unsupported attribute {0} at location {1} removed from model
 WLSDPLY-20202=Changing {0} to false for {1} "{2}"
 WLSDPLY-20203={0} entries "{1}" and "{2}" in {3} "{4}" have different {5} values: {6} and {7}
-WLSDPLY-20204=Dynamic cluster "{0}" does not specify {1}, which will cause deployment to fail
+WLSDPLY-20204=Adding {0} "{1}" to dynamic cluster "{2}" for compatibility with {3} target
 WLSDPLY-20205=The {0} value "{1}" is used by multiple dynamic clusters, which will cause deployment to fail
-WLSDPLY-20206=Adding {0} value "{1}" to model for WKO 3 compatibility
-WLSDPLY-20207=Adding {0} "{1}" to model for WKO 3 compatibility
+WLSDPLY-20206=Adding {0} value "{1}" to model for compatibility with {2} target
+WLSDPLY-20207=Adding {0} "{1}" to model for compatibility with {2} target
 
 # Common messages used for tool exit and clean-up
 WLSDPLY-21000={0} Messages:

--- a/core/src/main/targetconfigs/k8s/target.json
+++ b/core/src/main/targetconfigs/k8s/target.json
@@ -4,7 +4,10 @@
           { "name": "k8s_prep", "path": "@@TARGET_CONFIG_DIR@@/k8s_operator_filter.py" },
           { "id": "k8s_filter" }
         ]
-      },
+  },
+  "final_filters" : [
+    { "id": "k8s_final_filter" }
+  ],
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
   "credentials_method" : "secrets",

--- a/core/src/main/targetconfigs/vz-dii/target.json
+++ b/core/src/main/targetconfigs/vz-dii/target.json
@@ -4,6 +4,9 @@
             { "id": "vz_filter" }
         ]
     },
+    "final_filters" : [
+        { "id": "vz_final_filter" }
+    ],
     "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
     "validation_method" : "lax",
     "product_key": "vz",

--- a/core/src/main/targetconfigs/vz-pv/target.json
+++ b/core/src/main/targetconfigs/vz-pv/target.json
@@ -4,6 +4,9 @@
             { "id": "vz_filter" }
         ]
     },
+    "final_filters" : [
+        { "id": "vz_final_filter" }
+    ],
     "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
     "validation_method" : "lax",
     "product_key": "vz",

--- a/core/src/main/targetconfigs/vz/target.json
+++ b/core/src/main/targetconfigs/vz/target.json
@@ -5,6 +5,9 @@
             { "id": "vz_filter" }
         ]
     },
+    "final_filters" : [
+        { "id": "vz_final_filter" }
+    ],
     "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
     "validation_method" : "lax",
     "product_key": "vz",

--- a/core/src/main/targetconfigs/wko-dii/target.json
+++ b/core/src/main/targetconfigs/wko-dii/target.json
@@ -1,9 +1,12 @@
 {
   "model_filters" : {
         "discover": [
-          { "id": "wko3_filter" }
+          { "id": "wko_filter" }
         ]
   },
+  "final_filters" : [
+    { "id": "wko3_final_filter" }
+  ],
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
   "domain_home_source_type" : "dii",

--- a/core/src/main/targetconfigs/wko-pv/target.json
+++ b/core/src/main/targetconfigs/wko-pv/target.json
@@ -1,9 +1,12 @@
 {
   "model_filters" : {
         "discover": [
-          { "id": "wko3_filter" }
+          { "id": "wko_filter" }
         ]
   },
+  "final_filters" : [
+    { "id": "wko3_final_filter" }
+  ],
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
   "domain_home_source_type" : "pv",

--- a/core/src/main/targetconfigs/wko/target.json
+++ b/core/src/main/targetconfigs/wko/target.json
@@ -2,9 +2,12 @@
   "model_filters" : {
         "discover": [
           { "name": "wko_prep", "path": "@@TARGET_CONFIG_DIR@@/wko_operator_filter.py" },
-          { "id": "wko3_filter" }
+          { "id": "wko_filter" }
         ]
   },
+  "final_filters" : [
+    { "id": "wko3_final_filter" }
+  ],
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
   "domain_home_source_type" : "mii",

--- a/core/src/main/targetconfigs/wko4-dii/target.json
+++ b/core/src/main/targetconfigs/wko4-dii/target.json
@@ -4,6 +4,9 @@
           { "id": "wko_filter" }
         ]
   },
+  "final_filters" : [
+    { "id": "wko_final_filter" }
+  ],
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
   "domain_home_source_type" : "dii",

--- a/core/src/main/targetconfigs/wko4-pv/target.json
+++ b/core/src/main/targetconfigs/wko4-pv/target.json
@@ -4,6 +4,9 @@
           { "id": "wko_filter" }
         ]
   },
+  "final_filters" : [
+    { "id": "wko_final_filter" }
+  ],
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
   "domain_home_source_type" : "pv",

--- a/core/src/main/targetconfigs/wko4/target.json
+++ b/core/src/main/targetconfigs/wko4/target.json
@@ -4,6 +4,9 @@
           { "id": "wko_filter" }
         ]
   },
+  "final_filters" : [
+    { "id": "wko_final_filter" }
+  ],
   "variable_injectors" : {"PORT": {},"HOST": {},"URL": {}},
   "validation_method" : "lax",
   "domain_home_source_type" : "mii",

--- a/core/src/test/python/wlsdeploy/tool/util/filters/wko_filter_test.py
+++ b/core/src/test/python/wlsdeploy/tool/util/filters/wko_filter_test.py
@@ -27,6 +27,7 @@ from wlsdeploy.aliases.model_constants import SERVER_TEMPLATE
 from wlsdeploy.aliases.model_constants import TOPOLOGY
 from wlsdeploy.aliases.model_constants import VIRTUAL_TARGET
 from wlsdeploy.tool.util.filters import wko_filter
+from wlsdeploy.tool.util.filters import wko_final_filter
 from wlsdeploy.util.model_context import ModelContext
 from wlsdeploy.util.model_translator import FileToPython
 from wlsdeploy.util.model_translator import PythonToFile
@@ -48,7 +49,7 @@ class WkoFilterTestCase(BaseTestCase):
         BaseTestCase.setUp(self)
         self._establish_directory(self.FILTER_OUTPUT_DIR)
 
-    def test_dynamic_cluster_filter(self):
+    def test_dynamic_cluster_final_filter(self):
         model_file = os.path.join(self.MODELS_DIR, 'wko-filter-2.yaml')
         translator = FileToPython(model_file, use_ordering=True)
         model = translator.parse()
@@ -56,7 +57,7 @@ class WkoFilterTestCase(BaseTestCase):
         # Apply the filter
         self._suspend_logs('wlsdeploy.tool.util')
         model_context = ModelContext(self._program_name, {})
-        wko_filter.filter_model(model, model_context)
+        wko_final_filter.filter_final_model(model, model, model_context)
         self._restore_logs()
 
         # Write the result for test debugging
@@ -66,13 +67,10 @@ class WkoFilterTestCase(BaseTestCase):
 
         clusters = self._traverse(model, TOPOLOGY, CLUSTER)
 
-        # cluster 1 should have a placeholder server name prefix assigned
-        self._match('-- FIX PREFIX 1 --', clusters, 'dynamicCluster', DYNAMIC_SERVERS, SERVER_NAME_PREFIX)
+        # cluster 1 should have a default server name prefix assigned
+        self._match('dynamicCluster-', clusters, 'dynamicCluster', DYNAMIC_SERVERS, SERVER_NAME_PREFIX)
 
-        # cluster 3 should have server name prefix replaced with a placeholder
-        self._match('-- FIX PREFIX 2 --', clusters, 'dynamicCluster3', DYNAMIC_SERVERS, SERVER_NAME_PREFIX)
-
-    def test_wko3_filter(self):
+    def test_wko3_final_filter(self):
         model_file = os.path.join(self.MODELS_DIR, 'wko-filter-3.yaml')
         translator = FileToPython(model_file, use_ordering=True)
         model = translator.parse()
@@ -80,7 +78,7 @@ class WkoFilterTestCase(BaseTestCase):
         # Apply the filter
         self._suspend_logs('wlsdeploy.tool.util')
         model_context = ModelContext(self._program_name, {})
-        wko_filter.filter_model_for_wko3(model, model_context)
+        wko_final_filter.filter_final_model_for_wko3(model, model, model_context)
         self._restore_logs()
 
         # Write the result for test debugging


### PR DESCRIPTION
- For create and prepare, check server template assignments, regardless of target.

- For discover and prepare with `wko` targets, check dynamic cluster server name prefixes. Add default values for missing prefixes, issue a warning for duplicate prefixes.

- For discover and prepare with `wko` version 3 targets, check admin server name and definition. Add default admin server name is missing, add empty definition with derived name if missing.

- Corrections to prepare model are applied to the last (or only) model in the list.
