### PR TITLE
Correct wallet extraction logic 

### DIFF
--- a/core/src/main/python/wlsdeploy/tool/util/archive_helper.py
+++ b/core/src/main/python/wlsdeploy/tool/util/archive_helper.py
@@ -397,7 +397,7 @@ class ArchiveHelper(object):
                 # will all have the same path.
                 #
                 resulting_wallet_path = wallet_path
-
+                break
         self.__logger.exiting(class_name=self.__class_name, method_name=_method_name, result=resulting_wallet_path)
         return resulting_wallet_path
 


### PR DESCRIPTION
When multiple archives have the same named db wallet, we should break after the first found in reverse order